### PR TITLE
fix: native map parity, sea validation & seed coordinates

### DIFF
--- a/frontend/src/components/DiscoveryMap.native.tsx
+++ b/frontend/src/components/DiscoveryMap.native.tsx
@@ -1,31 +1,110 @@
-import React from 'react';
-import { StyleSheet } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
-import { CATEGORY_MARKER_COLORS, DiscoveryMapProps } from './DiscoveryMap.types';
+import React, { useEffect, useRef } from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import MapView, { Marker, Region } from 'react-native-maps';
+import { brandColors } from '../theme';
+import type { DiscoveryMapProps, DiscoveryMapRegion } from './DiscoveryMap.types';
+
+const BID_MARKER_COLOR = '#66BB6A';
+const DEFAULT_MARKER_COLOR = brandColors.primary;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const logoAsset = require('../../assets/logo-without-text.png');
 
 export default function DiscoveryMap({
   tasks,
+  centerLat,
+  centerLng,
+  fixerLat,
+  fixerLng,
+  bidTaskIds,
   mapRegion,
   onSelectTask,
   onClearSelection,
   onRegionChangeComplete,
 }: DiscoveryMapProps) {
+  const mapRef = useRef<MapView | null>(null);
+  const prevCenter = useRef({ lat: centerLat, lng: centerLng });
+
+  // Pan to new center when it changes (e.g. search)
+  useEffect(() => {
+    if (
+      mapRef.current &&
+      (prevCenter.current.lat !== centerLat || prevCenter.current.lng !== centerLng)
+    ) {
+      mapRef.current.animateToRegion(
+        {
+          latitude: centerLat,
+          longitude: centerLng,
+          latitudeDelta: mapRegion.latitudeDelta,
+          longitudeDelta: mapRegion.longitudeDelta,
+        },
+        300,
+      );
+      prevCenter.current = { lat: centerLat, lng: centerLng };
+    }
+  }, [centerLat, centerLng, mapRegion.latitudeDelta, mapRegion.longitudeDelta]);
+
+  const handleRegionChange = (region: Region) => {
+    const r: DiscoveryMapRegion = {
+      latitude: region.latitude,
+      longitude: region.longitude,
+      latitudeDelta: region.latitudeDelta,
+      longitudeDelta: region.longitudeDelta,
+    };
+    onRegionChangeComplete(r);
+  };
+
   return (
     <MapView
+      ref={mapRef}
       style={StyleSheet.absoluteFillObject}
-      initialRegion={mapRegion}
-      region={mapRegion}
+      initialRegion={{
+        latitude: centerLat,
+        longitude: centerLng,
+        latitudeDelta: mapRegion.latitudeDelta,
+        longitudeDelta: mapRegion.longitudeDelta,
+      }}
       onPress={onClearSelection}
-      onRegionChangeComplete={onRegionChangeComplete}
+      onRegionChangeComplete={handleRegionChange}
     >
-      {tasks.map((task) => (
+      {tasks.map((task) => {
+        const hasBid = bidTaskIds?.has(task.id);
+        return (
+          <Marker
+            key={task.id}
+            coordinate={{ latitude: task.lat, longitude: task.lng }}
+            pinColor={hasBid ? BID_MARKER_COLOR : DEFAULT_MARKER_COLOR}
+            onPress={() => onSelectTask(task.id)}
+          />
+        );
+      })}
+
+      {/* Fixer's own location */}
+      {fixerLat != null && fixerLng != null && (
         <Marker
-          key={task.id}
-          coordinate={{ latitude: task.lat, longitude: task.lng }}
-          pinColor={CATEGORY_MARKER_COLORS[task.category]}
-          onPress={() => onSelectTask(task.id)}
-        />
-      ))}
+          coordinate={{ latitude: fixerLat, longitude: fixerLng }}
+          anchor={{ x: 0.5, y: 0.5 }}
+          tracksViewChanges={false}
+        >
+          <View style={styles.fixerMarker}>
+            <Image source={logoAsset} style={styles.fixerMarkerImage} />
+          </View>
+        </Marker>
+      )}
     </MapView>
   );
 }
+
+const styles = StyleSheet.create({
+  fixerMarker: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fixerMarkerImage: {
+    width: 30,
+    height: 30,
+    resizeMode: 'contain',
+  },
+});


### PR DESCRIPTION
## Summary
Closes #59

- **Native map parity**: iOS/Android DiscoveryMap now supports green markers for bid tasks, fixer location marker, and animated center panning
- **Sea prevention**: Backend rejects task creation with coordinates in the sea; frontend privacy offset clamps markers to stay on land (Israel coastline approximation)
- **Seed fix**: Herzliya Pituach coordinates corrected (lon 34.788 → 34.805 — was in the sea)
- **Own-task filtering**: Moved user ID fetch to useEffect for reliable filtering

## Test plan
- [ ] Reseed DB — verify Herzliya task appears on land, not in sea
- [ ] Try creating a task by clicking in the sea — should get validation error
- [ ] Coastal tasks' privacy offset markers stay on land
- [ ] iOS/Android: green markers, fixer location, map panning all work
- [ ] Fixer doesn't see own tasks on discovery map

