### PR TITLE
feat(no-phase): real-time directions + global fixer celebration

### DIFF
--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -297,6 +297,66 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
   }
 });
 
+// GET /api/tasks/:id/directions?originLat=...&originLng=... — driving directions via Google
+router.get('/:id/directions', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { originLat, originLng } = req.query;
+    if (!originLat || !originLng) throw new ValidationError('originLat and originLng are required');
+
+    const coordsRow = await prisma.$queryRaw<{ lat: number; lng: number }[]>`
+      SELECT ST_Y(coordinates::geometry) AS lat, ST_X(coordinates::geometry) AS lng
+      FROM "Task" WHERE id = ${req.params.id}
+    `;
+    const dest = coordsRow[0];
+    if (!dest) throw new NotFoundError('Task not found');
+
+    const apiKey = process.env.GOOGLE_MAPS_API_KEY || '';
+    if (!apiKey) {
+      res.json({ directions: null });
+      return;
+    }
+
+    const url =
+      `https://maps.googleapis.com/maps/api/directions/json` +
+      `?origin=${originLat},${originLng}` +
+      `&destination=${dest.lat},${dest.lng}` +
+      `&mode=driving` +
+      `&departure_time=now` +
+      `&language=he` +
+      `&key=${apiKey}`;
+
+    const gRes = await fetch(url);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const data: any = await gRes.json();
+
+    if (data.status !== 'OK' || !data.routes?.length) {
+      res.json({ directions: null });
+      return;
+    }
+
+    const leg = data.routes[0].legs[0];
+
+    // Google returns English units even with language=he — localise to Hebrew
+    const toHe = (text: string) =>
+      text
+        .replace(/\bkm\b/g, 'ק״מ')
+        .replace(/\bm\b/g, 'מ׳')
+        .replace(/\bmins?\b/g, 'דקות')
+        .replace(/\bhours?\b/g, 'שעות')
+        .replace(/\bdays?\b/g, 'ימים');
+
+    res.json({
+      directions: {
+        distanceText: toHe(leg.distance.text),
+        durationText: toHe(leg.duration.text),
+        durationInTraffic: leg.duration_in_traffic?.text ? toHe(leg.duration_in_traffic.text) : null,
+      },
+    });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // PUT /api/tasks/:id — edit an OPEN task
 router.put('/:id', validate(updateTaskSchema), async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -9,6 +9,7 @@ import AuthScreen from './src/screens/AuthScreen';
 import { NotificationProvider } from './src/context/NotificationContext';
 import { AccessibilityProvider } from './src/context/AccessibilityContext';
 import AccessibilityWidget from './src/components/AccessibilityWidget';
+import GlobalCelebration from './src/components/GlobalCelebration';
 
 function RootContent() {
   const authState = useAuthBootstrap();
@@ -33,6 +34,7 @@ function RootContent() {
       <NavigationContainer theme={navigationTheme}>
         <AppNavigator />
       </NavigationContainer>
+      <GlobalCelebration />
     </NotificationProvider>
   );
 }

--- a/frontend/src/components/GlobalCelebration.tsx
+++ b/frontend/src/components/GlobalCelebration.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Platform } from 'react-native';
+import { useNotificationContext } from '../context/NotificationContext';
+import CelebrationOverlay from './CelebrationOverlay';
+
+/**
+ * Global celebration that fires a confetti overlay whenever the fixer
+ * receives a BID_ACCEPTED notification, regardless of which screen they
+ * are on. Persists "seen" notification IDs in localStorage (web) so the
+ * effect does not re-fire on refresh, but WILL fire on the next login
+ * for any BID_ACCEPTED notifications that arrived while the user was
+ * logged out.
+ */
+
+const STORAGE_KEY = 'fixit:celebrated_bid_ids';
+
+function loadSeenIds(): Set<string> {
+  if (Platform.OS !== 'web') return new Set();
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw) as string[];
+    return new Set(Array.isArray(arr) ? arr : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveSeenIds(ids: Set<string>) {
+  if (Platform.OS !== 'web') return;
+  try {
+    // Cap the stored array to avoid unbounded growth.
+    const arr = Array.from(ids).slice(-200);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(arr));
+  } catch {
+    // Ignore quota / access errors
+  }
+}
+
+export default function GlobalCelebration() {
+  const { notifications } = useNotificationContext();
+  const seenRef = useRef<Set<string>>(loadSeenIds());
+  const [fire, setFire] = useState(false);
+
+  useEffect(() => {
+    // Find BID_ACCEPTED notifications we haven't celebrated yet.
+    const unseen = notifications.filter(
+      (n) => n.type === 'BID_ACCEPTED' && !seenRef.current.has(n.id),
+    );
+    if (unseen.length === 0) return;
+
+    // Mark them all as seen and persist.
+    unseen.forEach((n) => seenRef.current.add(n.id));
+    saveSeenIds(seenRef.current);
+
+    // Trigger confetti (single shot — additional accepts during the
+    // animation will simply be marked seen without re-triggering).
+    setFire(true);
+  }, [notifications]);
+
+  return <CelebrationOverlay fire={fire} onComplete={() => setFire(false)} />;
+}

--- a/frontend/src/screens/TaskDetailsFixer.tsx
+++ b/frontend/src/screens/TaskDetailsFixer.tsx
@@ -27,22 +27,10 @@ import EmptyState from '../components/EmptyState';
 import { FButton, FInput } from '../components/ui';
 import { brandColors, spacing, radii, shadows, typography } from '../theme';
 
-/* ------------------------------------------------------------------ */
-/*  Haversine distance (km) + rough drive-time estimate               */
-/* ------------------------------------------------------------------ */
-function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
-  const R = 6371;
-  const dLat = ((lat2 - lat1) * Math.PI) / 180;
-  const dLng = ((lng2 - lng1) * Math.PI) / 180;
-  const a =
-    Math.sin(dLat / 2) ** 2 +
-    Math.cos((lat1 * Math.PI) / 180) * Math.cos((lat2 * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-}
-
-function estimateDriveMinutes(km: number): number {
-  // ~40 km/h average city driving in Israel
-  return Math.round((km / 40) * 60);
+interface DirectionsResult {
+  distanceText: string;   // e.g. "12.3 ק״מ"
+  durationText: string;   // e.g. "18 דקות"
+  durationInTraffic?: string | null; // real-time with traffic
 }
 
 type TaskStatus = 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
@@ -114,6 +102,7 @@ export default function TaskDetailsFixer({ route }: Props) {
 
   const [carouselIndex, setCarouselIndex] = useState(0);
   const [userCoords, setUserCoords] = useState<{ lat: number; lng: number } | null>(null);
+  const [directions, setDirections] = useState<DirectionsResult | null>(null);
 
   // Get user's location for distance calculation
   useEffect(() => {
@@ -140,6 +129,21 @@ export default function TaskDetailsFixer({ route }: Props) {
       }
     })();
   }, []);
+
+  // Fetch real driving directions via backend proxy (Google Directions API)
+  useEffect(() => {
+    if (!userCoords || !task?.lat || !task?.lng || !taskId) return;
+    (async () => {
+      try {
+        const res = await api.get(`/api/tasks/${taskId}/directions`, {
+          params: { originLat: userCoords.lat, originLng: userCoords.lng },
+        });
+        if (res.data.directions) setDirections(res.data.directions);
+      } catch {
+        // Directions unavailable — card simply won't show
+      }
+    })();
+  }, [userCoords, task?.lat, task?.lng, taskId]);
 
   const fetchData = useCallback(async () => {
     if (!taskId) return;
@@ -363,27 +367,23 @@ export default function TaskDetailsFixer({ route }: Props) {
             value={`${bidCount} ${bidCount === 1 ? 'bid' : 'bids'} submitted`}
           />
 
-          {/* Distance & travel time */}
-          {userCoords && task.lat != null && task.lng != null && (() => {
-            const km = haversineKm(userCoords.lat, userCoords.lng, task.lat, task.lng);
-            const mins = estimateDriveMinutes(km);
-            return (
-              <View style={styles.distanceCard}>
-                <View style={styles.distanceIconShell}>
-                  <MaterialCommunityIcons name="map-marker-distance" size={20} color={brandColors.primary} />
-                </View>
-                <View style={styles.distanceInfo}>
-                  <Text style={[typography.h3, { color: brandColors.textPrimary }]}>
-                    {km < 1 ? `${Math.round(km * 1000)}m` : `${km.toFixed(1)} km`} away
-                  </Text>
-                  <Text style={[typography.bodySm, { color: brandColors.textMuted }]}>
-                    ~{mins < 1 ? '1' : mins} min drive
-                  </Text>
-                </View>
-                <MaterialCommunityIcons name="car-outline" size={20} color={brandColors.textMuted} />
+          {/* Distance & travel time (Google Directions API) */}
+          {directions && (
+            <View style={styles.distanceCard}>
+              <View style={styles.distanceIconShell}>
+                <MaterialCommunityIcons name="map-marker-distance" size={20} color={brandColors.primary} />
               </View>
-            );
-          })()}
+              <View style={styles.distanceInfo}>
+                <Text style={[typography.h3, { color: brandColors.textPrimary }]}>
+                  {directions.distanceText}
+                </Text>
+                <Text style={[typography.bodySm, { color: brandColors.textMuted }]}>
+                  {directions.durationInTraffic ?? directions.durationText}
+                </Text>
+              </View>
+              <MaterialCommunityIcons name="car-outline" size={20} color={brandColors.textMuted} />
+            </View>
+          )}
 
           <Divider style={styles.divider} />
 


### PR DESCRIPTION
## Summary

Follow-up on #82 with three fixer-side polish items.

- **Real-time driving directions.** New `GET /api/tasks/:id/directions` backend endpoint proxies Google Directions API using the task's PostGIS coordinates as destination and the fixer's live geolocation as origin. Returns real distance, duration, and duration-in-traffic — replaces the haversine + hardcoded 40 km/h estimate.
- **Hebrew unit localisation.** Google returns English units even with `language=he`; backend now rewrites `km → ק״מ`, `mins → דקות`, etc, before returning.
- **Clean distance card text.** Drops the `(בתנועה)` suffix that rendered awkwardly in RTL (e.g. "דקות (בתנועה) 17"). Shows just the duration — "17 דקות".
- **Global fixer celebration.** New `GlobalCelebration` component consumes `NotificationContext`. Confetti now fires on every `BID_ACCEPTED` notification regardless of which screen the fixer is on. If a bid was accepted while the fixer was offline, confetti fires once on next login. Seen IDs are persisted in `localStorage` (`fixit:celebrated_bid_ids`) so refresh does not re-fire. The per-screen celebration in `TaskDetailsFixer` was removed to avoid double confetti.

## Test plan

- [ ] Open a task as fixer → distance card shows real Google-backed km + minutes in Hebrew, no "(בתנועה)" tail
- [ ] From a second account as requester, accept the fixer's bid
- [ ] Fixer on any screen sees confetti within the polling window (≤30s)
- [ ] Log fixer out, accept another bid, log back in → confetti fires immediately after login
- [ ] Refresh the page after confetti fires → it does NOT fire again

