### PR TITLE
fix: enable image upload on web in FixerProfileScreen

### DIFF
--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import {
   Alert,
   Image,
-  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -88,10 +87,6 @@ export default function FixerProfileScreen() {
   );
 
   const handleAvatarPress = async () => {
-    if (Platform.OS === 'web') {
-      Alert.alert('Not supported', 'Avatar upload is only available on mobile.');
-      return;
-    }
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: 'images',
       quality: 0.8,
@@ -136,10 +131,6 @@ export default function FixerProfileScreen() {
   };
 
   const handleAddPortfolio = async () => {
-    if (Platform.OS === 'web') {
-      Alert.alert('Not supported', 'Portfolio upload is only available on mobile.');
-      return;
-    }
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: 'images',
       quality: 0.8,


### PR DESCRIPTION
## Summary
Remove unnecessary `Platform.OS === 'web'` guards from avatar and portfolio upload handlers. `expo-image-picker` works on web — it opens the browser's native file picker dialog, the blob URI it returns is fetchable, and `uploadBytes` to Firebase Storage works the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)