### PR TITLE
fix: center and enlarge logo on auth welcome screen

### DIFF
--- a/frontend/src/components/AppLogo.tsx
+++ b/frontend/src/components/AppLogo.tsx
@@ -72,8 +72,9 @@ const styles = StyleSheet.create({
     gap: spacing.sm + 2,
   },
   fullLogo: {
-    width: 188,
+    width: 220,
     aspectRatio: FULL_LOGO_ASPECT_RATIO,
+    alignSelf: 'center',
   },
   // Outer container — sized to contain the badge even when rotated
   markOuter: {


### PR DESCRIPTION
## Summary
- Increase `fullLogo` width from 188 → 220px
- Add `alignSelf: 'center'` so the logo centers regardless of parent container flex direction

## Test plan
- [ ] Open app → welcome/auth screen → logo is centered and larger
- [ ] Login, register, forgot password modes unaffected (they use `compact` mode, not `fullLogo`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)