### PR TITLE
feat: B2.1 + B2.2 — User profile update, push-token, and portfolio endpoints

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,8 +1,10 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { TaskStatus, BidStatus } from '@prisma/client';
 import { authMiddleware } from '../middleware/auth';
+import { validate } from '../middleware/validate';
 import { prisma } from '../config/prisma';
-import { NotFoundError } from '../utils/errors';
+import { NotFoundError, ConflictError, ForbiddenError } from '../utils/errors';
+import { updateUserSchema, pushTokenSchema, createPortfolioItemSchema } from '../schemas';
 
 const router = Router();
 
@@ -93,6 +95,60 @@ router.get('/me/bids', async (req: Request, res: Response, next: NextFunction) =
     ]);
 
     res.json({ bids, total, page: pageNum, limit: limitNum });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /api/users/me — update authenticated user profile
+router.put('/me', validate(updateUserSchema), async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = await prisma.user.update({
+      where: { id: req.user.id },
+      data: req.body,
+    });
+    res.json({ user });
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === 'P2002') {
+      return next(new ConflictError('Phone number is already in use'));
+    }
+    next(err);
+  }
+});
+
+// POST /api/users/me/push-token — register or update Expo push token
+router.post('/me/push-token', validate(pushTokenSchema), async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await prisma.user.update({
+      where: { id: req.user.id },
+      data: { push_token: req.body.token },
+    });
+    res.json({ message: 'Push token registered' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// POST /api/users/me/portfolio — add a portfolio item
+router.post('/me/portfolio', validate(createPortfolioItemSchema), async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const item = await prisma.portfolioItem.create({
+      data: { fixer_id: req.user.id, ...req.body },
+    });
+    res.status(201).json({ item });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// DELETE /api/users/me/portfolio/:id — remove a portfolio item
+router.delete('/me/portfolio/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const item = await prisma.portfolioItem.findUnique({ where: { id: req.params.id } });
+    if (!item) throw new NotFoundError('Portfolio item not found');
+    if (item.fixer_id !== req.user.id) throw new ForbiddenError('You do not own this portfolio item');
+    await prisma.portfolioItem.delete({ where: { id: req.params.id } });
+    res.status(204).send();
   } catch (err) {
     next(err);
   }

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -39,3 +39,23 @@ export const createReviewSchema = z.object({
   rating: z.number().int().min(1).max(5),
   comment: z.string().trim().max(2000).optional(),
 });
+
+export const updateUserSchema = z.object({
+  full_name: z.string().trim().min(1).max(100).optional(),
+  bio: z.string().trim().max(2000).optional(),
+  avatar_url: z.url().optional(),
+  payment_link: z.url().optional(),
+  phone_number: z.string().trim().optional(),
+  specializations: z
+    .array(z.enum(['ASSEMBLY', 'MOUNTING', 'MOVING', 'PAINTING', 'PLUMBING', 'ELECTRICITY', 'OUTDOORS', 'CLEANING']))
+    .optional(),
+});
+
+export const pushTokenSchema = z.object({
+  token: z.string().min(1),
+});
+
+export const createPortfolioItemSchema = z.object({
+  image_url: z.url(),
+  description: z.string().trim().max(500).optional(),
+});


### PR DESCRIPTION
## Summary
- `PUT /api/users/me` — update profile fields (full_name, bio, avatar_url, payment_link, phone_number, specializations). Handles phone_number uniqueness conflict with 409.
- `POST /api/users/me/push-token` — register/overwrite Expo push token. Called on app launch after auth.
- `POST /api/users/me/portfolio` — add a portfolio item (image_url + optional description). Returns 201.
- `DELETE /api/users/me/portfolio/:id` — remove own portfolio item. Returns 403 if item belongs to another user, 404 if not found.
- Added Zod schemas: `updateUserSchema`, `pushTokenSchema`, `createPortfolioItemSchema` to `schemas.ts`

## Test plan
- [ ] `PUT /api/users/me` with valid body → returns updated user
- [ ] `PUT /api/users/me` with duplicate phone_number → returns 409 CONFLICT
- [ ] `PUT /api/users/me` with invalid avatar_url (not a URL) → returns 400 VALIDATION_ERROR
- [ ] `POST /api/users/me/push-token` with `{ token: "ExponentPushToken[xxx]" }` → returns 200
- [ ] `POST /api/users/me/portfolio` with valid image_url → returns 201 with item
- [ ] `DELETE /api/users/me/portfolio/:id` as owner → returns 204
- [ ] `DELETE /api/users/me/portfolio/:id` as non-owner → returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)