### PR TITLE
fix: split avatar tap targets — image=view, camera badge=change

### DIFF
--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -108,17 +108,6 @@ export default function FixerProfileScreen() {
     }
   };
 
-  const handleAvatarPress = () => {
-    if (profile?.avatar_url) {
-      Alert.alert('Profile Photo', undefined, [
-        { text: 'View Photo', onPress: () => setViewingAvatar(true) },
-        { text: 'Change Photo', onPress: () => void pickNewAvatar() },
-        { text: 'Cancel', style: 'cancel' },
-      ]);
-    } else {
-      void pickNewAvatar();
-    }
-  };
 
   const handleSaveProfile = async () => {
     setSaving(true);
@@ -192,24 +181,26 @@ export default function FixerProfileScreen() {
     >
       {/* ── Avatar ─────────────────────────────────────────────────── */}
       <View style={styles.avatarSection}>
-        <Pressable onPress={() => void handleAvatarPress()} style={styles.avatarWrapper}>
-          {profile?.avatar_url ? (
-            <Avatar.Image size={96} source={{ uri: profile.avatar_url }} />
-          ) : (
-            <Avatar.Icon
-              size={96}
-              icon="account"
-              style={{ backgroundColor: brandColors.primaryMuted }}
-            />
-          )}
-          <View style={styles.cameraBadge}>
+        <View style={styles.avatarWrapper}>
+          <Pressable onPress={() => profile?.avatar_url ? setViewingAvatar(true) : void pickNewAvatar()}>
+            {profile?.avatar_url ? (
+              <Avatar.Image size={96} source={{ uri: profile.avatar_url }} />
+            ) : (
+              <Avatar.Icon
+                size={96}
+                icon="account"
+                style={{ backgroundColor: brandColors.primaryMuted }}
+              />
+            )}
+          </Pressable>
+          <Pressable style={styles.cameraBadge} onPress={() => void pickNewAvatar()}>
             {uploadingAvatar ? (
               <MaterialCommunityIcons name="loading" size={14} color={brandColors.white} />
             ) : (
               <MaterialCommunityIcons name="camera" size={14} color={brandColors.white} />
             )}
-          </View>
-        </Pressable>
+          </Pressable>
+        </View>
 
         <Text style={[typography.h2, { color: brandColors.textPrimary, marginTop: spacing.md }]}>
           {profile?.full_name}


### PR DESCRIPTION
## Problem
`Alert.alert` with custom buttons doesn't work on web (React Native Web limitation — browser ignores custom button options). Tapping the avatar when a photo already existed did nothing visible.

## Fix
Two distinct tap targets instead of one alert:
- **Tap avatar image** → opens full-screen viewer modal (only when avatar exists; otherwise opens picker)
- **Tap camera badge** → always opens image picker to change the photo

Works on both web and mobile with no platform-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)