### PR TITLE
feat: A2.3 — Bid Endpoints

### DIFF
--- a/backend/src/routes/bids.ts
+++ b/backend/src/routes/bids.ts
@@ -1,7 +1,118 @@
-import { Router } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
+import { authMiddleware } from '../middleware/auth';
+import { prisma } from '../config/prisma';
+import { sendNotification } from '../services/notificationService';
+import {
+  NotFoundError,
+  ForbiddenError,
+  ValidationError,
+} from '../utils/errors';
 
 const router = Router();
 
-// Implemented in Phase 2
+router.use(authMiddleware);
+
+// PUT /api/bids/:id/accept — requester accepts a bid
+router.put('/:id/accept', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const bid = await prisma.bid.findUnique({
+      where: { id: req.params.id },
+      include: { task: true },
+    });
+
+    if (!bid) throw new NotFoundError('Bid not found');
+    if (req.user.id !== bid.task.requester_id) throw new ForbiddenError('Only the requester can accept a bid');
+    if (bid.status !== 'PENDING') throw new ValidationError('Only pending bids can be accepted');
+
+    // Run DB changes atomically — all tx calls must use tx. not prisma.
+    await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+      await tx.task.update({
+        where: { id: bid.task_id },
+        data: { status: 'IN_PROGRESS', assigned_fixer_id: bid.fixer_id },
+      });
+      await tx.bid.update({
+        where: { id: bid.id },
+        data: { status: 'ACCEPTED' },
+      });
+      await tx.bid.updateMany({
+        where: { task_id: bid.task_id, status: 'PENDING', id: { not: bid.id } },
+        data: { status: 'REJECTED' },
+      });
+    });
+
+    // Notify outside transaction — failure here should not roll back acceptance
+    await sendNotification(
+      bid.fixer_id,
+      'Bid Accepted',
+      'Your bid has been accepted!',
+      'BID_ACCEPTED',
+      bid.id,
+      'Bid',
+    );
+
+    const updated = await prisma.bid.findUnique({ where: { id: bid.id } });
+    res.json({ bid: updated });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /api/bids/:id/reject — requester rejects a bid
+router.put('/:id/reject', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const bid = await prisma.bid.findUnique({
+      where: { id: req.params.id },
+      include: { task: true },
+    });
+
+    if (!bid) throw new NotFoundError('Bid not found');
+    if (req.user.id !== bid.task.requester_id) throw new ForbiddenError('Only the requester can reject a bid');
+    if (bid.status !== 'PENDING') throw new ValidationError('Only pending bids can be rejected');
+
+    const updated = await prisma.bid.update({
+      where: { id: bid.id },
+      data: { status: 'REJECTED' },
+    });
+
+    await sendNotification(
+      bid.fixer_id,
+      'Bid Rejected',
+      'Your bid was not accepted.',
+      'BID_REJECTED',
+      bid.id,
+      'Bid',
+    );
+
+    res.json({ bid: updated });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /api/bids/:id/withdraw — fixer withdraws their own bid
+router.put('/:id/withdraw', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const bid = await prisma.bid.findUnique({
+      where: { id: req.params.id },
+    });
+
+    if (!bid) throw new NotFoundError('Bid not found');
+    if (req.user.id !== bid.fixer_id) throw new ForbiddenError('Only the fixer can withdraw their bid');
+    if (bid.status !== 'PENDING') throw new ValidationError('Only pending bids can be withdrawn');
+
+    const updated = await prisma.bid.update({
+      where: { id: bid.id },
+      data: { status: 'WITHDRAWN' },
+    });
+
+    // BID_WITHDRAWN does not exist in the NotificationType enum — skipping notification.
+    // Flagged in plan: needs to be added to the schema or confirmed as intentional omission.
+
+    res.json({ bid: updated });
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -7,6 +7,7 @@ import {
   NotFoundError,
   ForbiddenError,
   ValidationError,
+  ConflictError,
 } from '../utils/errors';
 
 const router = Router();
@@ -317,6 +318,78 @@ router.put('/:id/confirm-payment', async (req: Request, res: Response, next: Nex
     });
 
     res.json({ task: updated });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /api/tasks/:id/bids — fixer submits a bid
+router.post('/:id/bids', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const task = await prisma.task.findUnique({ where: { id: req.params.id } });
+
+    if (!task) throw new NotFoundError('Task not found');
+    if (task.status !== 'OPEN') throw new ValidationError('Bids can only be submitted on open tasks');
+    if (req.user.id === task.requester_id) throw new ForbiddenError('Requesters cannot bid on their own tasks');
+
+    // Per API spec: return existing bid with has_existing_bid flag instead of 409
+    const existing = await prisma.bid.findUnique({
+      where: { task_id_fixer_id: { task_id: task.id, fixer_id: req.user.id } },
+    });
+    if (existing) {
+      return res.status(200).json({ bid: existing, has_existing_bid: true });
+    }
+
+    // Enforce 15-bid cap (pending + accepted bids)
+    const bidCount = await prisma.bid.count({
+      where: { task_id: task.id, status: { in: ['PENDING', 'ACCEPTED'] } },
+    });
+    if (bidCount >= 15) throw new ConflictError('This task has reached the maximum number of bids');
+
+    const { offered_price, description } = req.body as {
+      offered_price: number;
+      description: string;
+    };
+
+    const bid = await prisma.bid.create({
+      data: {
+        task_id: task.id,
+        fixer_id: req.user.id,
+        offered_price,
+        description,
+      },
+    });
+
+    await sendNotification(
+      task.requester_id,
+      'New Bid',
+      'Someone submitted a bid on your task.',
+      'NEW_BID',
+      bid.id,
+      'Bid',
+    );
+
+    res.status(201).json({ bid, has_existing_bid: false });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /api/tasks/:id/bids — requester views all bids for their task
+router.get('/:id/bids', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const task = await prisma.task.findUnique({ where: { id: req.params.id } });
+
+    if (!task) throw new NotFoundError('Task not found');
+    if (req.user.id !== task.requester_id) throw new ForbiddenError('Only the requester can view bids');
+
+    const bids = await prisma.bid.findMany({
+      where: { task_id: task.id },
+      include: { fixer: true },
+      orderBy: { created_at: 'asc' },
+    });
+
+    res.json({ bids });
   } catch (err) {
     next(err);
   }

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { TaskStatus } from '@prisma/client';
+import { TaskStatus, BidStatus } from '@prisma/client';
 import { authMiddleware } from '../middleware/auth';
 import { prisma } from '../config/prisma';
 
@@ -42,6 +42,39 @@ router.get('/me/tasks', async (req: Request, res: Response, next: NextFunction) 
   }
 });
 
-// GET /api/users/me/bids — implemented in PR 3 (bid endpoints)
+// GET /api/users/me/bids — fixer's submitted bids
+router.get('/me/bids', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const {
+      status,
+      page = '1',
+      limit = '20',
+    } = req.query as { status?: BidStatus; page?: string; limit?: string };
+
+    const pageNum = Math.max(1, parseInt(page));
+    const limitNum = Math.min(50, Math.max(1, parseInt(limit)));
+    const offset = (pageNum - 1) * limitNum;
+
+    const where = {
+      fixer_id: req.user.id,
+      ...(status && { status }),
+    };
+
+    const [bids, total] = await prisma.$transaction([
+      prisma.bid.findMany({
+        where,
+        include: { task: true },
+        orderBy: { created_at: 'desc' },
+        skip: offset,
+        take: limitNum,
+      }),
+      prisma.bid.count({ where }),
+    ]);
+
+    res.json({ bids, total, page: pageNum, limit: limitNum });
+  } catch (err) {
+    next(err);
+  }
+});
 
 export default router;


### PR DESCRIPTION
## Summary

- **`POST /api/tasks/:id/bids`** — fixer submits a bid. Returns the existing bid with `has_existing_bid: true` (not a 409) if already bid. Enforces 15-bid cap on pending+accepted bids. Notifies the requester via notification stub.
- **`GET /api/tasks/:id/bids`** — requester views all bids for their task, with fixer profile included.
- **`GET /api/users/me/bids`** — fixer's submitted bids with task info, optional status filter, and pagination.
- **`PUT /api/bids/:id/accept`** — accepts a bid inside a `prisma.$transaction`: task → `IN_PROGRESS`, bid → `ACCEPTED`, all other pending bids → `REJECTED`. Fixer notification is sent outside the transaction so a notification failure doesn't roll back the acceptance.
- **`PUT /api/bids/:id/reject`** — requester rejects a pending bid, notifies the fixer.
- **`PUT /api/bids/:id/withdraw`** — fixer withdraws their own pending bid. Notification skipped — `BID_WITHDRAWN` does not exist in the `NotificationType` enum. This is a known spec gap; needs to be added to the schema or confirmed as intentional.

## Test plan

- [ ] `POST /api/tasks/:id/bids` → `201 { bid, has_existing_bid: false }`
- [ ] `POST /api/tasks/:id/bids` again with same user → `200 { bid, has_existing_bid: true }`
- [ ] `POST /api/tasks/:id/bids` as requester → `403 FORBIDDEN`
- [ ] `POST /api/tasks/:id/bids` on non-OPEN task → `400 VALIDATION_ERROR`
- [ ] `GET /api/tasks/:id/bids` as requester → list of bids with fixer profiles
- [ ] `GET /api/tasks/:id/bids` as non-requester → `403 FORBIDDEN`
- [ ] `GET /api/users/me/bids` → returns only current user's bids
- [ ] `PUT /api/bids/:id/accept` → task becomes IN_PROGRESS, other pending bids become REJECTED
- [ ] `PUT /api/bids/:id/accept` as non-requester → `403 FORBIDDEN`
- [ ] `PUT /api/bids/:id/reject` → bid becomes REJECTED
- [ ] `PUT /api/bids/:id/withdraw` as fixer → bid becomes WITHDRAWN
- [ ] `PUT /api/bids/:id/withdraw` as non-fixer → `403 FORBIDDEN`
- [ ] All endpoints without auth header → `401 UNAUTHORIZED`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)