### PR TITLE
C3.1 — General Design & UI Polish

### DIFF
--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -510,4 +510,28 @@ router.post('/:id/reviews', validate(createReviewSchema), async (req: Request, r
   }
 });
 
+// DELETE /api/tasks/:id — requester deletes a completed or canceled task
+router.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const task = await prisma.task.findUnique({ where: { id: req.params.id } });
+    if (!task) throw new NotFoundError('Task not found');
+    if (req.user.id !== task.requester_id) throw new ForbiddenError('Only the requester can delete this task');
+    if (task.status !== 'COMPLETED' && task.status !== 'CANCELED') {
+      throw new ValidationError('Only completed or canceled tasks can be deleted');
+    }
+
+    await prisma.$transaction([
+      prisma.review.deleteMany({ where: { task_id: task.id } }),
+      prisma.message.deleteMany({ where: { task_id: task.id } }),
+      prisma.bid.deleteMany({ where: { task_id: task.id } }),
+      prisma.notification.deleteMany({ where: { related_entity_id: task.id } }),
+      prisma.task.delete({ where: { id: task.id } }),
+    ]);
+
+    res.json({ message: 'Task deleted' });
+  } catch (err) {
+    next(err);
+  }
+});
+
 export default router;

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -167,7 +167,7 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   segmentedButtons: {
-    width: 168,
+    width: 220,
     backgroundColor: 'rgba(255, 252, 246, 0.08)',
     borderRadius: 999,
   },

--- a/frontend/src/screens/RequesterDashboard.tsx
+++ b/frontend/src/screens/RequesterDashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
-import { View, FlatList, ScrollView, StyleSheet, RefreshControl } from 'react-native';
-import { Text, FAB, useTheme, Card } from 'react-native-paper';
+import { View, FlatList, StyleSheet, RefreshControl, Platform } from 'react-native';
+import { Text, FAB, useTheme, Card, SegmentedButtons, IconButton } from 'react-native-paper';
 import { useFocusEffect } from '@react-navigation/native';
 import api from '../api/axiosInstance';
 import TaskCard from '../components/TaskCard';
@@ -54,8 +54,24 @@ export default function RequesterDashboard({ navigation }: Props) {
     fetchTasks();
   };
 
+  const [tab, setTab] = useState<'active' | 'past'>('active');
+
+  const deleteTask = async (taskId: string) => {
+    const confirmed = Platform.OS === 'web'
+      ? window.confirm('Delete this task permanently?')
+      : true;
+    if (!confirmed) return;
+    try {
+      await api.delete(`/api/tasks/${taskId}`);
+      fetchTasks();
+    } catch {
+      // ignore
+    }
+  };
+
   const activeTasks = tasks.filter((t) => t.status === 'OPEN' || t.status === 'IN_PROGRESS');
   const pastTasks = tasks.filter((t) => t.status === 'COMPLETED' || t.status === 'CANCELED');
+  const displayedTasks = tab === 'active' ? activeTasks : pastTasks;
 
   if (loading) {
     return <LoadingScreen label="Loading your tasks..." />;
@@ -83,7 +99,7 @@ export default function RequesterDashboard({ navigation }: Props) {
   return (
     <View style={styles.flex}>
       <FlatList
-        data={pastTasks}
+        data={displayedTasks}
         keyExtractor={(item) => item.id}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
         ListHeaderComponent={
@@ -91,64 +107,49 @@ export default function RequesterDashboard({ navigation }: Props) {
             <Card style={styles.heroCard} mode="elevated">
               <Card.Content style={styles.heroContent}>
                 <AppLogo />
-                <Text variant="bodyMedium" style={styles.heroText}>
-                  Keep track of open jobs, compare bids, and move each task forward without the UI
-                  fighting you.
-                </Text>
-                <View style={styles.heroStats}>
-                  <View style={styles.statPill}>
-                    <Text variant="labelMedium" style={styles.statText}>
-                      {activeTasks.length} active
-                    </Text>
-                  </View>
-                  <View style={styles.statPill}>
-                    <Text variant="labelMedium" style={styles.statText}>
-                      {pastTasks.length} past
-                    </Text>
-                  </View>
-                </View>
               </Card.Content>
             </Card>
-            {activeTasks.length > 0 && (
-              <View style={styles.section}>
-                <Text variant="titleMedium" style={styles.sectionTitle}>
-                  Active Tasks
-                </Text>
-                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                  {activeTasks.map((task) => (
-                    <View key={task.id} style={styles.activeCard}>
-                      <TaskCard
-                        title={task.title}
-                        category={task.category}
-                        status={task.status}
-                        suggestedPrice={task.suggested_price}
-                        locationName={task.general_location_name}
-                        bidCount={task.bid_count}
-                        fixerName={task.assigned_fixer_name}
-                        onPress={() => navigation.navigate('TaskDetails', { taskId: task.id })}
-                      />
-                    </View>
-                  ))}
-                </ScrollView>
-              </View>
-            )}
-            {pastTasks.length > 0 && (
-              <Text variant="titleMedium" style={styles.sectionTitle}>
-                Past Tasks
-              </Text>
-            )}
+            <SegmentedButtons
+              value={tab}
+              onValueChange={(v) => setTab(v as 'active' | 'past')}
+              buttons={[
+                { value: 'active', label: `Active (${activeTasks.length})` },
+                { value: 'past', label: `Past (${pastTasks.length})` },
+              ]}
+              style={styles.tabs}
+            />
           </>
         }
         renderItem={({ item }) => (
-          <TaskCard
-            title={item.title}
-            category={item.category}
-            status={item.status}
-            suggestedPrice={item.suggested_price}
-            locationName={item.general_location_name}
-            onPress={() => navigation.navigate('TaskDetails', { taskId: item.id })}
-          />
+          <View style={styles.taskRow}>
+            <View style={styles.taskCardWrap}>
+              <TaskCard
+                title={item.title}
+                category={item.category}
+                status={item.status}
+                suggestedPrice={item.suggested_price}
+                locationName={item.general_location_name}
+                bidCount={item.bid_count}
+                fixerName={item.assigned_fixer_name}
+                onPress={() => navigation.navigate('TaskDetails', { taskId: item.id })}
+              />
+            </View>
+            {tab === 'past' && (
+              <IconButton
+                icon="delete-outline"
+                iconColor={brandColors.danger}
+                size={22}
+                onPress={() => deleteTask(item.id)}
+                style={styles.deleteButton}
+              />
+            )}
+          </View>
         )}
+        ListEmptyComponent={
+          <Text variant="bodyMedium" style={styles.emptyText}>
+            {tab === 'active' ? 'No active tasks.' : 'No past tasks.'}
+          </Text>
+        }
         contentContainerStyle={styles.list}
       />
       <FAB
@@ -171,44 +172,32 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   heroCard: {
-    marginBottom: 18,
-    borderRadius: 28,
+    marginBottom: 8,
+    borderRadius: 20,
     backgroundColor: brandColors.surface,
   },
   heroContent: {
-    gap: 12,
+    alignItems: 'center' as const,
+    paddingVertical: 0,
   },
-  heroText: {
-    color: brandColors.textMuted,
-    lineHeight: 20,
+  tabs: {
+    marginBottom: 12,
   },
-  heroStats: {
+  taskRow: {
     flexDirection: 'row',
-    gap: 10,
-    flexWrap: 'wrap',
+    alignItems: 'center',
   },
-  statPill: {
-    paddingHorizontal: 14,
-    paddingVertical: 10,
-    borderRadius: 999,
-    backgroundColor: brandColors.surfaceAlt,
+  taskCardWrap: {
+    flex: 1,
   },
-  statText: {
-    color: brandColors.primary,
-    fontWeight: '700',
+  deleteButton: {
+    margin: 0,
   },
-  section: {
-    marginBottom: 16,
-  },
-  sectionTitle: {
-    paddingHorizontal: 4,
-    paddingVertical: 10,
-    fontWeight: '600',
-    color: brandColors.textPrimary,
-  },
-  activeCard: {
-    width: 272,
-    marginRight: 12,
+  emptyText: {
+    color: brandColors.textMuted,
+    fontStyle: 'italic',
+    textAlign: 'center' as const,
+    marginTop: 24,
   },
   list: {
     padding: 16,

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -1,10 +1,9 @@
 import React, { useState } from 'react';
-import { ScrollView, StyleSheet, Alert } from 'react-native';
+import { ScrollView, StyleSheet, Alert, Platform } from 'react-native';
 import { View } from 'react-native';
 import { Text, TextInput, Button, Card, Divider, Switch, useTheme } from 'react-native-paper';
 import { sendPasswordResetEmail, signOut } from 'firebase/auth';
 import { auth } from '../config/firebase';
-import AppLogo from '../components/AppLogo';
 import { brandColors } from '../theme';
 
 export default function SettingsScreen() {
@@ -25,26 +24,29 @@ export default function SettingsScreen() {
   };
 
   const handleLogout = async () => {
-    Alert.alert('Log Out', 'Are you sure you want to log out?', [
-      { text: 'Cancel' },
-      {
-        text: 'Log Out',
-        style: 'destructive',
-        onPress: async () => {
-          await signOut(auth);
+    if (Platform.OS === 'web') {
+      if (window.confirm('Are you sure you want to log out?')) {
+        await signOut(auth);
+      }
+    } else {
+      Alert.alert('Log Out', 'Are you sure you want to log out?', [
+        { text: 'Cancel' },
+        {
+          text: 'Log Out',
+          style: 'destructive',
+          onPress: async () => {
+            await signOut(auth);
+          },
         },
-      },
-    ]);
+      ]);
+    }
   };
 
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Card style={styles.heroCard}>
         <Card.Content style={styles.heroContent}>
-          <AppLogo />
-          <Text variant="bodyMedium" style={styles.heroText}>
-            Account preferences, sign-in settings, and notification controls all live here.
-          </Text>
+          <Text variant="titleMedium" style={styles.heroTitle}>Settings</Text>
         </Card.Content>
       </Card>
 
@@ -132,11 +134,11 @@ const styles = StyleSheet.create({
     backgroundColor: brandColors.surface,
   },
   heroContent: {
-    gap: 12,
+    paddingVertical: 4,
   },
-  heroText: {
-    color: brandColors.textMuted,
-    lineHeight: 20,
+  heroTitle: {
+    color: brandColors.textPrimary,
+    fontWeight: '600',
   },
   card: {
     width: '100%',

--- a/frontend/src/screens/TaskDetails.tsx
+++ b/frontend/src/screens/TaskDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { View, ScrollView, StyleSheet, Alert, Linking } from 'react-native';
+import { View, ScrollView, StyleSheet, Alert, Linking, Platform } from 'react-native';
 import {
   Text,
   Button,
@@ -7,14 +7,32 @@ import {
   useTheme,
   Divider,
   Avatar,
+  Icon,
   IconButton,
   TextInput,
+  Portal,
+  Modal,
 } from 'react-native-paper';
 import { useFocusEffect } from '@react-navigation/native';
 import api from '../api/axiosInstance';
 import StatusBadge from '../components/StatusBadge';
 import LoadingScreen from '../components/LoadingScreen';
 import { brandColors } from '../theme';
+
+function StarRating({ rating, size = 16 }: { rating: number; size?: number }) {
+  return (
+    <View style={{ flexDirection: 'row' }}>
+      {[1, 2, 3, 4, 5].map((s) => (
+        <Icon
+          key={s}
+          source={s <= Math.round(rating) ? 'star' : 'star-outline'}
+          size={size}
+          color={brandColors.secondary}
+        />
+      ))}
+    </View>
+  );
+}
 
 type TaskStatus = 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
 
@@ -55,6 +73,8 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
   const [reviewRating, setReviewRating] = useState(0);
   const [reviewComment, setReviewComment] = useState('');
   const [reviewSubmitted, setReviewSubmitted] = useState(false);
+  const [fixerReviews, setFixerReviews] = useState<{ rating: number; comment: string | null; reviewer?: { full_name: string } }[]>([]);
+  const [showFixerReviews, setShowFixerReviews] = useState(false);
 
   const fetchData = useCallback(async () => {
     try {
@@ -96,21 +116,25 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
   };
 
   const cancelTask = async () => {
-    Alert.alert('Cancel Task', 'Are you sure you want to cancel this task?', [
-      { text: 'No' },
-      {
-        text: 'Yes, Cancel',
-        style: 'destructive',
-        onPress: async () => {
-          try {
-            await api.put(`/api/tasks/${taskId}/status`, { status: 'CANCELED' });
-            navigation.goBack();
-          } catch {
-            Alert.alert('Error', 'Failed to cancel task.');
-          }
-        },
-      },
-    ]);
+    const doCancel = async () => {
+      try {
+        await api.put(`/api/tasks/${taskId}/status`, { status: 'CANCELED' });
+        navigation.goBack();
+      } catch {
+        Alert.alert('Error', 'Failed to cancel task.');
+      }
+    };
+
+    if (Platform.OS === 'web') {
+      if (window.confirm('Are you sure you want to cancel this task?')) {
+        await doCancel();
+      }
+    } else {
+      Alert.alert('Cancel Task', 'Are you sure you want to cancel this task?', [
+        { text: 'No' },
+        { text: 'Yes, Cancel', style: 'destructive', onPress: doCancel },
+      ]);
+    }
   };
 
   const markCompleted = async () => {
@@ -128,6 +152,17 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
       fetchData();
     } catch {
       Alert.alert('Error', 'Failed to confirm payment.');
+    }
+  };
+
+  const showReviewsForFixer = async (fixerId: string) => {
+    try {
+      const res = await api.get(`/api/users/${fixerId}/reviews`);
+      setFixerReviews(res.data.reviews || []);
+      setShowFixerReviews(true);
+    } catch {
+      setFixerReviews([]);
+      setShowFixerReviews(true);
     }
   };
 
@@ -160,6 +195,7 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
   const pendingBids = bids.filter((b) => b.status === 'PENDING');
 
   return (
+    <>
     <ScrollView contentContainerStyle={styles.container}>
       {/* Header */}
       <View style={styles.header}>
@@ -213,10 +249,19 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
                     <Avatar.Icon size={40} icon="account" />
                     <View style={styles.bidInfo}>
                       <Text variant="titleSmall">{bid.fixer?.full_name || 'Fixer'}</Text>
-                      {bid.fixer?.average_rating_as_fixer && (
-                        <Text variant="bodySmall">
-                          {bid.fixer.average_rating_as_fixer.toFixed(1)} ★
-                        </Text>
+                      {bid.fixer?.average_rating_as_fixer ? (
+                        <View style={styles.ratingRow}>
+                          <StarRating rating={bid.fixer.average_rating_as_fixer} />
+                          <Text
+                            variant="bodySmall"
+                            style={styles.ratingLink}
+                            onPress={() => showReviewsForFixer(bid.fixer_id)}
+                          >
+                            {bid.fixer.average_rating_as_fixer.toFixed(1)} — see reviews
+                          </Text>
+                        </View>
+                      ) : (
+                        <Text variant="bodySmall" style={{ color: brandColors.textMuted }}>No reviews yet</Text>
                       )}
                     </View>
                     <Text variant="titleMedium" style={{ color: theme.colors.primary }}>
@@ -269,10 +314,19 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
                 <Avatar.Icon size={48} icon="account" />
                 <View style={styles.bidInfo}>
                   <Text variant="titleSmall">{acceptedBid.fixer?.full_name || 'Fixer'}</Text>
-                  {acceptedBid.fixer?.average_rating_as_fixer && (
-                    <Text variant="bodySmall">
-                      {acceptedBid.fixer.average_rating_as_fixer.toFixed(1)} ★
-                    </Text>
+                  {acceptedBid.fixer?.average_rating_as_fixer ? (
+                    <View style={styles.ratingRow}>
+                      <StarRating rating={acceptedBid.fixer.average_rating_as_fixer} />
+                      <Text
+                        variant="bodySmall"
+                        style={styles.ratingLink}
+                        onPress={() => showReviewsForFixer(acceptedBid.fixer_id)}
+                      >
+                        {acceptedBid.fixer.average_rating_as_fixer.toFixed(1)} — see reviews
+                      </Text>
+                    </View>
+                  ) : (
+                    <Text variant="bodySmall" style={{ color: brandColors.textMuted }}>No reviews yet</Text>
                   )}
                   {acceptedBid.fixer?.phone_number && (
                     <Text
@@ -397,6 +451,39 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
         </View>
       )}
     </ScrollView>
+
+      <Portal>
+        <Modal visible={showFixerReviews} onDismiss={() => setShowFixerReviews(false)} contentContainerStyle={styles.reviewsModal}>
+          <Text variant="titleLarge" style={styles.reviewsModalTitle}>Fixer Reviews</Text>
+          {fixerReviews.length === 0 ? (
+            <Text variant="bodyMedium" style={{ color: brandColors.textMuted }}>No reviews yet.</Text>
+          ) : (
+            <ScrollView style={{ maxHeight: 400 }}>
+              {fixerReviews.map((r, i) => (
+                <Card key={i} style={styles.reviewItemCard}>
+                  <Card.Content>
+                    <View style={styles.reviewItemHeader}>
+                      <StarRating rating={r.rating} size={14} />
+                      {r.reviewer?.full_name && (
+                        <Text variant="bodySmall" style={{ color: brandColors.textMuted }}>
+                          {r.reviewer.full_name}
+                        </Text>
+                      )}
+                    </View>
+                    {r.comment && (
+                      <Text variant="bodyMedium" style={{ marginTop: 4 }}>{r.comment}</Text>
+                    )}
+                  </Card.Content>
+                </Card>
+              ))}
+            </ScrollView>
+          )}
+          <Button mode="text" onPress={() => setShowFixerReviews(false)} style={{ marginTop: 8 }}>
+            Close
+          </Button>
+        </Modal>
+      </Portal>
+    </>
   );
 }
 
@@ -502,5 +589,35 @@ const styles = StyleSheet.create({
   emptyText: {
     color: brandColors.textMuted,
     fontStyle: 'italic',
+  },
+  ratingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  ratingLink: {
+    color: brandColors.primaryMuted,
+    textDecorationLine: 'underline',
+  },
+  reviewsModal: {
+    backgroundColor: brandColors.surface,
+    margin: 20,
+    padding: 24,
+    borderRadius: 24,
+    maxHeight: '80%',
+  },
+  reviewsModalTitle: {
+    marginBottom: 16,
+    color: brandColors.textPrimary,
+  },
+  reviewItemCard: {
+    marginBottom: 8,
+    borderRadius: 16,
+    backgroundColor: brandColors.background,
+  },
+  reviewItemHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
 });


### PR DESCRIPTION
## Summary
Closes #63

General design improvements and UI polish across requester screens:

- **Dashboard**: Replaced large hero section with compact logo card + Active/Past segmented tabs for filtering tasks
- **Dashboard**: Added delete button (trash icon) on past tasks with backend `DELETE /api/tasks/:id` endpoint
- **TaskDetails**: Fixed Cancel Task not working on web (`Alert.alert` with buttons → `window.confirm` fallback)
- **TaskDetails**: Added star rating display (filled/empty stars) for fixers on bids
- **TaskDetails**: Added reviews modal — tap a fixer's rating to see all their reviews with comments
- **Settings**: Shrunk hero card (removed large text block), fixed Log Out button on web
- **AppNavigator**: Widened Requester/Fixer mode toggle so full text is visible

## Test plan
- [ ] Create a task, verify it appears in Active tab
- [ ] Cancel a task, verify it moves to Past tab
- [ ] Delete a past task using the trash icon, verify it disappears
- [ ] View bids on a task, verify star ratings display correctly
- [ ] Tap a fixer's rating, verify reviews modal opens with comments
- [ ] Log out from Settings, verify confirm dialog appears on web
- [ ] Verify Requester/Fixer toggle text is fully visible