### PR TITLE
feat: A4 — Socket.io chat server + message REST endpoints

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "helmet": "^7.1.0",
     "morgan": "^1.10.0",
     "prisma": "^6.19.2",
+    "socket.io": "^4.8.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -26,6 +27,7 @@
     "@types/express": "^4.17.21",
     "@types/morgan": "^1.9.9",
     "@types/node": "^20.11.5",
+    "@types/socket.io": "^3.0.1",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.57.0",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import http from 'http';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -9,7 +10,9 @@ import userRoutes from './routes/users';
 import taskRoutes from './routes/tasks';
 import bidRoutes from './routes/bids';
 import notificationRoutes from './routes/notifications';
+import messageRoutes from './routes/messages';
 import { errorHandler } from './middleware/errorHandler';
+import { initSocket } from './socket';
 
 const app = express();
 const PORT = process.env.PORT ?? 3000;
@@ -28,10 +31,14 @@ app.use('/api/users', userRoutes);
 app.use('/api/tasks', taskRoutes);
 app.use('/api/bids', bidRoutes);
 app.use('/api/notifications', notificationRoutes);
+app.use('/api', messageRoutes);
 
 app.use(errorHandler);
 
-app.listen(PORT, () => {
+const httpServer = http.createServer(app);
+initSocket(httpServer);
+
+httpServer.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });
 

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -1,0 +1,115 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { authMiddleware } from '../middleware/auth';
+import { prisma } from '../config/prisma';
+import { ForbiddenError, NotFoundError } from '../utils/errors';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+// GET /api/tasks/:id/messages — paginated chat history (oldest-first within page)
+router.get('/tasks/:id/messages', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const taskId = req.params.id;
+    const userId = req.user!.id;
+    const page = Math.max(1, parseInt((req.query.page as string) ?? '1', 10));
+    const rawLimit = parseInt((req.query.limit as string) ?? '30', 10);
+    const limit = Math.min(100, Math.max(1, rawLimit));
+
+    const task = await prisma.task.findUnique({ where: { id: taskId } });
+    if (!task) throw new NotFoundError('Task not found');
+
+    const isMember =
+      task.requester_id === userId || task.assigned_fixer_id === userId;
+    if (!isMember) throw new ForbiddenError('Not a participant in this chat');
+
+    const [messages, total] = await Promise.all([
+      prisma.message.findMany({
+        where: { task_id: taskId },
+        orderBy: { created_at: 'asc' },
+        skip: (page - 1) * limit,
+        take: limit,
+        include: {
+          sender: { select: { id: true, full_name: true, avatar_url: true } },
+        },
+      }),
+      prisma.message.count({ where: { task_id: taskId } }),
+    ]);
+
+    res.json({ messages, meta: { total, page, limit } });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// GET /api/conversations — conversation summaries for the authenticated user
+router.get('/conversations', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const userId = req.user!.id;
+
+    // Find all tasks where user is requester or assigned fixer and has messages
+    const tasks = await prisma.task.findMany({
+      where: {
+        OR: [{ requester_id: userId }, { assigned_fixer_id: userId }],
+        messages: { some: {} },
+      },
+      include: {
+        requester: { select: { id: true, full_name: true, avatar_url: true } },
+        fixer: { select: { id: true, full_name: true, avatar_url: true } },
+        messages: {
+          orderBy: { created_at: 'desc' },
+          take: 1,
+          select: { content: true, created_at: true, sender_id: true, is_read: true },
+        },
+        _count: {
+          select: {
+            messages: true,
+          },
+        },
+      },
+    });
+
+    // For each task, compute unread count (messages sent to me that are unread)
+    const conversationIds = tasks.map((t) => t.id);
+    const unreadCounts = await prisma.message.groupBy({
+      by: ['task_id'],
+      where: {
+        task_id: { in: conversationIds },
+        recipient_id: userId,
+        is_read: false,
+      },
+      _count: { id: true },
+    });
+
+    const unreadMap = new Map(unreadCounts.map((r) => [r.task_id, r._count.id]));
+
+    const conversations = tasks.map((task) => {
+      const otherParty =
+        task.requester_id === userId ? task.fixer : task.requester;
+      const lastMessage = task.messages[0] ?? null;
+
+      return {
+        taskId: task.id,
+        taskTitle: task.title,
+        otherParty,
+        lastMessage: lastMessage
+          ? { content: lastMessage.content, timestamp: lastMessage.created_at }
+          : null,
+        unreadCount: unreadMap.get(task.id) ?? 0,
+      };
+    });
+
+    // Sort by last message timestamp descending
+    conversations.sort((a, b) => {
+      const aTime = a.lastMessage?.timestamp.getTime() ?? 0;
+      const bTime = b.lastMessage?.timestamp.getTime() ?? 0;
+      return bTime - aTime;
+    });
+
+    res.json({ conversations });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/backend/src/socket/index.ts
+++ b/backend/src/socket/index.ts
@@ -1,0 +1,120 @@
+import { Server as HttpServer } from 'http';
+import { Server as SocketServer, Socket } from 'socket.io';
+import { prisma } from '../config/prisma';
+import admin from '../config/firebaseAdmin';
+import { sendNotification } from '../services/notificationService';
+import { NotificationType } from '@prisma/client';
+
+interface AuthenticatedSocket extends Socket {
+  userId: string;
+}
+
+export function initSocket(httpServer: HttpServer): SocketServer {
+  const io = new SocketServer(httpServer, {
+    cors: { origin: '*', methods: ['GET', 'POST'] },
+  });
+
+  // --- Auth handshake ---
+  io.use(async (socket, next) => {
+    try {
+      const token = socket.handshake.auth?.token as string | undefined;
+      if (!token) return next(new Error('Missing auth token'));
+
+      if (!admin.apps.length) return next(new Error('Firebase Admin not initialized'));
+
+      const decoded = await admin.auth().verifyIdToken(token);
+      const user = await prisma.user.findUnique({ where: { firebase_uid: decoded.uid } });
+      if (!user) return next(new Error('User not found'));
+
+      (socket as AuthenticatedSocket).userId = user.id;
+      next();
+    } catch {
+      next(new Error('Invalid auth token'));
+    }
+  });
+
+  io.on('connection', (socket: Socket) => {
+    const authedSocket = socket as AuthenticatedSocket;
+
+    // join_chat — validate membership and join room
+    socket.on('join_chat', async (taskId: string) => {
+      try {
+        const task = await prisma.task.findUnique({ where: { id: taskId } });
+        if (!task) return;
+
+        const isMember =
+          task.requester_id === authedSocket.userId ||
+          task.assigned_fixer_id === authedSocket.userId;
+        if (!isMember) return;
+
+        socket.join(`task_chat_${taskId}`);
+      } catch (err) {
+        console.error('[socket] join_chat error', err);
+      }
+    });
+
+    // send_message — persist and broadcast
+    socket.on(
+      'send_message',
+      async (payload: { taskId: string; content: string }) => {
+        try {
+          const { taskId, content } = payload;
+          if (!taskId || !content?.trim()) return;
+
+          const task = await prisma.task.findUnique({ where: { id: taskId } });
+          if (!task) return;
+
+          const isMember =
+            task.requester_id === authedSocket.userId ||
+            task.assigned_fixer_id === authedSocket.userId;
+          if (!isMember) return;
+
+          const recipientId =
+            task.requester_id === authedSocket.userId
+              ? task.assigned_fixer_id
+              : task.requester_id;
+
+          if (!recipientId) return;
+
+          const message = await prisma.message.create({
+            data: {
+              task_id: taskId,
+              sender_id: authedSocket.userId,
+              recipient_id: recipientId,
+              content: content.trim(),
+            },
+            include: {
+              sender: { select: { id: true, full_name: true, avatar_url: true } },
+            },
+          });
+
+          io.to(`task_chat_${taskId}`).emit('receive_message', message);
+
+          // If recipient is not in the room, send push notification
+          const room = io.sockets.adapter.rooms.get(`task_chat_${taskId}`);
+          const recipientInRoom = room
+            ? [...room].some((sid) => {
+                const s = io.sockets.sockets.get(sid) as AuthenticatedSocket | undefined;
+                return s?.userId === recipientId;
+              })
+            : false;
+
+          if (!recipientInRoom) {
+            await sendNotification(
+              recipientId,
+              'New message',
+              content.trim(),
+              NotificationType.NEW_MESSAGE,
+              taskId,
+              'Task',
+            );
+          }
+        } catch (err) {
+          console.error('[socket] send_message error', err);
+        }
+      },
+    );
+  });
+
+  return io;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "helmet": "^7.1.0",
         "morgan": "^1.10.0",
         "prisma": "^6.19.2",
+        "socket.io": "^4.8.3",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -35,6 +36,7 @@
         "@types/express": "^4.17.21",
         "@types/morgan": "^1.9.9",
         "@types/node": "^20.11.5",
+        "@types/socket.io": "^3.0.1",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.57.0",
@@ -4619,7 +4621,6 @@
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -4836,6 +4837,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/socket.io": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-3.0.1.tgz",
+      "integrity": "sha512-XSma2FhVD78ymvoxYV4xGXrIH/0EKQ93rR+YR0Y+Kw1xbPzLDCip/UWSejZ08FpxYeYNci/PZPQS9anrvJRqMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -4848,6 +4859,15 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -5635,6 +5655,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.13",
@@ -6931,6 +6960,27 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/engine.io": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
+      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
     "node_modules/engine.io-client": {
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
@@ -6972,6 +7022,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/env-editor": {
@@ -13264,6 +13335,55 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.3.tgz",
+      "integrity": "sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/socket.io-client": {


### PR DESCRIPTION
## Summary

- Install \`socket.io\` on backend
- **\`backend/src/socket/index.ts\`** — Socket.io server with Firebase auth handshake, \`join_chat\` room validation (requester/fixer only), \`send_message\` persistence + broadcast, push notification fallback when recipient is offline
- **\`backend/src/routes/messages.ts\`** — \`GET /api/tasks/:id/messages\` (paginated history, oldest-first) and \`GET /api/conversations\` (summaries with last message + unread counts)
- **\`backend/src/index.ts\`** — switched to \`http.createServer\` so Socket.io shares the same port; mounted \`/api\` message routes

## Test plan

- [ ] Connect a socket client with a valid Firebase token → should succeed
- [ ] Connect with an invalid/missing token → should be rejected
- [ ] \`join_chat\` as the task requester or assigned fixer → joins room
- [ ] \`join_chat\` as an unrelated user → silently ignored (no room join)
- [ ] \`send_message\` → message persisted in DB, \`receive_message\` emitted to room
- [ ] \`send_message\` when recipient is offline → push notification triggered
- [ ] \`GET /api/tasks/:id/messages\` as a participant → returns paginated messages
- [ ] \`GET /api/tasks/:id/messages\` as a non-participant → 403
- [ ] \`GET /api/conversations\` → returns threads sorted by most recent message with correct unread counts