### PR TITLE
fix(no-phase): submit review fails with "Task has no assigned fixer"

### DIFF
--- a/backend/prisma/repair-assigned-fixer.ts
+++ b/backend/prisma/repair-assigned-fixer.ts
@@ -1,0 +1,55 @@
+/**
+ * One-off repair: earlier versions of seed.ts created IN_PROGRESS and
+ * COMPLETED tasks with an ACCEPTED bid but without setting the task's
+ * assigned_fixer_id column. That broke review submission ("Task has no
+ * assigned fixer"). This script scans for such tasks and patches them
+ * using their ACCEPTED bid's fixer_id.
+ *
+ * Run: npx ts-node prisma/repair-assigned-fixer.ts
+ */
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const broken = await prisma.task.findMany({
+    where: {
+      status: { in: ['IN_PROGRESS', 'COMPLETED'] },
+      assigned_fixer_id: null,
+    },
+    include: {
+      bids: {
+        where: { status: 'ACCEPTED' },
+        select: { fixer_id: true },
+      },
+    },
+  });
+
+  console.log(`Found ${broken.length} tasks with missing assigned_fixer_id.`);
+
+  let fixed = 0;
+  let skipped = 0;
+
+  for (const task of broken) {
+    const acceptedBid = task.bids[0];
+    if (!acceptedBid) {
+      console.warn(`  ⚠ Task ${task.id} has no ACCEPTED bid — skipping.`);
+      skipped++;
+      continue;
+    }
+    await prisma.task.update({
+      where: { id: task.id },
+      data: { assigned_fixer_id: acceptedBid.fixer_id },
+    });
+    fixed++;
+  }
+
+  console.log(`✓ Repaired ${fixed} tasks; ${skipped} skipped (no ACCEPTED bid).`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -256,6 +256,16 @@ async function main() {
       });
       totalBids++;
 
+      // When a bid is accepted, the task must have assigned_fixer_id set —
+      // otherwise later flows (e.g. review submission) will reject the task
+      // with "Task has no assigned fixer".
+      if (bidStatus === BidStatus.ACCEPTED) {
+        await prisma.task.update({
+          where: { id: taskIds[t] },
+          data: { assigned_fixer_id: fixerIds[fixerIndex] },
+        });
+      }
+
       // Create review for completed tasks (requester reviews the accepted fixer)
       if (status === 'COMPLETED' && bidStatus === BidStatus.ACCEPTED) {
         const reviewData = reviewTexts[t % reviewTexts.length];

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -263,13 +263,21 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 // GET /api/tasks/:id — task details
 router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const [task, bidCount] = await prisma.$transaction([
+    const [task, bidCount, myReview] = await prisma.$transaction([
       prisma.task.findUnique({
         where: { id: req.params.id },
         include: { requester: true, fixer: true },
       }),
       prisma.bid.count({
         where: { task_id: req.params.id, status: { in: ['PENDING', 'ACCEPTED'] } },
+      }),
+      prisma.review.findUnique({
+        where: {
+          task_id_reviewer_id: {
+            task_id: req.params.id,
+            reviewer_id: req.user.id,
+          },
+        },
       }),
     ]);
 
@@ -291,7 +299,15 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
       ? task
       : taskWithoutAddress;
 
-    res.json({ task: { ...response, bid_count: bidCount, lat: coords.lat, lng: coords.lng } });
+    res.json({
+      task: {
+        ...response,
+        bid_count: bidCount,
+        lat: coords.lat,
+        lng: coords.lng,
+        my_review: myReview,
+      },
+    });
   } catch (err) {
     next(err);
   }

--- a/frontend/src/screens/TaskDetails.tsx
+++ b/frontend/src/screens/TaskDetails.tsx
@@ -30,6 +30,13 @@ interface Bid {
   };
 }
 
+interface MyReview {
+  id: string;
+  rating: number;
+  comment: string | null;
+  created_at: string;
+}
+
 interface Task {
   id: string;
   title: string;
@@ -43,6 +50,7 @@ interface Task {
   is_payment_confirmed: boolean;
   created_at: string;
   completed_at: string | null;
+  my_review: MyReview | null;
 }
 
 const STATUS_BANNER: Record<TaskStatus, { bg: string; color: string; icon: string }> = {
@@ -110,8 +118,15 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
         api.get(`/api/tasks/${taskId}`),
         api.get(`/api/tasks/${taskId}/bids`),
       ]);
-      setTask(taskRes.data.task);
+      const fetchedTask: Task = taskRes.data.task;
+      setTask(fetchedTask);
       setBids(bidsRes.data.bids || []);
+      // Sync review-submitted state with server (survives refresh / re-mount)
+      if (fetchedTask.my_review) {
+        setReviewSubmitted(true);
+        setReviewRating(fetchedTask.my_review.rating);
+        setReviewComment(fetchedTask.my_review.comment ?? '');
+      }
     } catch {
       // handle error
     } finally {
@@ -194,8 +209,26 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
         comment: reviewComment.trim() || undefined,
       });
       setReviewSubmitted(true);
-    } catch {
-      Alert.alert('Error', 'Failed to submit review.');
+    } catch (err: unknown) {
+      const axiosErr = err as {
+        response?: { data?: { error?: { message?: string } }; status?: number };
+      };
+      // 409 → review already exists. Refresh from server so the UI reflects it.
+      if (axiosErr.response?.status === 409) {
+        setReviewSubmitted(true);
+        fetchData();
+        return;
+      }
+      const message =
+        axiosErr.response?.data?.error?.message ?? 'Failed to submit review.';
+      // Alert.alert on react-native-web only shows the title — combine so the
+      // server-side error is actually visible.
+      if (Platform.OS === 'web') {
+        // eslint-disable-next-line no-alert
+        window.alert(`Error: ${message}`);
+      } else {
+        Alert.alert('Error', message);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes a bug where **Submit Review** failed with a silent 400 on completed tasks. Root cause was an old seed-data bug: tasks whose bid was marked ACCEPTED never had `assigned_fixer_id` written to the task row, so the review endpoint rejected every such task with `Task has no assigned fixer`.

Secondary issue: once a review *was* submitted, the `reviewSubmitted` state lived only in React memory. A refresh re-showed the form, the user resubmitted, the backend returned 409 (duplicate), and the frontend displayed a generic "Failed to submit review" because `Alert.alert` on react-native-web drops the message body.

## Changes

- **`backend/prisma/seed.ts`** — when a bid is marked ACCEPTED during seeding, update the parent task's `assigned_fixer_id`. New seeds are now consistent end-to-end.
- **`backend/prisma/repair-assigned-fixer.ts`** — one-off script to fix tasks already broken by the old seed. Run: `npx ts-node prisma/repair-assigned-fixer.ts`.
- **`backend/src/routes/tasks.ts`** — `GET /api/tasks/:id` now includes `my_review` (the current user's review on this task, if one exists).
- **`frontend/src/screens/TaskDetails.tsx`** — initialises `reviewSubmitted` from `task.my_review` so refresh keeps the "Review submitted" banner. 409 conflicts now re-sync state instead of alerting. Other errors are shown via `window.alert` on web (so the real server message is visible).

## Test plan

- [ ] Run `npx ts-node prisma/repair-assigned-fixer.ts` once to patch existing broken seed data
- [ ] Open a COMPLETED task as requester → Submit Review → works, banner appears
- [ ] Refresh the page → banner still shows (no form re-render, no duplicate submit)
- [ ] Submit with rating 0 → button stays disabled (unchanged)
- [ ] Any other backend failure surfaces the real error text on web (not the generic fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)