### PR TITLE
feat: Phase 3 Shick — design system, components, requester screens

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,20 +1,19 @@
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import { PaperProvider } from 'react-native-paper';
+import { NavigationContainer } from '@react-navigation/native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { theme } from './src/theme';
+import AppNavigator from './src/navigation/AppNavigator';
 
 export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.tsx to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
+    <SafeAreaProvider>
+      <PaperProvider theme={theme}>
+        <NavigationContainer>
+          <AppNavigator />
+          <StatusBar style="auto" />
+        </NavigationContainer>
+      </PaperProvider>
+    </SafeAreaProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@expo/vector-icons": "^15.0.3",
     "@react-navigation/bottom-tabs": "^7.15.9",
+    "@react-navigation/elements": "^2.9.14",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
     "axios": "^1.14.0",
@@ -23,12 +25,14 @@
     "expo-status-bar": "~3.0.9",
     "firebase": "^12.11.0",
     "react": "19.1.0",
+    "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-maps": "1.20.1",
     "react-native-paper": "^5.15.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-vector-icons": "^10.3.0",
+    "react-native-web": "^0.21.0",
     "socket.io-client": "^4.8.3"
   },
   "devDependencies": {

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text, Button, Icon } from 'react-native-paper';
+
+interface EmptyStateProps {
+  icon: string;
+  title: string;
+  message?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export default function EmptyState({ icon, title, message, actionLabel, onAction }: EmptyStateProps) {
+  return (
+    <View style={styles.container}>
+      <Icon source={icon} size={64} color="#9E9E9E" />
+      <Text variant="titleMedium" style={styles.title}>
+        {title}
+      </Text>
+      {message && (
+        <Text variant="bodyMedium" style={styles.message}>
+          {message}
+        </Text>
+      )}
+      {actionLabel && onAction && (
+        <Button mode="contained" onPress={onAction} style={styles.button}>
+          {actionLabel}
+        </Button>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+  },
+  title: {
+    marginTop: 16,
+    textAlign: 'center',
+    color: '#424242',
+  },
+  message: {
+    marginTop: 8,
+    textAlign: 'center',
+    color: '#757575',
+  },
+  button: {
+    marginTop: 24,
+  },
+});

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Chip } from 'react-native-paper';
+import { StyleSheet } from 'react-native';
+
+type TaskStatus = 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
+type BidStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'WITHDRAWN';
+
+type Status = TaskStatus | BidStatus;
+
+const STATUS_CONFIG: Record<Status, { label: string; bg: string; text: string }> = {
+  OPEN: { label: 'Open', bg: '#E3F2FD', text: '#1565C0' },
+  IN_PROGRESS: { label: 'In Progress', bg: '#FFF3E0', text: '#E65100' },
+  COMPLETED: { label: 'Completed', bg: '#E8F5E9', text: '#2E7D32' },
+  CANCELED: { label: 'Canceled', bg: '#FCE4EC', text: '#C62828' },
+  PENDING: { label: 'Pending', bg: '#FFF8E1', text: '#F9A825' },
+  ACCEPTED: { label: 'Accepted', bg: '#E8F5E9', text: '#2E7D32' },
+  REJECTED: { label: 'Rejected', bg: '#FCE4EC', text: '#C62828' },
+  WITHDRAWN: { label: 'Withdrawn', bg: '#F5F5F5', text: '#757575' },
+};
+
+interface StatusBadgeProps {
+  status: Status;
+}
+
+export default function StatusBadge({ status }: StatusBadgeProps) {
+  const config = STATUS_CONFIG[status];
+
+  return (
+    <Chip
+      mode="flat"
+      compact
+      style={[styles.chip, { backgroundColor: config.bg }]}
+      textStyle={[styles.text, { color: config.text }]}
+    >
+      {config.label}
+    </Chip>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    alignSelf: 'flex-start',
+  },
+  text: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Card, Icon, Text, useTheme } from 'react-native-paper';
+import StatusBadge from './StatusBadge';
+
+type TaskStatus = 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
+type Category = 'ELECTRICITY' | 'PLUMBING' | 'CARPENTRY' | 'PAINTING' | 'MOVING' | 'GENERAL';
+
+const CATEGORY_ICONS: Record<Category, string> = {
+  ELECTRICITY: 'lightning-bolt',
+  PLUMBING: 'water',
+  CARPENTRY: 'hammer',
+  PAINTING: 'format-paint',
+  MOVING: 'truck',
+  GENERAL: 'wrench',
+};
+
+interface TaskCardProps {
+  title: string;
+  category: Category;
+  status: TaskStatus;
+  suggestedPrice?: number | null;
+  locationName: string;
+  bidCount?: number;
+  fixerName?: string;
+  onPress?: () => void;
+}
+
+export default function TaskCard({
+  title,
+  category,
+  status,
+  suggestedPrice,
+  locationName,
+  bidCount,
+  fixerName,
+  onPress,
+}: TaskCardProps) {
+  const theme = useTheme();
+
+  return (
+    <Card style={styles.card} onPress={onPress} mode="elevated">
+      <Card.Title
+        title={title}
+        titleNumberOfLines={2}
+        titleVariant="titleSmall"
+        left={() => (
+          <Icon source={CATEGORY_ICONS[category]} size={28} color={theme.colors.primary} />
+        )}
+      />
+      <Card.Content style={styles.content}>
+        <StatusBadge status={status} />
+        <Text variant="bodySmall" style={styles.location}>
+          {locationName}
+        </Text>
+        {suggestedPrice != null && (
+          <Text variant="labelLarge" style={{ color: theme.colors.primary }}>
+            ₪{suggestedPrice}
+          </Text>
+        )}
+        {bidCount != null && status === 'OPEN' && (
+          <Text variant="bodySmall" style={styles.meta}>
+            {bidCount} bids
+          </Text>
+        )}
+        {fixerName && status === 'IN_PROGRESS' && (
+          <Text variant="bodySmall" style={styles.meta}>
+            Assigned to {fixerName}
+          </Text>
+        )}
+      </Card.Content>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginVertical: 6,
+    marginHorizontal: 4,
+  },
+  categoryIcon: {
+    fontSize: 24,
+  },
+  content: {
+    gap: 6,
+    paddingBottom: 12,
+  },
+  location: {
+    color: '#757575',
+  },
+  meta: {
+    color: '#9E9E9E',
+  },
+  icon: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+  },
+});

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useTheme } from 'react-native-paper';
+import RequesterTabs from './RequesterTabs';
+import CreateTask from '../screens/CreateTask';
+import TaskDetails from '../screens/TaskDetails';
+import SettingsScreen from '../screens/SettingsScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function AppNavigator() {
+  const theme = useTheme();
+
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        headerTintColor: theme.colors.primary,
+        contentStyle: { backgroundColor: '#E3F2FD' },
+      }}
+    >
+      <Stack.Screen
+        name="Main"
+        component={RequesterTabs}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name="CreateTask"
+        component={CreateTask}
+        options={{ title: 'Create Task' }}
+      />
+      <Stack.Screen
+        name="TaskDetails"
+        component={TaskDetails}
+        options={{ title: 'Task Details' }}
+      />
+      <Stack.Screen
+        name="Settings"
+        component={SettingsScreen}
+        options={{ title: 'Settings' }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/frontend/src/navigation/RequesterTabs.tsx
+++ b/frontend/src/navigation/RequesterTabs.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { useTheme } from 'react-native-paper';
+import RequesterDashboard from '../screens/RequesterDashboard';
+import PlaceholderScreen from '../screens/PlaceholderScreen';
+import SettingsScreen from '../screens/SettingsScreen';
+
+const Tab = createBottomTabNavigator();
+
+function MessagesScreen() {
+  return <PlaceholderScreen title="Messages" />;
+}
+
+export default function RequesterTabs() {
+  const theme = useTheme();
+
+  return (
+    <Tab.Navigator
+      screenOptions={{
+        tabBarActiveTintColor: theme.colors.primary,
+        tabBarInactiveTintColor: '#757575',
+        headerShown: false,
+        sceneStyle: { backgroundColor: '#E3F2FD' },
+      }}
+    >
+      <Tab.Screen
+        name="Dashboard"
+        component={RequesterDashboard}
+        options={{
+          tabBarLabel: 'Home',
+          tabBarIcon: ({ color, size }) => (
+            <MaterialCommunityIcons name="home" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="Messages"
+        component={MessagesScreen}
+        options={{
+          tabBarLabel: 'Messages',
+          tabBarIcon: ({ color, size }) => (
+            <MaterialCommunityIcons name="chat" color={color} size={size} />
+          ),
+        }}
+      />
+      <Tab.Screen
+        name="Profile"
+        component={SettingsScreen}
+        options={{
+          tabBarLabel: 'Profile',
+          tabBarIcon: ({ color, size }) => (
+            <MaterialCommunityIcons name="account" color={color} size={size} />
+          ),
+        }}
+      />
+    </Tab.Navigator>
+  );
+}

--- a/frontend/src/screens/CreateTask.tsx
+++ b/frontend/src/screens/CreateTask.tsx
@@ -1,0 +1,437 @@
+import React, { useState } from 'react';
+import { View, ScrollView, StyleSheet, Image, TouchableOpacity, Alert } from 'react-native';
+import {
+  Text,
+  TextInput,
+  Button,
+  ProgressBar,
+  Card,
+  useTheme,
+  IconButton,
+  Portal,
+  Modal,
+  SegmentedButtons,
+} from 'react-native-paper';
+import api from '../api/axiosInstance';
+
+type Category = 'ELECTRICITY' | 'PLUMBING' | 'CARPENTRY' | 'PAINTING' | 'MOVING' | 'GENERAL';
+
+const CATEGORIES: { value: Category; label: string; icon: string }[] = [
+  { value: 'ELECTRICITY', label: 'Electricity', icon: '⚡' },
+  { value: 'PLUMBING', label: 'Plumbing', icon: '🔧' },
+  { value: 'CARPENTRY', label: 'Carpentry', icon: '🔨' },
+  { value: 'PAINTING', label: 'Painting', icon: '🎨' },
+  { value: 'MOVING', label: 'Moving', icon: '📦' },
+  { value: 'GENERAL', label: 'General', icon: '🛠' },
+];
+
+interface Props {
+  navigation: { goBack: () => void; navigate: (screen: string) => void };
+}
+
+export default function CreateTask({ navigation }: Props) {
+  const theme = useTheme();
+  const [step, setStep] = useState(1);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [photos, setPhotos] = useState<string[]>([]);
+  const [category, setCategory] = useState<Category | null>(null);
+  const [budgetType, setBudgetType] = useState<'fixed' | 'quote'>('fixed');
+  const [price, setPrice] = useState('');
+  const [generalLocation, setGeneralLocation] = useState('');
+  const [exactAddress, setExactAddress] = useState('');
+  const [showReview, setShowReview] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const totalSteps = 5;
+
+  const canNext = (): boolean => {
+    switch (step) {
+      case 1: return title.trim().length > 0 && description.trim().length > 0;
+      case 2: return true;
+      case 3: return category !== null;
+      case 4: return budgetType === 'quote' || (budgetType === 'fixed' && parseFloat(price) > 0);
+      case 5: return generalLocation.trim().length > 0 && exactAddress.trim().length > 0;
+      default: return false;
+    }
+  };
+
+  const pickImage = async () => {
+    if (photos.length >= 5) return;
+    Alert.alert('Info', 'Photo picker is available on mobile only.');
+  };
+
+  const removePhoto = (index: number) => {
+    setPhotos(photos.filter((_, i) => i !== index));
+  };
+
+  const handlePublish = async () => {
+    setSubmitting(true);
+    try {
+      await api.post('/api/tasks', {
+        title: title.trim(),
+        description: description.trim(),
+        media_urls: [],
+        category,
+        suggested_price: budgetType === 'fixed' ? parseFloat(price) : null,
+        general_location_name: generalLocation.trim(),
+        exact_address: exactAddress.trim(),
+        lat: 32.8,
+        lng: 35.0,
+      });
+      setShowReview(false);
+      navigation.goBack();
+    } catch {
+      Alert.alert('Error', 'Failed to create task. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const renderStep = () => {
+    switch (step) {
+      case 1:
+        return (
+          <View>
+            <Text variant="headlineSmall" style={styles.stepTitle}>What do you need done?</Text>
+            <TextInput
+              label="Title"
+              value={title}
+              onChangeText={setTitle}
+              maxLength={80}
+              mode="outlined"
+              style={styles.input}
+            />
+            <Text variant="bodySmall" style={styles.counter}>{title.length}/80</Text>
+            <TextInput
+              label="Description"
+              value={description}
+              onChangeText={setDescription}
+              maxLength={500}
+              mode="outlined"
+              multiline
+              numberOfLines={5}
+              placeholder="Describe what you need done..."
+              style={styles.input}
+            />
+            <Text variant="bodySmall" style={styles.counter}>{description.length}/500</Text>
+          </View>
+        );
+
+      case 2:
+        return (
+          <View>
+            <Text variant="headlineSmall" style={styles.stepTitle}>Add photos</Text>
+            <Text variant="bodyMedium" style={styles.subtitle}>Up to 5 photos (optional)</Text>
+            <View style={styles.photoGrid}>
+              {photos.map((uri, index) => (
+                <View key={index} style={styles.photoContainer}>
+                  <Image source={{ uri }} style={styles.photo} />
+                  <IconButton
+                    icon="close-circle"
+                    size={20}
+                    style={styles.removePhoto}
+                    onPress={() => removePhoto(index)}
+                  />
+                </View>
+              ))}
+              {photos.length < 5 && (
+                <TouchableOpacity style={styles.addPhoto} onPress={pickImage}>
+                  <Text style={styles.addPhotoIcon}>+</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+          </View>
+        );
+
+      case 3:
+        return (
+          <View>
+            <Text variant="headlineSmall" style={styles.stepTitle}>Choose a category</Text>
+            <View style={styles.categoryGrid}>
+              {CATEGORIES.map((cat) => (
+                <TouchableOpacity
+                  key={cat.value}
+                  onPress={() => setCategory(cat.value)}
+                  style={[
+                    styles.categoryCard,
+                    category === cat.value && { borderColor: theme.colors.primary, borderWidth: 2 },
+                  ]}
+                >
+                  <Text style={styles.categoryIcon}>{cat.icon}</Text>
+                  <Text variant="labelMedium">{cat.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+        );
+
+      case 4:
+        return (
+          <View>
+            <Text variant="headlineSmall" style={styles.stepTitle}>Set your budget</Text>
+            <SegmentedButtons
+              value={budgetType}
+              onValueChange={(v) => setBudgetType(v as 'fixed' | 'quote')}
+              buttons={[
+                { value: 'fixed', label: 'Fixed Price' },
+                { value: 'quote', label: 'Quote Required' },
+              ]}
+              style={styles.segmented}
+            />
+            {budgetType === 'fixed' ? (
+              <TextInput
+                label="Budget (₪)"
+                value={price}
+                onChangeText={setPrice}
+                keyboardType="numeric"
+                mode="outlined"
+                style={styles.input}
+                placeholder="Enter your budget"
+              />
+            ) : (
+              <Text variant="bodyMedium" style={styles.quoteNote}>
+                Fixers will propose their own price.
+              </Text>
+            )}
+          </View>
+        );
+
+      case 5:
+        return (
+          <View>
+            <Text variant="headlineSmall" style={styles.stepTitle}>Location</Text>
+            <TextInput
+              label="General area (e.g., 'Hadar, Haifa')"
+              value={generalLocation}
+              onChangeText={setGeneralLocation}
+              mode="outlined"
+              style={styles.input}
+            />
+            <TextInput
+              label="Exact address (private — shared only with accepted Fixer)"
+              value={exactAddress}
+              onChangeText={setExactAddress}
+              mode="outlined"
+              style={styles.input}
+            />
+          </View>
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.progressSection}>
+        <ProgressBar progress={step / totalSteps} color={theme.colors.primary} />
+        <Text variant="bodySmall" style={styles.stepIndicator}>Step {step} of {totalSteps}</Text>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.container}>
+        <View style={styles.content}>
+          {renderStep()}
+        </View>
+
+        <View style={styles.buttons}>
+          {step > 1 && (
+            <Button mode="outlined" onPress={() => setStep(step - 1)} style={styles.button}>
+              Back
+            </Button>
+          )}
+          {step < totalSteps ? (
+            <Button
+              mode="contained"
+              onPress={() => setStep(step + 1)}
+              disabled={!canNext()}
+              style={styles.button}
+            >
+              Next
+            </Button>
+          ) : (
+            <Button
+              mode="contained"
+              onPress={() => setShowReview(true)}
+              disabled={!canNext()}
+              style={styles.button}
+            >
+              Review & Publish
+            </Button>
+          )}
+        </View>
+      </ScrollView>
+
+      <Portal>
+        <Modal visible={showReview} onDismiss={() => setShowReview(false)} contentContainerStyle={styles.modal}>
+          <Text variant="titleLarge" style={styles.modalTitle}>Review your task</Text>
+          <Card style={styles.reviewCard}>
+            <Card.Content>
+              <Text variant="labelLarge">Title</Text>
+              <Text variant="bodyMedium">{title}</Text>
+              <Text variant="labelLarge" style={styles.reviewLabel}>Category</Text>
+              <Text variant="bodyMedium">{CATEGORIES.find((c) => c.value === category)?.label}</Text>
+              <Text variant="labelLarge" style={styles.reviewLabel}>Budget</Text>
+              <Text variant="bodyMedium">
+                {budgetType === 'fixed' ? `₪${price}` : 'Quote Required'}
+              </Text>
+              <Text variant="labelLarge" style={styles.reviewLabel}>Location</Text>
+              <Text variant="bodyMedium">{generalLocation}</Text>
+              <Text variant="labelLarge" style={styles.reviewLabel}>Photos</Text>
+              <Text variant="bodyMedium">{photos.length} photo(s)</Text>
+            </Card.Content>
+          </Card>
+          <Button
+            mode="contained"
+            onPress={handlePublish}
+            loading={submitting}
+            disabled={submitting}
+            style={styles.publishButton}
+            buttonColor="#2E7D32"
+          >
+            Publish Task
+          </Button>
+          <Button mode="text" onPress={() => setShowReview(false)} style={styles.cancelButton}>
+            Go Back & Edit
+          </Button>
+        </Modal>
+      </Portal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    backgroundColor: '#E3F2FD',
+  },
+  progressSection: {
+    backgroundColor: '#E3F2FD',
+  },
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 90,
+    paddingBottom: 16,
+    alignItems: 'center',
+  },
+  stepIndicator: {
+    textAlign: 'center',
+    paddingTop: 4,
+    paddingBottom: 8,
+    color: '#757575',
+    backgroundColor: '#E3F2FD',
+  },
+  content: {
+    width: '100%',
+    maxWidth: 500,
+  },
+  stepTitle: {
+    marginBottom: 16,
+  },
+  subtitle: {
+    color: '#757575',
+    marginBottom: 16,
+  },
+  input: {
+    marginBottom: 8,
+  },
+  counter: {
+    textAlign: 'right',
+    color: '#9E9E9E',
+    marginBottom: 12,
+  },
+  photoGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+  },
+  photoContainer: {
+    width: 100,
+    height: 100,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  photo: {
+    width: '100%',
+    height: '100%',
+  },
+  removePhoto: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+  },
+  addPhoto: {
+    width: 100,
+    height: 100,
+    borderRadius: 8,
+    borderWidth: 2,
+    borderColor: '#E0E0E0',
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addPhotoIcon: {
+    fontSize: 32,
+    color: '#9E9E9E',
+  },
+  categoryGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 12,
+    justifyContent: 'center',
+  },
+  categoryCard: {
+    width: '45%',
+    padding: 20,
+    borderRadius: 12,
+    backgroundColor: '#F5F5F5',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: '#E0E0E0',
+  },
+  categoryIcon: {
+    fontSize: 32,
+    marginBottom: 8,
+  },
+  segmented: {
+    marginBottom: 16,
+  },
+  quoteNote: {
+    color: '#757575',
+    fontStyle: 'italic',
+    marginTop: 12,
+  },
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: 16,
+    gap: 12,
+    width: '100%',
+    maxWidth: 500,
+  },
+  button: {
+    flex: 1,
+  },
+  modal: {
+    backgroundColor: '#FFFFFF',
+    margin: 20,
+    padding: 24,
+    borderRadius: 16,
+  },
+  modalTitle: {
+    marginBottom: 16,
+  },
+  reviewCard: {
+    marginBottom: 16,
+  },
+  reviewLabel: {
+    marginTop: 12,
+  },
+  publishButton: {
+    marginBottom: 8,
+  },
+  cancelButton: {
+    marginBottom: 0,
+  },
+});

--- a/frontend/src/screens/PlaceholderScreen.tsx
+++ b/frontend/src/screens/PlaceholderScreen.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { Text } from 'react-native-paper';
+
+interface Props {
+  title: string;
+}
+
+export default function PlaceholderScreen({ title }: Props) {
+  return (
+    <View style={styles.container}>
+      <Text variant="headlineMedium">{title}</Text>
+      <Text variant="bodyMedium" style={styles.subtitle}>Coming soon</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#E3F2FD',
+  },
+  subtitle: {
+    marginTop: 8,
+    color: '#757575',
+  },
+});

--- a/frontend/src/screens/RequesterDashboard.tsx
+++ b/frontend/src/screens/RequesterDashboard.tsx
@@ -1,0 +1,174 @@
+import React, { useCallback, useState } from 'react';
+import { View, FlatList, ScrollView, StyleSheet, RefreshControl } from 'react-native';
+import { Text, FAB, useTheme, ActivityIndicator } from 'react-native-paper';
+import { useFocusEffect } from '@react-navigation/native';
+import api from '../api/axiosInstance';
+import TaskCard from '../components/TaskCard';
+import EmptyState from '../components/EmptyState';
+
+interface Task {
+  id: string;
+  title: string;
+  category: 'ELECTRICITY' | 'PLUMBING' | 'CARPENTRY' | 'PAINTING' | 'MOVING' | 'GENERAL';
+  status: 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
+  suggested_price: number | null;
+  general_location_name: string;
+  bid_count?: number;
+  assigned_fixer_name?: string;
+  created_at: string;
+}
+
+interface Props {
+  navigation: { navigate: (screen: string, params?: Record<string, unknown>) => void };
+}
+
+export default function RequesterDashboard({ navigation }: Props) {
+  const theme = useTheme();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const fetchTasks = useCallback(async () => {
+    try {
+      const res = await api.get('/api/users/me/tasks', { params: { limit: 50 } });
+      setTasks(res.data.tasks);
+    } catch {
+      // TODO: error handling
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchTasks();
+    }, [fetchTasks])
+  );
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    fetchTasks();
+  };
+
+  const activeTasks = tasks.filter((t) => t.status === 'OPEN' || t.status === 'IN_PROGRESS');
+  const pastTasks = tasks.filter((t) => t.status === 'COMPLETED' || t.status === 'CANCELED');
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <View style={styles.flex}>
+        <EmptyState
+          icon="clipboard-text-outline"
+          title="No tasks yet"
+          message="Post your first task and get help today!"
+          actionLabel="Create Task"
+          onAction={() => navigation.navigate('CreateTask')}
+        />
+        <FAB
+          icon="plus"
+          style={[styles.fab, { backgroundColor: theme.colors.secondary }]}
+          onPress={() => navigation.navigate('CreateTask')}
+        />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.flex}>
+      <FlatList
+        data={pastTasks}
+        keyExtractor={(item) => item.id}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+        ListHeaderComponent={
+          <>
+            {activeTasks.length > 0 && (
+              <View style={styles.section}>
+                <Text variant="titleMedium" style={styles.sectionTitle}>
+                  Active Tasks
+                </Text>
+                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                  {activeTasks.map((task) => (
+                    <View key={task.id} style={styles.activeCard}>
+                      <TaskCard
+                        title={task.title}
+                        category={task.category}
+                        status={task.status}
+                        suggestedPrice={task.suggested_price}
+                        locationName={task.general_location_name}
+                        bidCount={task.bid_count}
+                        fixerName={task.assigned_fixer_name}
+                        onPress={() => navigation.navigate('TaskDetails', { taskId: task.id })}
+                      />
+                    </View>
+                  ))}
+                </ScrollView>
+              </View>
+            )}
+            {pastTasks.length > 0 && (
+              <Text variant="titleMedium" style={styles.sectionTitle}>
+                Past Tasks
+              </Text>
+            )}
+          </>
+        }
+        renderItem={({ item }) => (
+          <TaskCard
+            title={item.title}
+            category={item.category}
+            status={item.status}
+            suggestedPrice={item.suggested_price}
+            locationName={item.general_location_name}
+            onPress={() => navigation.navigate('TaskDetails', { taskId: item.id })}
+          />
+        )}
+        contentContainerStyle={styles.list}
+      />
+      <FAB
+        icon="plus"
+        style={[styles.fab, { backgroundColor: theme.colors.secondary }]}
+        onPress={() => navigation.navigate('CreateTask')}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  section: {
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontWeight: '600',
+  },
+  activeCard: {
+    width: 260,
+    marginLeft: 12,
+  },
+  list: {
+    padding: 12,
+    paddingBottom: 80,
+  },
+  fab: {
+    position: 'absolute',
+    right: 16,
+    bottom: 16,
+  },
+});

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -1,0 +1,145 @@
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, Alert } from 'react-native';
+import { View } from 'react-native';
+import { Text, TextInput, Button, Card, Divider, Switch } from 'react-native-paper';
+import { sendPasswordResetEmail, signOut } from 'firebase/auth';
+import { auth } from '../config/firebase';
+
+export default function SettingsScreen() {
+  const user = auth.currentUser;
+  const [phone, setPhone] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [pushEnabled, setPushEnabled] = useState(true);
+
+  const handleChangePassword = async () => {
+    if (!user?.email) return;
+    try {
+      await sendPasswordResetEmail(auth, user.email);
+      Alert.alert('Success', 'Check your inbox for a password reset link.');
+    } catch {
+      Alert.alert('Error', 'Failed to send password reset email.');
+    }
+  };
+
+  const handleLogout = async () => {
+    Alert.alert('Log Out', 'Are you sure you want to log out?', [
+      { text: 'Cancel' },
+      {
+        text: 'Log Out',
+        style: 'destructive',
+        onPress: async () => {
+          await signOut(auth);
+        },
+      },
+    ]);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text variant="headlineSmall" style={styles.heading}>Settings</Text>
+
+      <Card style={styles.card}>
+        <Card.Content>
+          <Text variant="labelLarge">Email</Text>
+          <Text variant="bodyMedium" style={styles.value}>{user?.email || 'Not signed in'}</Text>
+
+          <Divider style={styles.divider} />
+
+          <Text variant="labelLarge">Phone Number</Text>
+          <TextInput
+            value={phone}
+            onChangeText={setPhone}
+            mode="outlined"
+            placeholder="Enter phone number"
+            keyboardType="phone-pad"
+            style={styles.input}
+          />
+          <Button
+            mode="contained"
+            onPress={() => {
+              setSaving(true);
+              setTimeout(() => {
+                setSaving(false);
+                Alert.alert('Saved', 'Phone number updated.');
+              }, 500);
+            }}
+            loading={saving}
+            disabled={saving || phone.trim().length === 0}
+            compact
+          >
+            Save
+          </Button>
+        </Card.Content>
+      </Card>
+
+      <Card style={styles.card}>
+        <Card.Content>
+          <View style={styles.pushRow}>
+            <Text variant="labelLarge">Push Notifications</Text>
+            <Switch value={pushEnabled} onValueChange={setPushEnabled} />
+          </View>
+
+          <Divider style={styles.divider} />
+
+          <Button
+            mode="outlined"
+            onPress={handleChangePassword}
+            style={styles.settingsButton}
+            icon="lock-reset"
+          >
+            Change Password
+          </Button>
+
+          <Button
+            mode="outlined"
+            onPress={handleLogout}
+            textColor="#C62828"
+            style={styles.settingsButton}
+            icon="logout"
+          >
+            Log Out
+          </Button>
+        </Card.Content>
+      </Card>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    paddingTop: 90,
+    backgroundColor: '#E3F2FD',
+    alignItems: 'center',
+  },
+  heading: {
+    marginBottom: 16,
+    width: '100%',
+    maxWidth: 500,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 500,
+    marginBottom: 16,
+  },
+  value: {
+    marginTop: 4,
+    marginBottom: 8,
+    color: '#616161',
+  },
+  divider: {
+    marginVertical: 12,
+  },
+  input: {
+    marginTop: 4,
+    marginBottom: 12,
+  },
+  pushRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  settingsButton: {
+    marginBottom: 8,
+  },
+});

--- a/frontend/src/screens/TaskDetails.tsx
+++ b/frontend/src/screens/TaskDetails.tsx
@@ -1,0 +1,498 @@
+import React, { useCallback, useState } from 'react';
+import { View, ScrollView, StyleSheet, Alert, Linking } from 'react-native';
+import {
+  Text,
+  Button,
+  Card,
+  useTheme,
+  Divider,
+  Avatar,
+  IconButton,
+  TextInput,
+  ActivityIndicator,
+} from 'react-native-paper';
+import { useFocusEffect } from '@react-navigation/native';
+import api from '../api/axiosInstance';
+import StatusBadge from '../components/StatusBadge';
+
+type TaskStatus = 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
+
+interface Bid {
+  id: string;
+  fixer_id: string;
+  offered_price: number;
+  description: string;
+  status: 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'WITHDRAWN';
+  fixer?: {
+    full_name: string;
+    average_rating_as_fixer: number | null;
+    phone_number: string | null;
+    payment_link: string | null;
+  };
+}
+
+interface Task {
+  id: string;
+  title: string;
+  description: string;
+  category: string;
+  status: TaskStatus;
+  suggested_price: number | null;
+  general_location_name: string;
+  exact_address: string;
+  is_payment_confirmed: boolean;
+  created_at: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function TaskDetails({ route, navigation }: { route: any; navigation: any }) {
+  const theme = useTheme();
+  const { taskId } = route.params;
+  const [task, setTask] = useState<Task | null>(null);
+  const [bids, setBids] = useState<Bid[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [reviewRating, setReviewRating] = useState(0);
+  const [reviewComment, setReviewComment] = useState('');
+  const [reviewSubmitted, setReviewSubmitted] = useState(false);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [taskRes, bidsRes] = await Promise.all([
+        api.get(`/api/tasks/${taskId}`),
+        api.get(`/api/tasks/${taskId}/bids`),
+      ]);
+      setTask(taskRes.data.task);
+      setBids(bidsRes.data.bids || []);
+    } catch {
+      // handle error
+    } finally {
+      setLoading(false);
+    }
+  }, [taskId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      fetchData();
+    }, [fetchData])
+  );
+
+  const acceptBid = async (bidId: string) => {
+    try {
+      await api.put(`/api/bids/${bidId}/accept`);
+      fetchData();
+    } catch {
+      Alert.alert('Error', 'Failed to accept bid.');
+    }
+  };
+
+  const declineBid = async (bidId: string) => {
+    try {
+      await api.put(`/api/bids/${bidId}/reject`);
+      fetchData();
+    } catch {
+      Alert.alert('Error', 'Failed to decline bid.');
+    }
+  };
+
+  const cancelTask = async () => {
+    Alert.alert('Cancel Task', 'Are you sure you want to cancel this task?', [
+      { text: 'No' },
+      {
+        text: 'Yes, Cancel',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await api.put(`/api/tasks/${taskId}/status`, { status: 'CANCELED' });
+            navigation.goBack();
+          } catch {
+            Alert.alert('Error', 'Failed to cancel task.');
+          }
+        },
+      },
+    ]);
+  };
+
+  const markCompleted = async () => {
+    try {
+      await api.put(`/api/tasks/${taskId}/status`, { status: 'COMPLETED' });
+      fetchData();
+    } catch {
+      Alert.alert('Error', 'Failed to mark task as completed.');
+    }
+  };
+
+  const confirmPayment = async () => {
+    try {
+      await api.put(`/api/tasks/${taskId}/confirm-payment`);
+      fetchData();
+    } catch {
+      Alert.alert('Error', 'Failed to confirm payment.');
+    }
+  };
+
+  const submitReview = async () => {
+    if (reviewRating === 0) return;
+    try {
+      await api.post(`/api/tasks/${taskId}/reviews`, {
+        rating: reviewRating,
+        comment: reviewComment.trim() || undefined,
+      });
+      setReviewSubmitted(true);
+    } catch {
+      Alert.alert('Error', 'Failed to submit review.');
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (!task) {
+    return (
+      <View style={styles.center}>
+        <Text variant="bodyLarge">Task not found</Text>
+      </View>
+    );
+  }
+
+  const acceptedBid = bids.find((b) => b.status === 'ACCEPTED');
+  const pendingBids = bids.filter((b) => b.status === 'PENDING');
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Text variant="headlineSmall" style={styles.title}>{task.title}</Text>
+        <StatusBadge status={task.status} />
+      </View>
+
+      {/* Details */}
+      <Card style={styles.card}>
+        <Card.Content>
+          <Text variant="bodyMedium">{task.description}</Text>
+          <Divider style={styles.divider} />
+          <View style={styles.detailRow}>
+            <Text variant="labelLarge">Budget:</Text>
+            <Text variant="bodyMedium">
+              {task.suggested_price ? `₪${task.suggested_price}` : 'Quote Required'}
+            </Text>
+          </View>
+          <View style={styles.detailRow}>
+            <Text variant="labelLarge">Location:</Text>
+            <Text variant="bodyMedium">{task.general_location_name}</Text>
+          </View>
+          {task.status !== 'OPEN' && (
+            <View style={styles.detailRow}>
+              <Text variant="labelLarge">Address:</Text>
+              <Text variant="bodyMedium">{task.exact_address}</Text>
+            </View>
+          )}
+        </Card.Content>
+      </Card>
+
+      {/* OPEN — Bids Section */}
+      {task.status === 'OPEN' && (
+        <View style={styles.section}>
+          <Text variant="titleMedium" style={styles.sectionTitle}>
+            Received Bids ({pendingBids.length})
+          </Text>
+          {pendingBids.length === 0 ? (
+            <Card style={styles.card}>
+              <Card.Content>
+                <Text variant="bodyMedium" style={styles.emptyText}>
+                  No bids yet. Sit tight — Fixers in your area will see your task!
+                </Text>
+              </Card.Content>
+            </Card>
+          ) : (
+            pendingBids.map((bid) => (
+              <Card key={bid.id} style={styles.bidCard}>
+                <Card.Content>
+                  <View style={styles.bidHeader}>
+                    <Avatar.Icon size={40} icon="account" />
+                    <View style={styles.bidInfo}>
+                      <Text variant="titleSmall">{bid.fixer?.full_name || 'Fixer'}</Text>
+                      {bid.fixer?.average_rating_as_fixer && (
+                        <Text variant="bodySmall">
+                          {bid.fixer.average_rating_as_fixer.toFixed(1)} ★
+                        </Text>
+                      )}
+                    </View>
+                    <Text variant="titleMedium" style={{ color: theme.colors.primary }}>
+                      ₪{bid.offered_price}
+                    </Text>
+                  </View>
+                  <Text variant="bodySmall" style={styles.bidDesc} numberOfLines={2}>
+                    {bid.description}
+                  </Text>
+                  <View style={styles.bidActions}>
+                    <Button
+                      mode="contained"
+                      buttonColor="#2E7D32"
+                      compact
+                      onPress={() => acceptBid(bid.id)}
+                    >
+                      Accept
+                    </Button>
+                    <Button
+                      mode="outlined"
+                      textColor="#C62828"
+                      compact
+                      onPress={() => declineBid(bid.id)}
+                    >
+                      Decline
+                    </Button>
+                  </View>
+                </Card.Content>
+              </Card>
+            ))
+          )}
+          <Button
+            mode="text"
+            textColor="#C62828"
+            onPress={cancelTask}
+            style={styles.cancelButton}
+          >
+            Cancel Task
+          </Button>
+        </View>
+      )}
+
+      {/* IN_PROGRESS — Assigned Fixer */}
+      {task.status === 'IN_PROGRESS' && acceptedBid && (
+        <View style={styles.section}>
+          <Text variant="titleMedium" style={styles.sectionTitle}>Assigned Fixer</Text>
+          <Card style={styles.card}>
+            <Card.Content>
+              <View style={styles.bidHeader}>
+                <Avatar.Icon size={48} icon="account" />
+                <View style={styles.bidInfo}>
+                  <Text variant="titleSmall">{acceptedBid.fixer?.full_name || 'Fixer'}</Text>
+                  {acceptedBid.fixer?.average_rating_as_fixer && (
+                    <Text variant="bodySmall">
+                      {acceptedBid.fixer.average_rating_as_fixer.toFixed(1)} ★
+                    </Text>
+                  )}
+                  {acceptedBid.fixer?.phone_number && (
+                    <Text
+                      variant="bodySmall"
+                      style={styles.phone}
+                      onPress={() => Linking.openURL(`tel:${acceptedBid.fixer!.phone_number}`)}
+                    >
+                      {acceptedBid.fixer.phone_number}
+                    </Text>
+                  )}
+                </View>
+                <Text variant="titleMedium" style={{ color: theme.colors.primary }}>
+                  ₪{acceptedBid.offered_price}
+                </Text>
+              </View>
+            </Card.Content>
+          </Card>
+          <Button
+            mode="contained"
+            buttonColor="#2E7D32"
+            onPress={markCompleted}
+            style={styles.actionButton}
+          >
+            Mark as Completed
+          </Button>
+          <Button
+            mode="text"
+            textColor="#C62828"
+            onPress={cancelTask}
+          >
+            Cancel Task
+          </Button>
+        </View>
+      )}
+
+      {/* COMPLETED — Payment & Review */}
+      {task.status === 'COMPLETED' && (
+        <View style={styles.section}>
+          {/* Payment */}
+          <Text variant="titleMedium" style={styles.sectionTitle}>Payment</Text>
+          <Card style={styles.card}>
+            <Card.Content>
+              {task.is_payment_confirmed ? (
+                <Text variant="bodyMedium" style={styles.confirmed}>Payment Confirmed ✓</Text>
+              ) : (
+                <View>
+                  {acceptedBid?.fixer?.payment_link ? (
+                    <>
+                      <Button
+                        mode="contained"
+                        onPress={() => Linking.openURL(acceptedBid.fixer!.payment_link!)}
+                        style={styles.actionButton}
+                      >
+                        Pay Fixer
+                      </Button>
+                      <Button mode="outlined" onPress={confirmPayment}>
+                        Confirm Payment
+                      </Button>
+                    </>
+                  ) : (
+                    <View>
+                      <Text variant="bodyMedium">
+                        This Fixer hasn't set up a payment link. Contact them directly.
+                      </Text>
+                      {acceptedBid?.fixer?.phone_number && (
+                        <Text
+                          variant="bodyMedium"
+                          style={styles.phone}
+                          onPress={() => Linking.openURL(`tel:${acceptedBid.fixer!.phone_number}`)}
+                        >
+                          {acceptedBid.fixer.phone_number}
+                        </Text>
+                      )}
+                    </View>
+                  )}
+                </View>
+              )}
+            </Card.Content>
+          </Card>
+
+          {/* Review */}
+          <Text variant="titleMedium" style={styles.sectionTitle}>Review</Text>
+          <Card style={styles.card}>
+            <Card.Content>
+              {reviewSubmitted ? (
+                <Text variant="bodyMedium" style={styles.confirmed}>Review submitted. Thank you!</Text>
+              ) : (
+                <View>
+                  <Text variant="bodyMedium" style={{ marginBottom: 8 }}>Rate the fixer:</Text>
+                  <View style={styles.stars}>
+                    {[1, 2, 3, 4, 5].map((star) => (
+                      <IconButton
+                        key={star}
+                        icon={star <= reviewRating ? 'star' : 'star-outline'}
+                        iconColor={star <= reviewRating ? '#FFC107' : '#9E9E9E'}
+                        size={32}
+                        onPress={() => setReviewRating(star)}
+                      />
+                    ))}
+                  </View>
+                  <TextInput
+                    label="Comment (optional)"
+                    value={reviewComment}
+                    onChangeText={setReviewComment}
+                    mode="outlined"
+                    multiline
+                    numberOfLines={3}
+                    maxLength={2000}
+                    style={styles.input}
+                  />
+                  <Button
+                    mode="contained"
+                    onPress={submitReview}
+                    disabled={reviewRating === 0}
+                  >
+                    Submit Review
+                  </Button>
+                </View>
+              )}
+            </Card.Content>
+          </Card>
+        </View>
+      )}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  container: {
+    padding: 16,
+    paddingTop: 90,
+    backgroundColor: '#E3F2FD',
+    alignItems: 'center',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    maxWidth: 500,
+    marginBottom: 16,
+  },
+  title: {
+    flex: 1,
+    marginRight: 12,
+  },
+  card: {
+    width: '100%',
+    maxWidth: 500,
+    marginBottom: 12,
+  },
+  divider: {
+    marginVertical: 12,
+  },
+  detailRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  section: {
+    width: '100%',
+    maxWidth: 500,
+    marginTop: 8,
+  },
+  sectionTitle: {
+    marginBottom: 12,
+    fontWeight: '600',
+  },
+  bidCard: {
+    marginBottom: 12,
+  },
+  bidHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  bidInfo: {
+    flex: 1,
+  },
+  bidDesc: {
+    marginTop: 8,
+    color: '#616161',
+  },
+  bidActions: {
+    flexDirection: 'row',
+    gap: 12,
+    marginTop: 12,
+  },
+  actionButton: {
+    marginBottom: 8,
+  },
+  cancelButton: {
+    marginTop: 8,
+  },
+  phone: {
+    color: '#1565C0',
+    textDecorationLine: 'underline',
+    marginTop: 4,
+  },
+  confirmed: {
+    color: '#2E7D32',
+    fontWeight: '600',
+  },
+  stars: {
+    flexDirection: 'row',
+    marginBottom: 12,
+  },
+  input: {
+    marginBottom: 12,
+  },
+  emptyText: {
+    color: '#757575',
+    fontStyle: 'italic',
+  },
+});

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,0 +1,23 @@
+import { MD3LightTheme, configureFonts } from 'react-native-paper';
+
+export const theme = {
+  ...MD3LightTheme,
+  colors: {
+    ...MD3LightTheme.colors,
+    primary: '#1A237E',        // Deep Navy Blue — buttons, active states, top bar
+    onPrimary: '#FFFFFF',      // White text/icons on navy backgrounds
+    secondary: '#FFC107',      // Golden Yellow — accents, highlights, FAB
+    onSecondary: '#212121',    // Dark Gray text/icons on yellow backgrounds
+    surface: '#F5F5F5',        // Light Gray — card backgrounds
+    onSurface: '#212121',
+    background: '#FFFFFF',
+    onBackground: '#212121',
+    error: '#B00020',
+    onError: '#FFFFFF',
+    outline: '#79747E',
+    surfaceVariant: '#E7E0EC',
+  },
+  fonts: configureFonts({ config: { fontFamily: 'System' } }),
+};
+
+export type AppTheme = typeof theme;

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,7 +161,9 @@
     "frontend": {
       "version": "1.0.0",
       "dependencies": {
+        "@expo/vector-icons": "^15.0.3",
         "@react-navigation/bottom-tabs": "^7.15.9",
+        "@react-navigation/elements": "^2.9.14",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
         "axios": "^1.14.0",
@@ -173,12 +175,14 @@
         "expo-status-bar": "~3.0.9",
         "firebase": "^12.11.0",
         "react": "19.1.0",
+        "react-dom": "19.1.0",
         "react-native": "0.81.5",
         "react-native-maps": "1.20.1",
         "react-native-paper": "^5.15.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-vector-icons": "^10.3.0",
+        "react-native-web": "^0.21.0",
         "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
@@ -6515,6 +6519,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6527,6 +6540,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-in-js-utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
+      "license": "MIT",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.3"
       }
     },
     "node_modules/csstype": {
@@ -7695,6 +7717,62 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fbjs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.5.tgz",
+      "integrity": "sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "fbjs-css-vars": "^1.0.0",
+        "loose-envify": "^1.0.0",
+        "object-assign": "^4.1.0",
+        "promise": "^7.1.1",
+        "setimmediate": "^1.0.5",
+        "ua-parser-js": "^1.0.35"
+      }
+    },
+    "node_modules/fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
+      "license": "MIT"
+    },
+    "node_modules/fbjs/node_modules/promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.3"
+      }
+    },
+    "node_modules/fbjs/node_modules/ua-parser-js": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
+      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -8706,6 +8784,12 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -8823,6 +8907,15 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
+    },
+    "node_modules/inline-style-prefixer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0"
+      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -9648,9 +9741,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9670,9 +9760,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9694,9 +9781,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9716,9 +9800,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -10944,7 +11025,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -11731,6 +11811,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12118,6 +12204,18 @@
         }
       }
     },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
     "node_modules/react-freeze": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
@@ -12349,6 +12447,38 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/react-native-web": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
+      "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@react-native/normalize-colors": "^0.74.1",
+        "fbjs": "^3.0.4",
+        "inline-style-prefixer": "^7.0.1",
+        "memoize-one": "^6.0.0",
+        "nullthrows": "^1.1.1",
+        "postcss-value-parser": "^4.2.0",
+        "styleq": "^0.1.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-native-web/node_modules/@react-native/normalize-colors": {
+      "version": "0.74.89",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.74.89.tgz",
+      "integrity": "sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-web/node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
     },
     "node_modules/react-native/node_modules/commander": {
       "version": "12.1.0",
@@ -12798,6 +12928,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -13304,6 +13440,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/styleq": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/styleq/-/styleq-0.1.3.tgz",
+      "integrity": "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==",
+      "license": "MIT"
+    },
     "node_modules/sucrase": {
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
@@ -13687,8 +13829,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
@@ -14092,8 +14233,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -14129,7 +14269,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -12,8 +12,14 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "backend/src/**/*.ts": ["eslint --fix", "bash -c 'tsc -p backend/tsconfig.json --noEmit'"],
-    "frontend/src/**/*.{ts,tsx}": ["eslint --fix", "bash -c 'tsc -p frontend/tsconfig.json --noEmit'"]
+    "backend/src/**/*.ts": [
+      "eslint --fix",
+      "bash -c 'tsc -p backend/tsconfig.json --noEmit'"
+    ],
+    "frontend/src/**/*.{ts,tsx}": [
+      "eslint --fix",
+      "bash -c 'tsc -p frontend/tsconfig.json --noEmit'"
+    ]
   },
   "devDependencies": {
     "husky": "^9.1.7",


### PR DESCRIPTION
## Summary
- **Design System**: `theme.ts` with Fixlt palette (Primary #1A237E, Secondary #FFC107, Surface #F5F5F5), app wrapped in `PaperProvider`
- **Shared Components**: `StatusBadge`, `EmptyState`, `TaskCard` — ready for Stein and Zilber's screens
- **Navigation**: Bottom tabs (Home, Messages, Profile) + stack navigator for CreateTask, TaskDetails, Settings
- **Requester Dashboard**: Active tasks horizontal scroll, past tasks list, FAB (+), empty state, connected to `GET /api/users/me/tasks`
- **Task Creation Wizard**: 5-step flow (Title → Photos → Category → Budget → Location) + review modal, connected to `POST /api/tasks`
- **Task Details**: 3 states — OPEN (bid list with Accept/Decline), IN_PROGRESS (assigned fixer card, Mark Completed), COMPLETED (payment deep-link, review with stars)
- **Settings**: Phone edit, push notifications toggle, change password, log out

## How to run
```bash
# 1. Clone and install
git clone https://github.com/GuyStein1/CSFinalProject.git
cd CSFinalProject
npm install

# 2. Create frontend/.env (copy from .env.example and fill in Firebase keys)
cp frontend/.env.example frontend/.env

# 3. Start the web app
cd frontend
npx expo start --web
```

## Test plan
- [ ] `npm run typecheck --workspace frontend` passes
- [ ] `npm run lint --workspace frontend` passes
- [ ] Home tab shows empty state with "Create Task" button
- [ ] FAB (+) navigates to Create Task wizard
- [ ] All 5 wizard steps render correctly with Next/Back navigation
- [ ] Review modal shows before publish
- [ ] Profile tab shows Settings with phone, push toggle, password, logout
- [ ] Task Details screen renders for all 3 statuses (OPEN, IN_PROGRESS, COMPLETED)

Closes #24