### PR TITLE
feat(no-phase): Celebration Effects + Distance Calculator

### DIFF
--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -275,6 +275,13 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
 
     if (!task) throw new NotFoundError('Task not found');
 
+    // Extract lat/lng from PostGIS coordinates
+    const coordsRow = await prisma.$queryRaw<{ lat: number; lng: number }[]>`
+      SELECT ST_Y(coordinates::geometry) AS lat, ST_X(coordinates::geometry) AS lng
+      FROM "Task" WHERE id = ${req.params.id}
+    `;
+    const coords = coordsRow[0] ?? { lat: null, lng: null };
+
     const isRequester = req.user.id === task.requester_id;
     const isFixer = req.user.id === task.assigned_fixer_id;
 
@@ -284,7 +291,7 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
       ? task
       : taskWithoutAddress;
 
-    res.json({ task: { ...response, bid_count: bidCount } });
+    res.json({ task: { ...response, bid_count: bidCount, lat: coords.lat, lng: coords.lng } });
   } catch (err) {
     next(err);
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-confetti-cannon": "^1.5.2",
     "react-native-maps": "1.20.1",
     "react-native-paper": "^5.15.0",
     "react-native-safe-area-context": "~5.6.0",

--- a/frontend/src/components/CelebrationOverlay.tsx
+++ b/frontend/src/components/CelebrationOverlay.tsx
@@ -1,0 +1,44 @@
+import React, { useRef, useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import ConfettiCannon from 'react-native-confetti-cannon';
+
+interface Props {
+  /** Set to true to trigger the celebration. Resets automatically. */
+  fire: boolean;
+  onComplete?: () => void;
+}
+
+export default function CelebrationOverlay({ fire, onComplete }: Props) {
+  const confettiRef = useRef<ConfettiCannon>(null);
+
+  useEffect(() => {
+    if (fire && confettiRef.current) {
+      confettiRef.current.start();
+    }
+  }, [fire]);
+
+  if (!fire) return null;
+
+  return (
+    <View style={styles.container} pointerEvents="none">
+      <ConfettiCannon
+        ref={confettiRef}
+        count={120}
+        origin={{ x: -10, y: 0 }}
+        autoStart
+        fadeOut
+        fallSpeed={3000}
+        explosionSpeed={350}
+        colors={['#F1B545', '#1C3C56', '#2A5478', '#F7CF7A', '#517A58', '#D49A2A']}
+        onAnimationEnd={onComplete}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 9998,
+  },
+});

--- a/frontend/src/screens/TaskDetails.tsx
+++ b/frontend/src/screens/TaskDetails.tsx
@@ -10,6 +10,7 @@ import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useFocusEffect } from '@react-navigation/native';
 import api from '../api/axiosInstance';
 import LoadingScreen from '../components/LoadingScreen';
+import CelebrationOverlay from '../components/CelebrationOverlay';
 import { FButton, FCard, FInput, FSectionHeader } from '../components/ui';
 import { brandColors, spacing, radii, typography } from '../theme';
 
@@ -91,6 +92,7 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
   const [editPrice, setEditPrice] = useState('');
   const [editLocation, setEditLocation] = useState('');
   const [editAddress, setEditAddress] = useState('');
+  const [showCelebration, setShowCelebration] = useState(false);
 
   const showReviewsForFixer = async (fixerId: string) => {
     try {
@@ -126,6 +128,7 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
   const acceptBid = async (bidId: string) => {
     try {
       await api.put(`/api/bids/${bidId}/accept`);
+      setShowCelebration(true);
       fetchData();
     } catch {
       Alert.alert('Error', 'Failed to accept bid.');
@@ -176,6 +179,7 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
   const confirmPayment = async () => {
     try {
       await api.put(`/api/tasks/${taskId}/confirm-payment`);
+      setShowCelebration(true);
       fetchData();
     } catch {
       Alert.alert('Error', 'Failed to confirm payment.');
@@ -259,6 +263,8 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
       contentContainerStyle={styles.container}
       showsVerticalScrollIndicator={false}
     >
+      <CelebrationOverlay fire={showCelebration} onComplete={() => setShowCelebration(false)} />
+
       {/* Status Banner + Edit button */}
       <View style={styles.statusRow}>
         <View style={[styles.statusBanner, { backgroundColor: banner.bg }]}>

--- a/frontend/src/screens/TaskDetailsFixer.tsx
+++ b/frontend/src/screens/TaskDetailsFixer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Alert,
   Dimensions,
@@ -19,12 +19,31 @@ import {
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useFocusEffect } from '@react-navigation/native';
+import * as Location from 'expo-location';
 import api from '../api/axiosInstance';
 import StatusBadge from '../components/StatusBadge';
 import LoadingScreen from '../components/LoadingScreen';
 import EmptyState from '../components/EmptyState';
 import { FButton, FInput } from '../components/ui';
 import { brandColors, spacing, radii, shadows, typography } from '../theme';
+
+/* ------------------------------------------------------------------ */
+/*  Haversine distance (km) + rough drive-time estimate               */
+/* ------------------------------------------------------------------ */
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function estimateDriveMinutes(km: number): number {
+  // ~40 km/h average city driving in Israel
+  return Math.round((km / 40) * 60);
+}
 
 type TaskStatus = 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
 
@@ -48,6 +67,8 @@ interface Task {
   requester_id: string;
   requester?: TaskRequester;
   bid_count?: number;
+  lat?: number | null;
+  lng?: number | null;
 }
 
 interface ExistingBid {
@@ -92,6 +113,33 @@ export default function TaskDetailsFixer({ route }: Props) {
   const [bidError, setBidError] = useState<string | null>(null);
 
   const [carouselIndex, setCarouselIndex] = useState(0);
+  const [userCoords, setUserCoords] = useState<{ lat: number; lng: number } | null>(null);
+
+  // Get user's location for distance calculation
+  useEffect(() => {
+    (async () => {
+      try {
+        if (Platform.OS === 'web') {
+          const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
+            navigator.geolocation.getCurrentPosition(resolve, reject, {
+              enableHighAccuracy: false,
+              timeout: 8000,
+              maximumAge: 120_000,
+            });
+          });
+          setUserCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+        } else {
+          const { status } = await Location.requestForegroundPermissionsAsync();
+          if (status === 'granted') {
+            const pos = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+            setUserCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+          }
+        }
+      } catch {
+        // Location unavailable — distance card simply won't show
+      }
+    })();
+  }, []);
 
   const fetchData = useCallback(async () => {
     if (!taskId) return;
@@ -314,6 +362,28 @@ export default function TaskDetailsFixer({ route }: Props) {
             label="Bids"
             value={`${bidCount} ${bidCount === 1 ? 'bid' : 'bids'} submitted`}
           />
+
+          {/* Distance & travel time */}
+          {userCoords && task.lat != null && task.lng != null && (() => {
+            const km = haversineKm(userCoords.lat, userCoords.lng, task.lat, task.lng);
+            const mins = estimateDriveMinutes(km);
+            return (
+              <View style={styles.distanceCard}>
+                <View style={styles.distanceIconShell}>
+                  <MaterialCommunityIcons name="map-marker-distance" size={20} color={brandColors.primary} />
+                </View>
+                <View style={styles.distanceInfo}>
+                  <Text style={[typography.h3, { color: brandColors.textPrimary }]}>
+                    {km < 1 ? `${Math.round(km * 1000)}m` : `${km.toFixed(1)} km`} away
+                  </Text>
+                  <Text style={[typography.bodySm, { color: brandColors.textMuted }]}>
+                    ~{mins < 1 ? '1' : mins} min drive
+                  </Text>
+                </View>
+                <MaterialCommunityIcons name="car-outline" size={20} color={brandColors.textMuted} />
+              </View>
+            );
+          })()}
 
           <Divider style={styles.divider} />
 
@@ -583,6 +653,27 @@ const styles = StyleSheet.create({
     ...shadows.sm,
   },
   requesterInfo: {
+    flex: 1,
+    gap: 2,
+  },
+
+  distanceCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    padding: spacing.lg,
+    borderRadius: radii.lg,
+    backgroundColor: brandColors.infoSoft,
+  },
+  distanceIconShell: {
+    width: 38,
+    height: 38,
+    borderRadius: 19,
+    backgroundColor: brandColors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  distanceInfo: {
     flex: 1,
     gap: 2,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -180,6 +180,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-confetti-cannon": "^1.5.2",
         "react-native-maps": "1.20.1",
         "react-native-paper": "^5.15.0",
         "react-native-safe-area-context": "~5.6.0",
@@ -12373,6 +12374,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-native-confetti-cannon": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-confetti-cannon/-/react-native-confetti-cannon-1.5.2.tgz",
+      "integrity": "sha512-IZuWjlW7QsdxEGNnvpD6W+7iKCCQhnd5BvuNvMtirU7Nxm8WS2N6LPGMBz1ZYDuusG+GRZkoXXTNCdoAAGpCTg==",
+      "license": "MIT"
     },
     "node_modules/react-native-is-edge-to-edge": {
       "version": "1.3.1",


### PR DESCRIPTION
## Summary
- Confetti celebration effect when a bid is accepted (requester side)
- Confetti celebration effect when payment is confirmed (requester side)
- Distance & estimated drive time card on fixer's task detail screen (uses haversine + user GPS)
- Backend: GET /api/tasks/:id now returns `lat`/`lng` via PostGIS coordinate extraction

## Test plan
- [ ] Accept a bid → confetti should fire
- [ ] Confirm payment on completed task → confetti should fire
- [ ] Open a task as fixer → distance card shows km + estimated drive time
- [ ] Distance card hidden if location permission denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)