### PR TITLE
feat: B3.1 — auth screens (welcome, register, forgot password)

### DIFF
--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -11,9 +11,17 @@ const router = Router();
 // All user routes require authentication
 router.use(authMiddleware);
 
-// GET /api/users/me — current authenticated user profile
-router.get('/me', (req: Request, res: Response) => {
-  res.json({ user: req.user });
+// GET /api/users/me — current authenticated user profile (includes portfolio_items)
+router.get('/me', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      include: { portfolio_items: { orderBy: { created_at: 'desc' } } },
+    });
+    res.json({ user });
+  } catch (err) {
+    next(err);
+  }
 });
 
 // GET /api/users/me/tasks — requester's own tasks
@@ -163,9 +171,11 @@ router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
         id: true,
         full_name: true,
         avatar_url: true,
+        bio: true,
         average_rating_as_fixer: true,
         specializations: true,
         created_at: true,
+        portfolio_items: { orderBy: { created_at: 'desc' } },
       },
     });
     if (!user) throw new NotFoundError('User not found');

--- a/frontend/src/screens/AuthScreen.tsx
+++ b/frontend/src/screens/AuthScreen.tsx
@@ -3,6 +3,8 @@ import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet, View } from 're
 import { Text } from 'react-native-paper';
 import { LinearGradient } from 'expo-linear-gradient';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { createUserWithEmailAndPassword, sendPasswordResetEmail } from 'firebase/auth';
+import { auth } from '../config/firebase';
 import AppLogo from '../components/AppLogo';
 import LoadingScreen from '../components/LoadingScreen';
 import { FButton, FCard, FInput } from '../components/ui';
@@ -20,6 +22,8 @@ interface AuthScreenProps {
   onLogOut: () => Promise<void>;
 }
 
+type Mode = 'welcome' | 'login' | 'register' | 'forgot';
+
 export default function AuthScreen({
   status,
   error,
@@ -30,26 +34,86 @@ export default function AuthScreen({
   onRetry,
   onLogOut,
 }: AuthScreenProps) {
+  const [mode, setMode] = useState<Mode>('welcome');
+
+  // Login fields
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+
+  // Register fields
+  const [registerFullName, setRegisterFullName] = useState('');
+  const [registerEmail, setRegisterEmail] = useState('');
+  const [registerPassword, setRegisterPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [registerPhone, setRegisterPhone] = useState('');
+
+  // Forgot password fields
+  const [forgotEmail, setForgotEmail] = useState('');
+  const [forgotSent, setForgotSent] = useState(false);
+
+  // Shared
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
   const [fullName, setFullName] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
-
-  const canSignIn = email.trim().length > 0 && password.length > 0;
-  const canSyncLocalAccount = fullName.trim().length > 0;
 
   useEffect(() => {
     setFullName((current) => current || suggestedFullName);
   }, [suggestedFullName]);
 
-  const submitSignIn = () => {
-    if (!canSignIn) return;
-    void onSignIn(email, password);
+  const clearErrors = () => setLocalError(null);
+
+  const goTo = (m: Mode) => {
+    clearErrors();
+    setMode(m);
+  };
+
+  const submitSignIn = async () => {
+    if (!email.trim() || !password) return;
+    clearErrors();
+    try {
+      await onSignIn(email.trim(), password);
+    } catch {
+      // error is surfaced via the `error` prop from parent
+    }
+  };
+
+  const submitRegister = async () => {
+    clearErrors();
+    if (!registerFullName.trim()) { setLocalError('Full name is required'); return; }
+    if (!registerEmail.trim()) { setLocalError('Email is required'); return; }
+    if (registerPassword.length < 6) { setLocalError('Password must be at least 6 characters'); return; }
+    if (registerPassword !== confirmPassword) { setLocalError('Passwords do not match'); return; }
+
+    setSubmitting(true);
+    try {
+      await createUserWithEmailAndPassword(auth, registerEmail.trim(), registerPassword);
+      await onSyncLocalAccount(registerFullName.trim(), registerPhone.trim());
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Registration failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const submitForgot = async () => {
+    clearErrors();
+    if (!forgotEmail.trim()) { setLocalError('Please enter your email address'); return; }
+    setSubmitting(true);
+    try {
+      await sendPasswordResetEmail(auth, forgotEmail.trim());
+      setForgotSent(true);
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Failed to send reset email');
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const submitLocalAccountSync = () => {
-    if (!canSyncLocalAccount) return;
-    void onSyncLocalAccount(fullName, phoneNumber);
+    if (!fullName.trim()) return;
+    void onSyncLocalAccount(fullName.trim(), phoneNumber.trim());
   };
 
   const renderShell = (content: React.ReactNode) => (
@@ -75,10 +139,12 @@ export default function AuthScreen({
     </LinearGradient>
   );
 
+  // ── Loading ────────────────────────────────────────────────────────────────
   if (status === 'checking') {
     return <LoadingScreen label="Checking your session..." />;
   }
 
+  // ── Needs sync (Firebase account exists, no local DB user) ─────────────────
   if (status === 'needs_sync') {
     return renderShell(
       <View style={styles.content}>
@@ -113,7 +179,7 @@ export default function AuthScreen({
           <Text style={[typography.bodySm, { color: brandColors.danger }]}>{error}</Text>
         )}
 
-        <FButton onPress={submitLocalAccountSync} disabled={!canSyncLocalAccount} fullWidth>
+        <FButton onPress={submitLocalAccountSync} disabled={!fullName.trim()} fullWidth>
           Create Local Account
         </FButton>
         <FButton variant="ghost" onPress={onLogOut} fullWidth>
@@ -123,6 +189,7 @@ export default function AuthScreen({
     );
   }
 
+  // ── Error ──────────────────────────────────────────────────────────────────
   if (status === 'error' && userEmail) {
     return renderShell(
       <View style={styles.content}>
@@ -144,39 +211,181 @@ export default function AuthScreen({
     );
   }
 
+  // ── Welcome ────────────────────────────────────────────────────────────────
+  if (mode === 'welcome') {
+    return renderShell(
+      <View style={styles.content}>
+        <AppLogo showTagline />
+        <Text style={[typography.body, styles.body]}>
+          Find trusted fixers for any home task — or earn money as one.
+        </Text>
+        <FButton onPress={() => goTo('login')} fullWidth icon="login">
+          Sign In
+        </FButton>
+        <FButton variant="secondary" onPress={() => goTo('register')} fullWidth icon="account-plus">
+          Create Account
+        </FButton>
+      </View>
+    );
+  }
+
+  // ── Login ──────────────────────────────────────────────────────────────────
+  if (mode === 'login') {
+    return renderShell(
+      <View style={styles.content}>
+        <AppLogo compact showTagline />
+        <Text style={[typography.h1, styles.title]}>Sign in to Fixlt</Text>
+
+        <FInput
+          label="Email"
+          autoCapitalize="none"
+          autoComplete="email"
+          keyboardType="email-address"
+          value={email}
+          onChangeText={setEmail}
+          returnKeyType="next"
+        />
+        <FInput
+          label="Password"
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+          returnKeyType="done"
+          onSubmitEditing={() => void submitSignIn()}
+        />
+
+        {(error || localError) && (
+          <Text style={[typography.bodySm, { color: brandColors.danger }]}>{localError ?? error}</Text>
+        )}
+
+        <FButton onPress={() => void submitSignIn()} disabled={!email.trim() || !password} fullWidth icon="login">
+          Sign In
+        </FButton>
+
+        <FButton variant="ghost" onPress={() => goTo('forgot')} fullWidth>
+          Forgot Password?
+        </FButton>
+
+        <View style={styles.dividerRow}>
+          <View style={styles.dividerLine} />
+          <Text style={[typography.caption, { color: brandColors.textMuted, marginHorizontal: spacing.sm }]}>or</Text>
+          <View style={styles.dividerLine} />
+        </View>
+
+        <FButton variant="ghost" onPress={() => goTo('register')} fullWidth>
+          Don't have an account? Create one
+        </FButton>
+
+        <FButton variant="ghost" onPress={() => goTo('welcome')} fullWidth>
+          ← Back
+        </FButton>
+      </View>
+    );
+  }
+
+  // ── Register ───────────────────────────────────────────────────────────────
+  if (mode === 'register') {
+    return renderShell(
+      <View style={styles.content}>
+        <AppLogo compact showTagline />
+        <Text style={[typography.h1, styles.title]}>Create your account</Text>
+
+        <FInput
+          label="Full Name"
+          value={registerFullName}
+          onChangeText={setRegisterFullName}
+          returnKeyType="next"
+        />
+        <FInput
+          label="Email"
+          autoCapitalize="none"
+          autoComplete="email"
+          keyboardType="email-address"
+          value={registerEmail}
+          onChangeText={setRegisterEmail}
+          returnKeyType="next"
+        />
+        <FInput
+          label="Password"
+          secureTextEntry
+          value={registerPassword}
+          onChangeText={setRegisterPassword}
+          returnKeyType="next"
+        />
+        <FInput
+          label="Confirm Password"
+          secureTextEntry
+          value={confirmPassword}
+          onChangeText={setConfirmPassword}
+          returnKeyType="next"
+        />
+        <FInput
+          label="Phone Number (optional)"
+          value={registerPhone}
+          onChangeText={setRegisterPhone}
+          keyboardType="phone-pad"
+          returnKeyType="done"
+          onSubmitEditing={() => void submitRegister()}
+        />
+
+        {localError && (
+          <Text style={[typography.bodySm, { color: brandColors.danger }]}>{localError}</Text>
+        )}
+
+        <FButton onPress={() => void submitRegister()} loading={submitting} disabled={submitting} fullWidth icon="account-plus">
+          Create Account
+        </FButton>
+
+        <FButton variant="ghost" onPress={() => goTo('login')} fullWidth>
+          Already have an account? Sign In
+        </FButton>
+      </View>
+    );
+  }
+
+  // ── Forgot Password ────────────────────────────────────────────────────────
   return renderShell(
     <View style={styles.content}>
       <AppLogo compact showTagline />
-      <Text style={[typography.h1, styles.title]}>Sign in to Fixlt</Text>
-      <Text style={[typography.body, styles.body]}>
-        Use your Firebase test user so the app can send authenticated API requests locally.
-      </Text>
+      <Text style={[typography.h1, styles.title]}>Reset your password</Text>
 
-      <FInput
-        label="Email"
-        autoCapitalize="none"
-        autoComplete="email"
-        keyboardType="email-address"
-        value={email}
-        onChangeText={setEmail}
-        returnKeyType="next"
-      />
-      <FInput
-        label="Password"
-        secureTextEntry
-        value={password}
-        onChangeText={setPassword}
-        returnKeyType="done"
-        onSubmitEditing={submitSignIn}
-      />
-
-      {error && (
-        <Text style={[typography.bodySm, { color: brandColors.danger }]}>{error}</Text>
+      {forgotSent ? (
+        <>
+          <View style={styles.successIconCircle}>
+            <MaterialCommunityIcons name="email-check-outline" size={36} color={brandColors.success} />
+          </View>
+          <Text style={[typography.body, styles.body]}>
+            Check your inbox — we sent a reset link to {forgotEmail}.
+          </Text>
+          <FButton onPress={() => goTo('login')} fullWidth icon="login">
+            Back to Sign In
+          </FButton>
+        </>
+      ) : (
+        <>
+          <Text style={[typography.body, styles.body]}>
+            Enter your email and we'll send you a link to reset your password.
+          </Text>
+          <FInput
+            label="Email"
+            autoCapitalize="none"
+            keyboardType="email-address"
+            value={forgotEmail}
+            onChangeText={setForgotEmail}
+            returnKeyType="done"
+            onSubmitEditing={() => void submitForgot()}
+          />
+          {localError && (
+            <Text style={[typography.bodySm, { color: brandColors.danger }]}>{localError}</Text>
+          )}
+          <FButton onPress={() => void submitForgot()} loading={submitting} disabled={submitting} fullWidth icon="email-send">
+            Send Reset Link
+          </FButton>
+          <FButton variant="ghost" onPress={() => goTo('login')} fullWidth>
+            ← Back to Sign In
+          </FButton>
+        </>
       )}
-
-      <FButton onPress={submitSignIn} disabled={!canSignIn} fullWidth icon="login">
-        Sign In
-      </FButton>
     </View>
   );
 }
@@ -228,5 +437,24 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     alignSelf: 'center',
+  },
+  successIconCircle: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    backgroundColor: brandColors.successSoft,
+    alignItems: 'center',
+    justifyContent: 'center',
+    alignSelf: 'center',
+  },
+  dividerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: spacing.xs,
+  },
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: brandColors.outlineLight,
   },
 });


### PR DESCRIPTION
## Summary
- **Welcome screen**: Logo + tagline + Sign In / Create Account buttons (new landing for unauthenticated users)
- **Registration**: Full name, email, password, confirm password, phone → `createUserWithEmailAndPassword` → `POST /api/auth/sync`
- **Forgot Password**: Email input → `sendPasswordResetEmail` → success confirmation
- **Login**: Unchanged logic, now has "Forgot Password?" and "Create Account" links
- **Backend**: `GET /api/users/me` now includes `portfolio_items`; `GET /api/users/:id` adds `bio` + `portfolio_items`

## Test plan
- [ ] Open app → Welcome screen appears (not login form directly)
- [ ] Create Account with a new email → app opens as new user
- [ ] Existing sign-in (`zilber@example.com` / `guyguyguy`) still works
- [ ] Forgot Password → email input → success message shown
- [ ] `needs_sync` fallback still works (Firebase user, no local DB user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)