### PR TITLE
feat: B2.3 — Firebase Storage image upload utility

### DIFF
--- a/frontend/src/screens/CreateTask.tsx
+++ b/frontend/src/screens/CreateTask.tsx
@@ -19,6 +19,8 @@ import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import * as ImagePicker from 'expo-image-picker';
 import * as Location from 'expo-location';
 import api from '../api/axiosInstance';
+import { auth } from '../config/firebase';
+import { uploadImage } from '../utils/uploadImage';
 import LocationMap from '../components/LocationMap';
 import { FButton, FInput } from '../components/ui';
 import { brandColors, spacing, radii, shadows, typography } from '../theme';
@@ -326,10 +328,17 @@ export default function CreateTask({ navigation, route }: Props) {
   const handlePublish = async () => {
     setSubmitting(true);
     try {
+      const userId = auth.currentUser?.uid ?? 'unknown';
+      const mediaUrls = await Promise.all(
+        photos.map((uri, i) =>
+          uploadImage(uri, `tasks/${userId}/${Date.now()}_${i}.jpg`)
+        )
+      );
+
       await api.post('/api/tasks', {
         title: title.trim(),
         description: description.trim(),
-        media_urls: [],
+        media_urls: mediaUrls,
         category,
         suggested_price: budgetType === 'fixed' ? parseFloat(price) : null,
         general_location_name: generalLocationName || address.trim(),

--- a/frontend/src/utils/uploadImage.ts
+++ b/frontend/src/utils/uploadImage.ts
@@ -1,0 +1,22 @@
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { storage } from '../config/firebase';
+
+/**
+ * Uploads a local image URI to Firebase Storage and returns the public download URL.
+ *
+ * @param uri   Local file URI from expo-image-picker (e.g. "file:///...")
+ * @param path  Destination path in Firebase Storage (e.g. "avatars/userId/123.jpg")
+ * @returns     Public HTTPS download URL
+ *
+ * Usage:
+ *   Avatar:    uploadImage(localUri, `avatars/${userId}/${Date.now()}.jpg`)
+ *   Portfolio: uploadImage(localUri, `portfolio/${userId}/${Date.now()}.jpg`)
+ *   Task:      uploadImage(localUri, `tasks/${taskId}/${Date.now()}.jpg`)
+ */
+export async function uploadImage(uri: string, path: string): Promise<string> {
+  const response = await fetch(uri);
+  const blob = await response.blob();
+  const storageRef = ref(storage, path);
+  await uploadBytes(storageRef, blob);
+  return getDownloadURL(storageRef);
+}


### PR DESCRIPTION
## Summary
- Creates `frontend/src/utils/uploadImage.ts` — a reusable helper that takes a local image URI (from `expo-image-picker`) and a Firebase Storage path, uploads the file, and returns the public download URL
- **Bug fix:** `CreateTask.tsx` had `media_urls: []` hardcoded on submit — photos picked by the user were shown in the UI but never uploaded. Now calls `uploadImage` for each photo before the API call and passes the returned URLs as `media_urls`

## Usage
\`\`\`typescript
import { uploadImage } from '../utils/uploadImage';

// Avatar
const url = await uploadImage(localUri, \`avatars/\${userId}/\${Date.now()}.jpg\`);

// Portfolio
const url = await uploadImage(localUri, \`portfolio/\${userId}/\${Date.now()}.jpg\`);

// Task media (already wired in CreateTask)
const url = await uploadImage(localUri, \`tasks/\${userId}/\${Date.now()}_0.jpg\`);
\`\`\`

## Test plan
- [ ] `npm run typecheck --workspace frontend` passes
- [ ] Create a task with 1+ photos → files appear in Firebase Storage under `tasks/` → task details shows the image(s)
- [ ] Create a task with no photos → works normally (`media_urls: []`)
- [ ] Call `uploadImage` directly from a screen → URL appears in Firebase Storage console → URL loads in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)