### PR TITLE
fix: route ordering, input trimming, seed production guard

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,6 +1,10 @@
 import { PrismaClient, Category, BidStatus } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
+if (process.env.NODE_ENV === 'production') {
+  throw new Error('Seed script cannot run in production');
+}
+
 const prisma = new PrismaClient();
 
 // Placeholder users — replace firebase_uid with real UIDs in Phase 2

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -35,6 +35,21 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
   }
 });
 
+// PUT /api/notifications/read-all — mark all notifications as read
+// Must be defined BEFORE /:id/read so Express doesn't match "read-all" as :id
+router.put('/read-all', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await prisma.notification.updateMany({
+      where: { user_id: req.user.id, is_read: false },
+      data: { is_read: true },
+    });
+
+    res.json({ message: 'All notifications marked as read' });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // PUT /api/notifications/:id/read — mark single notification as read
 router.put('/:id/read', async (req: Request, res: Response, next: NextFunction) => {
   try {
@@ -53,20 +68,6 @@ router.put('/:id/read', async (req: Request, res: Response, next: NextFunction) 
     });
 
     res.json({ notification: updated });
-  } catch (err) {
-    next(err);
-  }
-});
-
-// PUT /api/notifications/read-all — mark all notifications as read
-router.put('/read-all', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    await prisma.notification.updateMany({
-      where: { user_id: req.user.id, is_read: false },
-      data: { is_read: true },
-    });
-
-    res.json({ message: 'All notifications marked as read' });
   } catch (err) {
     next(err);
   }

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -1,18 +1,18 @@
 import { z } from 'zod';
 
 export const authSyncSchema = z.object({
-  full_name: z.string().min(1, 'Full name is required').max(100),
-  phone_number: z.string().optional(),
+  full_name: z.string().trim().min(1, 'Full name is required').max(100),
+  phone_number: z.string().trim().optional(),
 });
 
 export const createTaskSchema = z.object({
-  title: z.string().min(1, 'Title is required').max(200),
-  description: z.string().min(1, 'Description is required').max(2000),
-  media_urls: z.array(z.string().url()).optional(),
+  title: z.string().trim().min(1, 'Title is required').max(200),
+  description: z.string().trim().min(1, 'Description is required').max(2000),
+  media_urls: z.array(z.url()).optional(),
   category: z.enum(['ELECTRICITY', 'PLUMBING', 'CARPENTRY', 'PAINTING', 'MOVING', 'GENERAL']),
   suggested_price: z.number().positive().nullable().optional(),
-  general_location_name: z.string().min(1, 'General location is required'),
-  exact_address: z.string().min(1, 'Exact address is required'),
+  general_location_name: z.string().trim().min(1, 'General location is required'),
+  exact_address: z.string().trim().min(1, 'Exact address is required'),
   lat: z.number().min(-90).max(90),
   lng: z.number().min(-180).max(180),
 });
@@ -23,10 +23,10 @@ export const updateTaskStatusSchema = z.object({
 
 export const createBidSchema = z.object({
   offered_price: z.number().positive('Offered price must be positive'),
-  description: z.string().min(1, 'Description is required').max(1000),
+  description: z.string().trim().min(1, 'Description is required').max(1000),
 });
 
 export const createReviewSchema = z.object({
   rating: z.number().int().min(1).max(5),
-  comment: z.string().max(2000).optional(),
+  comment: z.string().trim().max(2000).optional(),
 });


### PR DESCRIPTION
## Summary

- **notifications.ts** — Move `/read-all` before `/:id/read` to fix Express route matching bug (was treating "read-all" as `:id`)
- **schemas.ts** — Add `.trim()` to all user-provided text fields to strip leading/trailing whitespace
- **seed.ts** — Add production guard: throws error if `NODE_ENV=production`

## Test plan

- [ ] `npm run typecheck --workspace backend` passes
- [ ] `npm run lint --workspace backend` passes
- [ ] `PUT /api/notifications/read-all` reaches correct handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)