### PR TITLE
fix: sea validation, seed coordinates & map reliability

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -100,7 +100,7 @@ const taskSeedData = [
 
   // ══════════ OPEN — NETANYA / SHARON (4) ══════════
   { title: 'תליית מנורות בכניסה', description: 'שתי מנורות קיר לתלייה בכניסה לבית. חיבור חשמלי קיים.', category: Category.MOUNTING, suggested_price: 150, general_location_name: 'מרכז, נתניה', exact_address: 'רחוב הרצל 80, נתניה', lon: 34.8570, lat: 32.3215 },
-  { title: 'שטיפת חצר ומדרגות בלחץ', description: 'חצר ומדרגות חיצוניות מלוכלכות. צריך שטיפה בלחץ מים גבוה.', category: Category.OUTDOORS, suggested_price: 250, general_location_name: 'הרצליה פיתוח', exact_address: 'רחוב המדע 5, הרצליה פיתוח', lon: 34.7880, lat: 32.1620 },
+  { title: 'שטיפת חצר ומדרגות בלחץ', description: 'חצר ומדרגות חיצוניות מלוכלכות. צריך שטיפה בלחץ מים גבוה.', category: Category.OUTDOORS, suggested_price: 250, general_location_name: 'הרצליה פיתוח', exact_address: 'רחוב המדע 5, הרצליה פיתוח', lon: 34.8050, lat: 32.1620 },
   { title: 'הרכבת מיטת קומותיים לילדים', description: 'מיטת קומותיים מאיקאה MYDAL. כל החלקים קיימים. צריך הרכבה בטוחה.', category: Category.ASSEMBLY, suggested_price: 250, general_location_name: 'כפר סבא', exact_address: 'רחוב ויצמן 30, כפר סבא', lon: 34.9060, lat: 32.1780 },
   { title: 'תיקון נזילה מהתקרה', description: 'כתם רטוב בתקרה של חדר האמבטיה. כנראה צנרת מהשכן למעלה.', category: Category.PLUMBING, suggested_price: 300, general_location_name: 'רעננה', exact_address: 'רחוב אחוזה 50, רעננה', lon: 34.8700, lat: 32.1840 },
 

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -20,6 +20,27 @@ import {
 
 const router = Router();
 
+// Israel coastline approximation — minimum longitude per latitude band
+const COASTLINE: [number, number][] = [
+  [29.50, 34.94], [31.20, 34.56], [31.70, 34.62],
+  [32.00, 34.75], [32.10, 34.77], [32.30, 34.84],
+  [32.50, 34.87], [32.80, 34.96], [33.10, 35.08],
+];
+
+function isInSea(lat: number, lng: number): boolean {
+  if (lat < COASTLINE[0][0] || lat > COASTLINE[COASTLINE.length - 1][0]) return false;
+  for (let i = 0; i < COASTLINE.length - 1; i++) {
+    const [lat0, lng0] = COASTLINE[i];
+    const [lat1, lng1] = COASTLINE[i + 1];
+    if (lat >= lat0 && lat <= lat1) {
+      const t = (lat - lat0) / (lat1 - lat0);
+      const minLng = lng0 + t * (lng1 - lng0);
+      return lng < minLng;
+    }
+  }
+  return false;
+}
+
 // All task routes require authentication
 router.use(authMiddleware);
 
@@ -47,6 +68,11 @@ router.post('/', validate(createTaskSchema), async (req: Request, res: Response,
       lat: number;
       lng: number;
     };
+
+    // Validate coordinates are on land (not in the sea)
+    if (isInSea(lat, lng)) {
+      throw new ValidationError('Location appears to be in the sea. Please pick a valid address on land.');
+    }
 
     // Insert with PostGIS point — must use raw SQL for the geometry column.
     // ST_MakePoint takes (longitude, latitude) — longitude first.

--- a/frontend/src/components/DiscoveryMap.native.tsx
+++ b/frontend/src/components/DiscoveryMap.native.tsx
@@ -1,31 +1,110 @@
-import React from 'react';
-import { StyleSheet } from 'react-native';
-import MapView, { Marker } from 'react-native-maps';
-import { CATEGORY_MARKER_COLORS, DiscoveryMapProps } from './DiscoveryMap.types';
+import React, { useEffect, useRef } from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+import MapView, { Marker, Region } from 'react-native-maps';
+import { brandColors } from '../theme';
+import type { DiscoveryMapProps, DiscoveryMapRegion } from './DiscoveryMap.types';
+
+const BID_MARKER_COLOR = '#66BB6A';
+const DEFAULT_MARKER_COLOR = brandColors.primary;
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const logoAsset = require('../../assets/logo-without-text.png');
 
 export default function DiscoveryMap({
   tasks,
+  centerLat,
+  centerLng,
+  fixerLat,
+  fixerLng,
+  bidTaskIds,
   mapRegion,
   onSelectTask,
   onClearSelection,
   onRegionChangeComplete,
 }: DiscoveryMapProps) {
+  const mapRef = useRef<MapView | null>(null);
+  const prevCenter = useRef({ lat: centerLat, lng: centerLng });
+
+  // Pan to new center when it changes (e.g. search)
+  useEffect(() => {
+    if (
+      mapRef.current &&
+      (prevCenter.current.lat !== centerLat || prevCenter.current.lng !== centerLng)
+    ) {
+      mapRef.current.animateToRegion(
+        {
+          latitude: centerLat,
+          longitude: centerLng,
+          latitudeDelta: mapRegion.latitudeDelta,
+          longitudeDelta: mapRegion.longitudeDelta,
+        },
+        300,
+      );
+      prevCenter.current = { lat: centerLat, lng: centerLng };
+    }
+  }, [centerLat, centerLng, mapRegion.latitudeDelta, mapRegion.longitudeDelta]);
+
+  const handleRegionChange = (region: Region) => {
+    const r: DiscoveryMapRegion = {
+      latitude: region.latitude,
+      longitude: region.longitude,
+      latitudeDelta: region.latitudeDelta,
+      longitudeDelta: region.longitudeDelta,
+    };
+    onRegionChangeComplete(r);
+  };
+
   return (
     <MapView
+      ref={mapRef}
       style={StyleSheet.absoluteFillObject}
-      initialRegion={mapRegion}
-      region={mapRegion}
+      initialRegion={{
+        latitude: centerLat,
+        longitude: centerLng,
+        latitudeDelta: mapRegion.latitudeDelta,
+        longitudeDelta: mapRegion.longitudeDelta,
+      }}
       onPress={onClearSelection}
-      onRegionChangeComplete={onRegionChangeComplete}
+      onRegionChangeComplete={handleRegionChange}
     >
-      {tasks.map((task) => (
+      {tasks.map((task) => {
+        const hasBid = bidTaskIds?.has(task.id);
+        return (
+          <Marker
+            key={task.id}
+            coordinate={{ latitude: task.lat, longitude: task.lng }}
+            pinColor={hasBid ? BID_MARKER_COLOR : DEFAULT_MARKER_COLOR}
+            onPress={() => onSelectTask(task.id)}
+          />
+        );
+      })}
+
+      {/* Fixer's own location */}
+      {fixerLat != null && fixerLng != null && (
         <Marker
-          key={task.id}
-          coordinate={{ latitude: task.lat, longitude: task.lng }}
-          pinColor={CATEGORY_MARKER_COLORS[task.category]}
-          onPress={() => onSelectTask(task.id)}
-        />
-      ))}
+          coordinate={{ latitude: fixerLat, longitude: fixerLng }}
+          anchor={{ x: 0.5, y: 0.5 }}
+          tracksViewChanges={false}
+        >
+          <View style={styles.fixerMarker}>
+            <Image source={logoAsset} style={styles.fixerMarkerImage} />
+          </View>
+        </Marker>
+      )}
     </MapView>
   );
 }
+
+const styles = StyleSheet.create({
+  fixerMarker: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  fixerMarkerImage: {
+    width: 30,
+    height: 30,
+    resizeMode: 'contain',
+  },
+});

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -60,6 +60,34 @@ type ApiTask = {
   bid_count: number;
 };
 
+// --- Israel coastline approximation (minimum longitude per latitude) ---
+// Used to prevent privacy offsets from landing in the sea.
+const COASTLINE: [number, number][] = [
+  [29.50, 34.94], // Eilat
+  [31.20, 34.56], // South (Ashkelon)
+  [31.70, 34.62], // Ashdod
+  [32.00, 34.75], // Tel Aviv south
+  [32.10, 34.77], // Tel Aviv / Herzliya
+  [32.30, 34.84], // Netanya
+  [32.50, 34.87], // Hadera
+  [32.80, 34.96], // Haifa
+  [33.10, 35.08], // Nahariya
+];
+
+function minLngForLat(lat: number): number {
+  if (lat <= COASTLINE[0][0]) return COASTLINE[0][1];
+  if (lat >= COASTLINE[COASTLINE.length - 1][0]) return COASTLINE[COASTLINE.length - 1][1];
+  for (let i = 0; i < COASTLINE.length - 1; i++) {
+    const [lat0, lng0] = COASTLINE[i];
+    const [lat1, lng1] = COASTLINE[i + 1];
+    if (lat >= lat0 && lat <= lat1) {
+      const t = (lat - lat0) / (lat1 - lat0);
+      return lng0 + t * (lng1 - lng0);
+    }
+  }
+  return COASTLINE[0][1];
+}
+
 // --- Privacy offset: shift task markers by up to 50 m so the exact address is hidden ---
 // Uses a simple hash of the task ID to produce a deterministic angle + distance.
 const OFFSET_MAX_METERS = 50;
@@ -75,7 +103,6 @@ function hashCode(s: string): number {
 
 function applyPrivacyOffset(lat: number, lng: number, taskId: string): { lat: number; lng: number } {
   const h = hashCode(taskId);
-  // Derive angle (0–2π) and distance (10–50 m) from the hash
   const angle = ((h & 0xffff) / 0xffff) * Math.PI * 2;
   const distance = 10 + ((h >>> 16) / 0xffff) * (OFFSET_MAX_METERS - 10);
 
@@ -83,7 +110,14 @@ function applyPrivacyOffset(lat: number, lng: number, taskId: string): { lat: nu
   const dLat = (Math.sin(angle) * distance) / METERS_PER_DEG_LAT;
   const dLng = (Math.cos(angle) * distance) / metersPerDegLng;
 
-  return { lat: lat + dLat, lng: lng + dLng };
+  let newLng = lng + dLng;
+  const coastMin = minLngForLat(lat + dLat);
+  // If offset pushed the point into the sea, clamp to coastline + small buffer
+  if (newLng < coastMin) {
+    newLng = coastMin + 0.001; // ~100m inland from coastline
+  }
+
+  return { lat: lat + dLat, lng: newLng };
 }
 
 

--- a/frontend/src/screens/DiscoveryFeedScreen.tsx
+++ b/frontend/src/screens/DiscoveryFeedScreen.tsx
@@ -56,6 +56,13 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
   const [fixerGps, setFixerGps] = useState<{ lat: number; lng: number } | null>(null);
   const [bidTaskIds, setBidTaskIds] = useState<Set<string>>(new Set());
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  // Fetch current user ID once on mount to filter out own tasks
+  useEffect(() => {
+    api.get('/api/users/me')
+      .then((res) => setCurrentUserId(res.data.user?.id ?? null))
+      .catch(() => { /* ignore */ });
+  }, []);
   const autocompleteRef = useRef<google.maps.places.AutocompleteService | null>(null);
   const placesServiceRef = useRef<google.maps.places.PlacesService | null>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -174,10 +181,7 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
   useFocusEffect(
     useCallback(() => {
       evaluatePermissionState();
-      // Fetch current user ID to hide own tasks + fixer's bids for green markers
-      api.get('/api/users/me')
-        .then((res) => setCurrentUserId(res.data.user?.id ?? null))
-        .catch(() => { /* ignore */ });
+      // Fetch fixer's bids for green markers
       api.get('/api/users/me/bids', { params: { limit: 50 } })
         .then((res) => {
           const ids = new Set<string>(


### PR DESCRIPTION
## Summary
Closes #59

- **Sea prevention**: Backend rejects task creation if coordinates fall in the Mediterranean; frontend privacy offset clamps markers to stay on land (Israel coastline approximation table)
- **Seed fix**: Herzliya Pituach lon 34.788 → 34.805 (marker was in the sea)
- **Own-task filtering**: Moved user ID fetch to useEffect([]) so it's ready before tasks load
- **Native map parity**: already merged in #79

## Test plan
- [ ] Reseed DB — Herzliya task on land
- [ ] Click in the sea during task creation → validation error
- [ ] Coastal task markers stay on land after privacy offset
- [ ] Fixer doesn't see own tasks on map

