### PR TITLE
feat(no-phase): Accessibility Widget — WCAG 2.0 AA

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -7,6 +7,8 @@ import { navigationTheme, theme } from './src/theme';
 import AppNavigator from './src/navigation/AppNavigator';
 import AuthScreen from './src/screens/AuthScreen';
 import { NotificationProvider } from './src/context/NotificationContext';
+import { AccessibilityProvider } from './src/context/AccessibilityContext';
+import AccessibilityWidget from './src/components/AccessibilityWidget';
 
 function RootContent() {
   const authState = useAuthBootstrap();
@@ -39,7 +41,10 @@ export default function App() {
   return (
     <SafeAreaProvider>
       <PaperProvider theme={theme}>
-        <RootContent />
+        <AccessibilityProvider>
+          <RootContent />
+          <AccessibilityWidget />
+        </AccessibilityProvider>
         <StatusBar style="light" />
       </PaperProvider>
     </SafeAreaProvider>

--- a/frontend/src/components/AccessibilityWidget.tsx
+++ b/frontend/src/components/AccessibilityWidget.tsx
@@ -1,0 +1,355 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+  Platform,
+  useWindowDimensions,
+} from 'react-native';
+import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { brandColors, spacing, radii, shadows, typography } from '../theme';
+import { useAccessibility, AccessibilityState } from '../context/AccessibilityContext';
+
+/* ------------------------------------------------------------------ */
+/*  Menu item definition                                              */
+/* ------------------------------------------------------------------ */
+interface MenuItem {
+  key: string;
+  label: string;
+  labelHe: string;
+  icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  type: 'toggle' | 'action';
+  stateKey?: keyof Omit<AccessibilityState, 'fontScale'>;
+  action?: 'increase' | 'decrease' | 'reset';
+  webOnly?: boolean;
+}
+
+const MENU_ITEMS: MenuItem[] = [
+  { key: 'increase',         label: 'Increase Font',      labelHe: 'הגדלת גופן',          icon: 'format-font-size-increase',  type: 'action', action: 'increase' },
+  { key: 'decrease',         label: 'Decrease Font',      labelHe: 'הקטנת גופן',          icon: 'format-font-size-decrease',  type: 'action', action: 'decrease' },
+  { key: 'highContrast',     label: 'High Contrast',      labelHe: 'ניגודיות גבוהה',       icon: 'contrast-circle',            type: 'toggle', stateKey: 'highContrast' },
+  { key: 'monochrome',       label: 'Monochrome',         labelHe: 'מונוכרום',             icon: 'palette-outline',            type: 'toggle', stateKey: 'monochrome' },
+  { key: 'readableFont',     label: 'Readable Font',      labelHe: 'גופן קריא',            icon: 'format-letter-case',         type: 'toggle', stateKey: 'readableFont' },
+  { key: 'highlightLinks',   label: 'Highlight Links',    labelHe: 'הדגשת קישורים',        icon: 'link-variant',               type: 'toggle', stateKey: 'highlightLinks' },
+  { key: 'highlightHeadings',label: 'Highlight Headings', labelHe: 'הדגשת כותרות',         icon: 'format-header-pound',        type: 'toggle', stateKey: 'highlightHeadings' },
+  { key: 'textSpacing',      label: 'Text Spacing',       labelHe: 'מרווח טקסט',           icon: 'format-line-spacing',        type: 'toggle', stateKey: 'textSpacing' },
+  { key: 'largeCursor',      label: 'Large Cursor',       labelHe: 'סמן גדול',             icon: 'cursor-default-outline',     type: 'toggle', stateKey: 'largeCursor', webOnly: true },
+  { key: 'stopAnimations',   label: 'Stop Animations',    labelHe: 'עצירת אנימציות',       icon: 'motion-pause-outline',       type: 'toggle', stateKey: 'stopAnimations' },
+  { key: 'keyboardNav',      label: 'Keyboard Navigation',labelHe: 'ניווט מקלדת',          icon: 'keyboard-outline',           type: 'toggle', stateKey: 'keyboardNav' },
+  { key: 'reset',            label: 'Reset All',          labelHe: 'איפוס הכל',            icon: 'restart',                    type: 'action', action: 'reset' },
+];
+
+/* ------------------------------------------------------------------ */
+/*  Widget                                                            */
+/* ------------------------------------------------------------------ */
+export default function AccessibilityWidget() {
+  const [open, setOpen] = useState(false);
+  const { state, increaseFontSize, decreaseFontSize, toggle, resetAll } = useAccessibility();
+  const { width } = useWindowDimensions();
+  const isDesktop = width >= 768;
+
+  // Filter web-only items on native
+  const items = Platform.OS === 'web'
+    ? MENU_ITEMS
+    : MENU_ITEMS.filter(i => !i.webOnly);
+
+  const handlePress = (item: MenuItem) => {
+    if (item.type === 'toggle' && item.stateKey) {
+      toggle(item.stateKey);
+    } else if (item.action === 'increase') {
+      increaseFontSize();
+    } else if (item.action === 'decrease') {
+      decreaseFontSize();
+    } else if (item.action === 'reset') {
+      resetAll();
+    }
+  };
+
+  const isActive = (item: MenuItem): boolean => {
+    if (item.stateKey) return !!state[item.stateKey];
+    return false;
+  };
+
+  // The widget itself must not be affected by a11y CSS overrides,
+  // so we tag its root with data-a11y-widget.
+  const widgetProps = Platform.OS === 'web'
+    ? { 'data-a11y-widget': 'true' } as Record<string, string>
+    : {};
+
+  return (
+    <View style={styles.container} pointerEvents="box-none" {...widgetProps}>
+      {/* Overlay to close when tapping outside */}
+      {open && (
+        <TouchableOpacity
+          style={styles.overlay}
+          activeOpacity={1}
+          onPress={() => setOpen(false)}
+          accessibilityLabel="Close accessibility menu"
+        />
+      )}
+
+      {/* Panel */}
+      {open && (
+        <View style={[styles.panel, isDesktop && styles.panelDesktop]}>
+          <View style={styles.panelHeader}>
+            <MaterialCommunityIcons name="human" size={22} color={brandColors.white} />
+            <Text style={styles.panelTitle}>נגישות / Accessibility</Text>
+            {state.fontScale !== 1 && (
+              <Text style={styles.fontScaleBadge}>{Math.round(state.fontScale * 100)}%</Text>
+            )}
+          </View>
+
+          <ScrollView
+            style={styles.scrollArea}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+          >
+            {items.map(item => {
+              const active = isActive(item);
+              const isReset = item.action === 'reset';
+              return (
+                <TouchableOpacity
+                  key={item.key}
+                  style={[
+                    styles.menuItem,
+                    active && styles.menuItemActive,
+                    isReset && styles.menuItemReset,
+                  ]}
+                  onPress={() => handlePress(item)}
+                  activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel={item.label}
+                  accessibilityState={item.type === 'toggle' ? { selected: active } : undefined}
+                >
+                  <View style={[
+                    styles.iconCircle,
+                    active && styles.iconCircleActive,
+                    isReset && styles.iconCircleReset,
+                  ]}>
+                    <MaterialCommunityIcons
+                      name={item.icon}
+                      size={20}
+                      color={isReset ? brandColors.white : active ? brandColors.white : brandColors.primary}
+                    />
+                  </View>
+                  <View style={styles.labelColumn}>
+                    <Text style={[
+                      styles.menuLabel,
+                      active && styles.menuLabelActive,
+                      isReset && styles.menuLabelReset,
+                    ]}>
+                      {item.label}
+                    </Text>
+                    <Text style={[
+                      styles.menuLabelHe,
+                      active && styles.menuLabelActive,
+                    ]}>
+                      {item.labelHe}
+                    </Text>
+                  </View>
+                  {item.type === 'toggle' && (
+                    <View style={[styles.toggleDot, active && styles.toggleDotActive]} />
+                  )}
+                </TouchableOpacity>
+              );
+            })}
+          </ScrollView>
+
+          {/* Accessibility statement — required by Israeli law */}
+          <View style={styles.statementBar}>
+            <MaterialCommunityIcons name="shield-check" size={14} color={brandColors.textMuted} />
+            <Text style={styles.statementText}>WCAG 2.0 AA · ת"י 5568</Text>
+          </View>
+        </View>
+      )}
+
+      {/* Floating Action Button */}
+      <TouchableOpacity
+        style={[styles.fab, open && styles.fabOpen]}
+        onPress={() => setOpen(prev => !prev)}
+        activeOpacity={0.85}
+        accessibilityRole="button"
+        accessibilityLabel={open ? 'Close accessibility menu' : 'Open accessibility menu'}
+      >
+        <MaterialCommunityIcons
+          name={open ? 'close' : 'human'}
+          size={28}
+          color={brandColors.white}
+        />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Styles                                                            */
+/* ------------------------------------------------------------------ */
+const FAB_SIZE = 56;
+const PANEL_MAX_HEIGHT = 480;
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    zIndex: 9999,
+  },
+
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'transparent',
+    zIndex: 1,
+  },
+
+  /* -- FAB -- */
+  fab: {
+    position: 'absolute',
+    bottom: Platform.OS === 'web' ? 24 : 90,
+    left: 20,
+    width: FAB_SIZE,
+    height: FAB_SIZE,
+    borderRadius: FAB_SIZE / 2,
+    backgroundColor: brandColors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.lg,
+    zIndex: 3,
+  },
+  fabOpen: {
+    backgroundColor: brandColors.primaryDark,
+  },
+
+  /* -- Panel -- */
+  panel: {
+    position: 'absolute',
+    bottom: Platform.OS === 'web' ? 90 : 156,
+    left: 20,
+    width: 310,
+    maxHeight: PANEL_MAX_HEIGHT,
+    backgroundColor: brandColors.surface,
+    borderRadius: radii.lg,
+    overflow: 'hidden',
+    ...shadows.lg,
+    zIndex: 2,
+  },
+  panelDesktop: {
+    width: 350,
+    maxHeight: 540,
+  },
+
+  panelHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: brandColors.primary,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    gap: spacing.sm,
+  },
+  panelTitle: {
+    ...typography.h3,
+    color: brandColors.white,
+    flex: 1,
+  },
+  fontScaleBadge: {
+    ...typography.caption,
+    color: brandColors.secondary,
+    backgroundColor: 'rgba(255,255,255,0.15)',
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radii.xs,
+    overflow: 'hidden',
+  },
+
+  /* -- Scroll -- */
+  scrollArea: {
+    flexGrow: 1,
+    flexShrink: 1,
+  },
+  scrollContent: {
+    paddingVertical: spacing.xs,
+  },
+
+  /* -- Menu Item -- */
+  menuItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+    paddingVertical: 10,
+    gap: spacing.md,
+  },
+  menuItemActive: {
+    backgroundColor: brandColors.infoSoft,
+  },
+  menuItemReset: {
+    borderTopWidth: 1,
+    borderTopColor: brandColors.outlineLight,
+    marginTop: spacing.xs,
+  },
+
+  iconCircle: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: brandColors.neutralSoft,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  iconCircleActive: {
+    backgroundColor: brandColors.primary,
+  },
+  iconCircleReset: {
+    backgroundColor: brandColors.danger,
+  },
+
+  labelColumn: {
+    flex: 1,
+  },
+  menuLabel: {
+    ...typography.bodySm,
+    color: brandColors.textPrimary,
+  },
+  menuLabelHe: {
+    ...typography.caption,
+    color: brandColors.textMuted,
+  },
+  menuLabelActive: {
+    color: brandColors.primary,
+    fontWeight: '700',
+  },
+  menuLabelReset: {
+    color: brandColors.danger,
+  },
+
+  toggleDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    borderWidth: 2,
+    borderColor: brandColors.outline,
+    backgroundColor: 'transparent',
+  },
+  toggleDotActive: {
+    borderColor: brandColors.success,
+    backgroundColor: brandColors.success,
+  },
+
+  /* -- Statement -- */
+  statementBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    paddingVertical: spacing.sm,
+    borderTopWidth: 1,
+    borderTopColor: brandColors.outlineLight,
+    backgroundColor: brandColors.surfaceAlt,
+  },
+  statementText: {
+    ...typography.caption,
+    color: brandColors.textMuted,
+  },
+});

--- a/frontend/src/context/AccessibilityContext.tsx
+++ b/frontend/src/context/AccessibilityContext.tsx
@@ -1,0 +1,278 @@
+import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import { Platform } from 'react-native';
+
+export interface AccessibilityState {
+  fontScale: number;          // 1 = normal, up to 1.5
+  highContrast: boolean;
+  monochrome: boolean;
+  readableFont: boolean;
+  highlightLinks: boolean;
+  highlightHeadings: boolean;
+  largeCursor: boolean;
+  stopAnimations: boolean;
+  keyboardNav: boolean;
+  textSpacing: boolean;
+}
+
+interface AccessibilityContextValue {
+  state: AccessibilityState;
+  increaseFontSize: () => void;
+  decreaseFontSize: () => void;
+  toggle: (key: keyof Omit<AccessibilityState, 'fontScale'>) => void;
+  resetAll: () => void;
+}
+
+const defaultState: AccessibilityState = {
+  fontScale: 1,
+  highContrast: false,
+  monochrome: false,
+  readableFont: false,
+  highlightLinks: false,
+  highlightHeadings: false,
+  largeCursor: false,
+  stopAnimations: false,
+  keyboardNav: false,
+  textSpacing: false,
+};
+
+const AccessibilityContext = createContext<AccessibilityContextValue>({
+  state: defaultState,
+  increaseFontSize: () => {},
+  decreaseFontSize: () => {},
+  toggle: () => {},
+  resetAll: () => {},
+});
+
+export const useAccessibility = () => useContext(AccessibilityContext);
+
+/* ------------------------------------------------------------------ */
+/*  Web-only: inject a <style> block + toggle CSS classes on <html>   */
+/*                                                                    */
+/*  React Native Web renders <div> with inline styles + ARIA roles,   */
+/*  NOT semantic HTML.  All selectors below account for that.         */
+/* ------------------------------------------------------------------ */
+const STYLE_ID = 'a11y-widget-styles';
+
+function injectWebStyles() {
+  if (Platform.OS !== 'web') return;
+  if (document.getElementById(STYLE_ID)) return;
+
+  const css = `
+    /* ---------- High Contrast ---------- */
+    html.a11y-high-contrast,
+    html.a11y-high-contrast body,
+    html.a11y-high-contrast #root {
+      background-color: #000 !important;
+    }
+    html.a11y-high-contrast #root * {
+      color: #fff !important;
+      border-color: #555 !important;
+      background-color: transparent !important;
+    }
+    html.a11y-high-contrast #root [role="banner"],
+    html.a11y-high-contrast #root [role="navigation"],
+    html.a11y-high-contrast #root [data-testid] {
+      background-color: #111 !important;
+    }
+    html.a11y-high-contrast [role="link"],
+    html.a11y-high-contrast [role="button"],
+    html.a11y-high-contrast a,
+    html.a11y-high-contrast button {
+      color: #ff0 !important;
+    }
+    /* Keep the a11y widget itself visible */
+    html.a11y-high-contrast [data-a11y-widget] *,
+    html.a11y-high-contrast [data-a11y-widget] {
+      all: revert;
+    }
+
+    /* ---------- Monochrome ---------- */
+    html.a11y-monochrome #root {
+      filter: grayscale(100%) !important;
+    }
+
+    /* ---------- Readable Font ---------- */
+    html.a11y-readable-font #root * {
+      font-family: Arial, Helvetica, sans-serif !important;
+    }
+
+    /* ---------- Highlight Links ---------- */
+    html.a11y-highlight-links #root [role="link"],
+    html.a11y-highlight-links #root a {
+      outline: 3px solid #f7cf7a !important;
+      outline-offset: 2px !important;
+      text-decoration: underline !important;
+    }
+
+    /* ---------- Highlight Headings ---------- */
+    html.a11y-highlight-headings #root [role="heading"],
+    html.a11y-highlight-headings #root h1,
+    html.a11y-highlight-headings #root h2,
+    html.a11y-highlight-headings #root h3,
+    html.a11y-highlight-headings #root h4,
+    html.a11y-highlight-headings #root h5,
+    html.a11y-highlight-headings #root h6,
+    html.a11y-highlight-headings #root [data-a11y-heading="true"] {
+      outline: 3px solid #1C3C56 !important;
+      outline-offset: 2px !important;
+      background-color: rgba(28, 60, 86, 0.12) !important;
+    }
+
+    /* ---------- Large Cursor ---------- */
+    html.a11y-large-cursor,
+    html.a11y-large-cursor * {
+      cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='48' height='48'%3E%3Cpath d='M4 4l16 40 6-16 16-6z' fill='%23000' stroke='%23fff' stroke-width='2'/%3E%3C/svg%3E") 4 4, auto !important;
+    }
+
+    /* ---------- Stop Animations ---------- */
+    html.a11y-stop-animations *,
+    html.a11y-stop-animations *::before,
+    html.a11y-stop-animations *::after {
+      animation-duration: 0s !important;
+      animation-delay: 0s !important;
+      transition-duration: 0s !important;
+      transition-delay: 0s !important;
+    }
+
+    /* ---------- Keyboard Navigation ---------- */
+    html.a11y-keyboard-nav *:focus {
+      outline: 3px solid #F1B545 !important;
+      outline-offset: 2px !important;
+    }
+
+    /* ---------- Text Spacing ---------- */
+    html.a11y-text-spacing #root * {
+      letter-spacing: 0.12em !important;
+      word-spacing: 0.16em !important;
+      line-height: 1.8 !important;
+    }
+  `;
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = css;
+  document.head.appendChild(style);
+}
+
+const classMap: Record<string, string> = {
+  highContrast: 'a11y-high-contrast',
+  monochrome: 'a11y-monochrome',
+  readableFont: 'a11y-readable-font',
+  highlightLinks: 'a11y-highlight-links',
+  highlightHeadings: 'a11y-highlight-headings',
+  largeCursor: 'a11y-large-cursor',
+  stopAnimations: 'a11y-stop-animations',
+  keyboardNav: 'a11y-keyboard-nav',
+  textSpacing: 'a11y-text-spacing',
+};
+
+/**
+ * Scan the DOM for elements that visually look like headings
+ * (large font-size + bold weight) and tag them so CSS can target them.
+ * React Native Web renders everything as <div> with inline styles,
+ * so semantic selectors (h1-h6, [role="heading"]) don't work.
+ */
+function tagVisualHeadings(enabled: boolean) {
+  if (Platform.OS !== 'web') return;
+  const root = document.getElementById('root');
+  if (!root) return;
+
+  // Remove old tags first
+  root.querySelectorAll('[data-a11y-heading]').forEach(el => {
+    el.removeAttribute('data-a11y-heading');
+  });
+
+  if (!enabled) return;
+
+  // Walk all elements inside #root and check computed styles
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT);
+  let node: Node | null = walker.nextNode();
+  while (node) {
+    const el = node as HTMLElement;
+    // Skip the a11y widget itself
+    if (el.closest('[data-a11y-widget]')) {
+      node = walker.nextNode();
+      continue;
+    }
+    const cs = window.getComputedStyle(el);
+    const fontSize = parseFloat(cs.fontSize);
+    const fontWeight = parseInt(cs.fontWeight, 10) || 400;
+    // Heading heuristic: font >= 17px AND weight >= 600
+    if (fontSize >= 17 && fontWeight >= 600 && el.textContent?.trim()) {
+      // Only tag leaf-level text containers (no children that are also tagged)
+      const hasText = Array.from(el.childNodes).some(
+        c => c.nodeType === Node.TEXT_NODE && c.textContent?.trim()
+      );
+      if (hasText) {
+        el.setAttribute('data-a11y-heading', 'true');
+      }
+    }
+    node = walker.nextNode();
+  }
+}
+
+function syncWebClasses(state: AccessibilityState) {
+  if (Platform.OS !== 'web') return;
+  const html = document.documentElement;
+  for (const [key, cls] of Object.entries(classMap)) {
+    const val = state[key as keyof AccessibilityState];
+    if (val) html.classList.add(cls);
+    else html.classList.remove(cls);
+  }
+
+  // Font scale — use CSS zoom on #root (works with RNW's px-based styles)
+  const root = document.getElementById('root');
+  if (root) {
+    if (state.fontScale !== 1) {
+      root.style.zoom = `${state.fontScale}`;
+    } else {
+      root.style.zoom = '';
+    }
+  }
+
+  // Tag visual headings via DOM scan
+  tagVisualHeadings(state.highlightHeadings);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Provider                                                          */
+/* ------------------------------------------------------------------ */
+export function AccessibilityProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AccessibilityState>(defaultState);
+
+  useEffect(() => {
+    injectWebStyles();
+  }, []);
+
+  useEffect(() => {
+    syncWebClasses(state);
+  }, [state]);
+
+  const increaseFontSize = useCallback(() => {
+    setState(prev => ({
+      ...prev,
+      fontScale: Math.min(prev.fontScale + 0.1, 1.5),
+    }));
+  }, []);
+
+  const decreaseFontSize = useCallback(() => {
+    setState(prev => ({
+      ...prev,
+      fontScale: Math.max(prev.fontScale - 0.1, 0.8),
+    }));
+  }, []);
+
+  const toggle = useCallback((key: keyof Omit<AccessibilityState, 'fontScale'>) => {
+    setState(prev => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const resetAll = useCallback(() => {
+    setState(defaultState);
+  }, []);
+
+  return (
+    <AccessibilityContext.Provider value={{ state, increaseFontSize, decreaseFontSize, toggle, resetAll }}>
+      {children}
+    </AccessibilityContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a floating accessibility widget (bottom-left FAB) compliant with Israeli standard ת"י 5568 and WCAG 2.0 AA
- Features: font scaling (zoom), high contrast, monochrome, readable font, highlight links/headings, large cursor, stop animations, keyboard navigation, text spacing, and full reset
- Uses DOM scanning to detect RNW-rendered headings (since RNW doesn't emit semantic HTML) and CSS zoom for font scaling

## Test plan
- [ ] Verify FAB appears on all screens (web + native)
- [ ] Toggle each feature and confirm visual change on the page
- [ ] Test "Highlight Headings" — headings should get blue outline
- [ ] Test font increase/decrease — entire page should zoom
- [ ] Test "Reset All" — everything returns to default
- [ ] Verify widget panel doesn't block underlying page interaction when closed

