### PR TITLE
feat: C5 — Real-time read receipts for chat

### DIFF
--- a/backend/src/__tests__/routes/messages.test.ts
+++ b/backend/src/__tests__/routes/messages.test.ts
@@ -299,6 +299,45 @@ describe('PUT /api/tasks/:id/messages/read', () => {
   });
 });
 
+// ── PUT /api/tasks/:id/messages/read — messages_read emit ────────────────────
+
+describe('PUT /api/tasks/:id/messages/read (read receipts)', () => {
+  it('only marks messages where the caller is recipient', async () => {
+    const task = await createTaskInProgress();
+    // Fixer sends 2 messages to requester; requester sends 1 to fixer
+    await prisma.message.createMany({
+      data: [
+        { task_id: task.id, sender_id: fixerId, recipient_id: requesterId, content: 'hi 1', is_read: false },
+        { task_id: task.id, sender_id: fixerId, recipient_id: requesterId, content: 'hi 2', is_read: false },
+        { task_id: task.id, sender_id: requesterId, recipient_id: fixerId, content: 'reply', is_read: false },
+      ],
+    });
+
+    __setUid('requester-uid');
+    await request(app)
+      .put(`/api/tasks/${task.id}/messages/read`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    // Requester's unread should be 0, fixer's unread stays 1
+    const requesterUnread = await prisma.message.count({ where: { task_id: task.id, recipient_id: requesterId, is_read: false } });
+    const fixerUnread = await prisma.message.count({ where: { task_id: task.id, recipient_id: fixerId, is_read: false } });
+    expect(requesterUnread).toBe(0);
+    expect(fixerUnread).toBe(1);
+  });
+
+  it('is idempotent — calling again when already read returns ok', async () => {
+    const task = await createTaskInProgress();
+
+    __setUid('requester-uid');
+    const res = await request(app)
+      .put(`/api/tasks/${task.id}/messages/read`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});
+
 // ── GET /api/conversations ────────────────────────────────────────────────────
 
 describe('GET /api/conversations', () => {
@@ -377,5 +416,62 @@ describe('GET /api/conversations', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.conversations).toHaveLength(0);
+  });
+
+  it('includes conversations for a fixer with pending bid', async () => {
+    // Requester creates task, fixer bids (not accepted), then messages are exchanged
+    __setUid('requester-uid');
+    const taskRes = await request(app)
+      .post('/api/tasks')
+      .set('Authorization', REQUESTER_AUTH)
+      .send({
+        title: 'Bid chat task',
+        description: 'Testing conversations with pending bid.',
+        category: 'PLUMBING',
+        general_location_name: 'Haifa',
+        exact_address: '5 Herzl St',
+        lat: 32.81,
+        lng: 34.99,
+      });
+    const taskId = taskRes.body.task.id as string;
+
+    __setUid('fixer-uid');
+    await request(app)
+      .post(`/api/tasks/${taskId}/bids`)
+      .set('Authorization', FIXER_AUTH)
+      .send({ offered_price: 100, description: 'I can help.' });
+
+    // Seed messages between them
+    await prisma.message.create({
+      data: { task_id: taskId, sender_id: requesterId, recipient_id: fixerId, content: 'Hi, interested?' },
+    });
+
+    __setUid('fixer-uid');
+    const res = await request(app)
+      .get('/api/conversations')
+      .set('Authorization', FIXER_AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toHaveLength(1);
+    expect(res.body.conversations[0].otherParty?.full_name).toBe('Requester');
+  });
+
+  it('shows the correct other party name for both sides', async () => {
+    const task = await createTaskInProgress();
+    await seedMessages(task.id);
+
+    // Requester sees Fixer
+    __setUid('requester-uid');
+    const reqRes = await request(app)
+      .get('/api/conversations')
+      .set('Authorization', REQUESTER_AUTH);
+    expect(reqRes.body.conversations[0].otherParty?.full_name).toBe('Fixer');
+
+    // Fixer sees Requester
+    __setUid('fixer-uid');
+    const fixRes = await request(app)
+      .get('/api/conversations')
+      .set('Authorization', FIXER_AUTH);
+    expect(fixRes.body.conversations[0].otherParty?.full_name).toBe('Requester');
   });
 });

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { authMiddleware } from '../middleware/auth';
 import { prisma } from '../config/prisma';
 import { ForbiddenError, NotFoundError } from '../utils/errors';
+import { getIO } from '../socket';
 
 const router = Router();
 
@@ -127,10 +128,28 @@ router.put('/tasks/:id/messages/read', async (req: Request, res: Response, next:
         });
     if (!isMember && !bid) throw new ForbiddenError('Not a participant in this chat');
 
+    // Find which messages will be marked so we can notify the sender
+    const unreadMessages = await prisma.message.findMany({
+      where: { task_id: taskId, recipient_id: userId, is_read: false },
+      select: { id: true },
+    });
+
     await prisma.message.updateMany({
       where: { task_id: taskId, recipient_id: userId, is_read: false },
       data: { is_read: true },
     });
+
+    // Emit real-time read receipt to the chat room
+    if (unreadMessages.length > 0) {
+      const io = getIO();
+      if (io) {
+        io.to(`task_chat_${taskId}`).emit('messages_read', {
+          taskId,
+          readerId: userId,
+          messageIds: unreadMessages.map((m) => m.id),
+        });
+      }
+    }
 
     res.json({ ok: true });
   } catch (err) {

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -53,10 +53,14 @@ router.get('/conversations', async (req: Request, res: Response, next: NextFunct
   try {
     const userId = req.user!.id;
 
+    // Find all tasks where the user has sent or received messages
     const tasks = await prisma.task.findMany({
       where: {
-        OR: [{ requester_id: userId }, { assigned_fixer_id: userId }],
-        messages: { some: {} },
+        messages: {
+          some: {
+            OR: [{ sender_id: userId }, { recipient_id: userId }],
+          },
+        },
       },
       include: {
         requester: { select: { id: true, full_name: true, avatar_url: true } },
@@ -64,7 +68,9 @@ router.get('/conversations', async (req: Request, res: Response, next: NextFunct
         messages: {
           orderBy: { created_at: 'desc' },
           take: 1,
-          select: { content: true, created_at: true, sender_id: true, is_read: true },
+          include: {
+            sender: { select: { id: true, full_name: true, avatar_url: true } },
+          },
         },
       },
     });
@@ -84,13 +90,26 @@ router.get('/conversations', async (req: Request, res: Response, next: NextFunct
 
     const conversations = tasks
       .map((task) => {
-        const otherParty =
-          task.requester_id === userId ? task.fixer : task.requester;
+        // Determine the other party: if user is requester, show fixer (or last message sender)
+        // If user is fixer/bidder, show requester
+        let otherParty: { id: string; full_name: string; avatar_url: string | null } | null = null;
+        if (task.requester_id === userId) {
+          otherParty = task.fixer ?? task.messages[0]?.sender ?? null;
+        } else {
+          otherParty = task.requester;
+        }
+        // Make sure we don't show ourselves as the "other party"
+        if (otherParty?.id === userId && task.messages[0]?.sender) {
+          // Last message was from us — look at recipient side
+          otherParty = task.requester_id === userId ? task.fixer : task.requester;
+        }
+
         const lastMessage = task.messages[0] ?? null;
 
         return {
           taskId: task.id,
           taskTitle: task.title,
+          taskStatus: task.status,
           otherParty,
           lastMessage: lastMessage
             ? { content: lastMessage.content, timestamp: lastMessage.created_at }

--- a/backend/src/socket/index.ts
+++ b/backend/src/socket/index.ts
@@ -9,10 +9,18 @@ interface AuthenticatedSocket extends Socket {
   userId: string;
 }
 
+let ioInstance: SocketServer | null = null;
+
+/** Get the live Socket.io server instance (available after initSocket is called). */
+export function getIO(): SocketServer | null {
+  return ioInstance;
+}
+
 export function initSocket(httpServer: HttpServer): SocketServer {
   const io = new SocketServer(httpServer, {
     cors: { origin: '*', methods: ['GET', 'POST'] },
   });
+  ioInstance = io;
 
   // Auth handshake — verify Firebase token and attach userId to socket
   io.use(async (socket, next) => {
@@ -140,6 +148,50 @@ export function initSocket(httpServer: HttpServer): SocketServer {
         }
       },
     );
+
+    // mark_read — batch-update unread messages and notify the sender in real-time
+    socket.on('mark_read', async (taskId: string) => {
+      try {
+        if (!taskId) return;
+
+        const task = await prisma.task.findUnique({ where: { id: taskId } });
+        if (!task) return;
+
+        const userId = authedSocket.userId;
+        const isMember =
+          task.requester_id === userId || task.assigned_fixer_id === userId;
+        const hasBid = isMember
+          ? true
+          : !!(await prisma.bid.findFirst({
+              where: { task_id: taskId, fixer_id: userId, status: { in: ['PENDING', 'ACCEPTED'] } },
+            }));
+        if (!isMember && !hasBid) return;
+
+        // Find unread messages sent TO this user, then mark them read
+        const unreadMessages = await prisma.message.findMany({
+          where: { task_id: taskId, recipient_id: userId, is_read: false },
+          select: { id: true, sender_id: true },
+        });
+
+        if (unreadMessages.length === 0) return;
+
+        await prisma.message.updateMany({
+          where: { task_id: taskId, recipient_id: userId, is_read: false },
+          data: { is_read: true },
+        });
+
+        const messageIds = unreadMessages.map((m) => m.id);
+
+        // Emit to the room so the sender's UI can show read indicators
+        io.to(`task_chat_${taskId}`).emit('messages_read', {
+          taskId,
+          readerId: userId,
+          messageIds,
+        });
+      } catch (err) {
+        console.error('[socket] mark_read error', err);
+      }
+    });
   });
 
   return io;

--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -16,8 +16,8 @@ export interface AppNotification {
   updated_at: string;
 }
 
-export const FIXER_NOTIF_TYPES = ['BID_ACCEPTED', 'BID_REJECTED', 'TASK_COMPLETED', 'TASK_CANCELED', 'NEW_MESSAGE'];
-export const REQUESTER_NOTIF_TYPES = ['NEW_BID', 'NEW_MESSAGE'];
+export const FIXER_NOTIF_TYPES = ['BID_ACCEPTED', 'BID_REJECTED', 'TASK_COMPLETED', 'TASK_CANCELED'];
+export const REQUESTER_NOTIF_TYPES = ['NEW_BID'];
 
 interface NotificationContextValue {
   notifications: AppNotification[];

--- a/frontend/src/hooks/__tests__/useUnreadMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useUnreadMessages.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useUnreadMessages } from '../useUnreadMessages';
+import api from '../../api/axiosInstance';
+
+const mockApi = api as jest.Mocked<typeof api>;
+
+const mockSocket = {
+  on: jest.fn(),
+  off: jest.fn(),
+  emit: jest.fn(),
+  connected: true,
+};
+
+jest.mock('../../utils/socket', () => ({
+  getSocket: () => Promise.resolve(mockSocket),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockApi.get.mockResolvedValue({ data: { conversations: [] } });
+});
+
+describe('useUnreadMessages', () => {
+  it('returns 0 when there are no conversations', async () => {
+    mockApi.get.mockResolvedValue({ data: { conversations: [] } });
+
+    const { result } = renderHook(() => useUnreadMessages());
+    await waitFor(() => expect(mockApi.get).toHaveBeenCalledWith('/api/conversations'));
+
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it('sums unreadCount across all conversations', async () => {
+    mockApi.get.mockResolvedValue({
+      data: {
+        conversations: [
+          { taskId: 't1', unreadCount: 3 },
+          { taskId: 't2', unreadCount: 5 },
+          { taskId: 't3', unreadCount: 0 },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useUnreadMessages());
+    await waitFor(() => expect(result.current.unreadCount).toBe(8));
+  });
+
+  it('refetch function updates the count', async () => {
+    mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 2 }] } });
+
+    const { result } = renderHook(() => useUnreadMessages());
+    await waitFor(() => expect(result.current.unreadCount).toBe(2));
+
+    mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 0 }] } });
+    await act(async () => { await result.current.refetch(); });
+
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it('handles API errors gracefully', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useUnreadMessages());
+    await waitFor(() => expect(mockApi.get).toHaveBeenCalled());
+
+    expect(result.current.unreadCount).toBe(0);
+  });
+
+  it('listens to socket events for real-time updates', async () => {
+    mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 1 }] } });
+
+    renderHook(() => useUnreadMessages());
+    await waitFor(() => expect(mockSocket.on).toHaveBeenCalled());
+
+    const eventNames = mockSocket.on.mock.calls.map((call: [string, unknown]) => call[0]);
+    expect(eventNames).toContain('receive_message');
+    expect(eventNames).toContain('messages_read');
+  });
+});

--- a/frontend/src/hooks/useUnreadMessages.ts
+++ b/frontend/src/hooks/useUnreadMessages.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import api from '../api/axiosInstance';
+import { getSocket } from '../utils/socket';
+import { auth } from '../config/firebase';
+
+const POLL_INTERVAL = 30_000;
+
+/**
+ * Tracks total unread message count across all conversations.
+ * Refreshes on socket `receive_message` events and periodically.
+ */
+export function useUnreadMessages() {
+  const [unreadCount, setUnreadCount] = useState(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetch = useCallback(async () => {
+    if (!auth.currentUser) return;
+    try {
+      const res = await api.get('/api/conversations');
+      const conversations: { unreadCount: number }[] = res.data.conversations ?? [];
+      const total = conversations.reduce((sum, c) => sum + c.unreadCount, 0);
+      setUnreadCount(total);
+    } catch {
+      // non-fatal
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetch();
+
+    intervalRef.current = setInterval(() => void fetch(), POLL_INTERVAL);
+
+    // Listen for new messages to refresh count
+    let socket: Awaited<ReturnType<typeof getSocket>> | null = null;
+    void (async () => {
+      if (!auth.currentUser) return;
+      socket = await getSocket();
+      socket.on('receive_message', () => void fetch());
+      socket.on('messages_read', () => void fetch());
+    })();
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      socket?.off('receive_message');
+      socket?.off('messages_read');
+    };
+  }, [fetch]);
+
+  return { unreadCount, refetch: fetch };
+}

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -24,6 +24,7 @@ import ChatScreen from '../screens/ChatScreen';
 import AppLogo from '../components/AppLogo';
 import HamburgerMenu from '../components/HamburgerMenu';
 import { useNotificationContext, FIXER_NOTIF_TYPES, REQUESTER_NOTIF_TYPES } from '../context/NotificationContext';
+import { useUnreadMessages } from '../hooks/useUnreadMessages';
 import { brandColors, spacing, radii, shadows, typography } from '../theme';
 import type { Category } from '../constants/categories';
 import {
@@ -93,6 +94,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
   const typeFilter = mode === 'fixer' ? FIXER_NOTIF_TYPES : REQUESTER_NOTIF_TYPES;
   const { unreadCount } = useNotificationContext();
   const notificationCount = unreadCount(typeFilter);
+  const { unreadCount: unreadMsgCount } = useUnreadMessages();
 
   useEffect(() => {
     return navigation.addListener('state', () => {
@@ -156,11 +158,13 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
     ? [
         { label: 'Find Jobs', screen: 'FindJobs', icon: 'map-search-outline' },
         { label: 'My Bids', screen: 'MyBids', icon: 'format-list-checks' },
+        { label: 'Messages', screen: 'Messages', icon: 'chat-outline' },
         { label: 'Profile', screen: 'FixerProfile', icon: 'account-hard-hat-outline' },
       ]
     : [
         { label: 'Home', screen: 'Dashboard', icon: 'home-outline' },
         { label: 'My Tasks', screen: 'MyTasks', icon: 'clipboard-list-outline' },
+        { label: 'Messages', screen: 'Messages', icon: 'chat-outline' },
         { label: 'Account', screen: 'Profile', icon: 'account-circle-outline' },
       ];
 
@@ -233,6 +237,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
           <View style={styles.desktopPageTabs}>
             {workspaceTabs.map((item) => {
               const selected = activeScreen === item.screen;
+              const showMsgBadge = item.screen === 'Messages' && unreadMsgCount > 0;
               return (
                 <Pressable
                   key={item.screen}
@@ -248,12 +253,13 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
                 >
                   <MaterialCommunityIcons
                     name={item.icon as never}
-                    size={16}
+                    size={18}
                     color={selected ? brandColors.primary : brandColors.textMuted}
                   />
                   <Text style={[styles.desktopPageTabText, selected && styles.desktopPageTabTextActive]}>
                     {item.label}
                   </Text>
+                  {showMsgBadge && <NotifBadge count={unreadMsgCount} />}
                 </Pressable>
               );
             })}
@@ -712,11 +718,13 @@ const styles = StyleSheet.create({
   },
   desktopPageTab: {
     minHeight: 38,
-    flexDirection: 'row',
+    flexDirection: 'column',
     alignItems: 'center',
-    gap: spacing.xs,
+    justifyContent: 'center',
+    gap: 2,
     paddingHorizontal: spacing.md,
-    borderRadius: radii.pill,
+    paddingVertical: spacing.xs,
+    borderRadius: radii.md,
     borderWidth: 1,
     borderColor: 'transparent',
   },
@@ -725,9 +733,9 @@ const styles = StyleSheet.create({
     borderColor: brandColors.outlineLight,
   },
   desktopPageTabText: {
-    fontSize: 13,
+    fontSize: 10,
     fontWeight: '700',
-    lineHeight: 16,
+    lineHeight: 13,
     color: brandColors.textMuted,
   },
   desktopPageTabTextActive: {

--- a/frontend/src/navigation/FixerTabs.tsx
+++ b/frontend/src/navigation/FixerTabs.tsx
@@ -7,6 +7,7 @@ import DiscoveryFeedScreen from '../screens/DiscoveryFeedScreen';
 import MyBidsScreen from '../screens/MyBidsScreen';
 import FixerProfileScreen from '../screens/FixerProfileScreen';
 import ConversationListScreen from '../screens/ConversationListScreen';
+import { useUnreadMessages } from '../hooks/useUnreadMessages';
 import { brandColors, shadows, spacing } from '../theme';
 
 const Tab = createBottomTabNavigator();
@@ -28,6 +29,7 @@ export default function FixerTabs() {
   const theme = useTheme();
   const { width } = useWindowDimensions();
   const useDesktopNavigation = Platform.OS === 'web' && width >= 900;
+  const { unreadCount } = useUnreadMessages();
 
   return (
     <Tab.Navigator
@@ -67,6 +69,8 @@ export default function FixerTabs() {
         component={ConversationListScreen}
         options={{
           tabBarLabel: 'Messages',
+          tabBarBadge: unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : undefined,
+          tabBarBadgeStyle: { backgroundColor: brandColors.secondaryDark, fontSize: 10, fontWeight: '700' },
           tabBarIcon: ({ color, size, focused }: { color: string; size: number; focused: boolean }) => (
             <TabIcon name={focused ? 'chat' : 'chat-outline'} color={color} size={size} focused={focused} />
           ),

--- a/frontend/src/navigation/RequesterTabs.tsx
+++ b/frontend/src/navigation/RequesterTabs.tsx
@@ -7,6 +7,7 @@ import RequesterDashboard from '../screens/RequesterDashboard';
 import MyTasksScreen from '../screens/MyTasksScreen';
 import SettingsScreen from '../screens/SettingsScreen';
 import ConversationListScreen from '../screens/ConversationListScreen';
+import { useUnreadMessages } from '../hooks/useUnreadMessages';
 import { brandColors, shadows, spacing } from '../theme';
 
 const Tab = createBottomTabNavigator();
@@ -32,6 +33,7 @@ export default function RequesterTabs() {
   const theme = useTheme();
   const { width } = useWindowDimensions();
   const useDesktopNavigation = Platform.OS === 'web' && width >= 900;
+  const { unreadCount } = useUnreadMessages();
 
   return (
     <Tab.Navigator
@@ -71,6 +73,8 @@ export default function RequesterTabs() {
         component={ConversationListScreen}
         options={{
           tabBarLabel: 'Messages',
+          tabBarBadge: unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : undefined,
+          tabBarBadgeStyle: { backgroundColor: brandColors.primary, fontSize: 10, fontWeight: '700' },
           tabBarIcon: ({ color, size, focused }) => (
             <TabIcon name={focused ? 'chat' : 'chat-outline'} color={color} size={size} focused={focused} />
           ),

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -122,6 +122,10 @@ export default function ChatScreen({ route }: { route: any }) {
       const socket = await getSocket();
       socketRef.current = socket;
       socket.emit('join_chat', taskId);
+
+      // Also emit mark_read via socket so the sender gets real-time receipt
+      socket.emit('mark_read', taskId);
+
       socket.on('receive_message', (msg: Message) => {
         const sentByMe = msg.sender?.firebase_uid
           ? msg.sender.firebase_uid === auth.currentUser?.uid
@@ -142,12 +146,27 @@ export default function ChatScreen({ route }: { route: any }) {
         flatListRef.current?.scrollToEnd({ animated: true });
 
         // Only refresh bell badge for messages from the other party
-        if (!sentByMe) void refetchNotifications();
+        if (!sentByMe) {
+          void refetchNotifications();
+          // Mark incoming messages as read immediately since the chat is open
+          socket.emit('mark_read', taskId);
+        }
+      });
+
+      // Listen for read receipts — update sent messages to show as read
+      socket.on('messages_read', (payload: { taskId: string; readerId: string; messageIds: string[] }) => {
+        if (payload.taskId !== taskId) return;
+        setMessages(prev =>
+          prev.map(m =>
+            payload.messageIds.includes(m.id) ? { ...m, is_read: true } : m,
+          ),
+        );
       });
     })();
 
     return () => {
       socketRef.current?.off('receive_message');
+      socketRef.current?.off('messages_read');
     };
   }, [taskId, loadMessages]);
 
@@ -224,9 +243,19 @@ export default function ChatScreen({ route }: { route: any }) {
                 <Text style={[styles.bubbleText, { color: isMine ? brandColors.white : brandColors.textPrimary }]}>
                   {item.content}
                 </Text>
-                <Text style={[typography.caption, styles.bubbleTime, { color: isMine ? 'rgba(255,255,255,0.65)' : brandColors.textMuted }]}>
-                  {formatTime(item.created_at)}
-                </Text>
+                <View style={styles.bubbleMeta}>
+                  <Text style={[typography.caption, styles.bubbleTime, { color: isMine ? 'rgba(255,255,255,0.65)' : brandColors.textMuted }]}>
+                    {formatTime(item.created_at)}
+                  </Text>
+                  {isMine && (
+                    <MaterialCommunityIcons
+                      name={item.is_read ? 'check-all' : 'check'}
+                      size={14}
+                      color={item.is_read ? '#7DD3FC' : 'rgba(255,255,255,0.5)'}
+                      style={styles.readIndicator}
+                    />
+                  )}
+                </View>
               </View>
             </View>
           );
@@ -330,9 +359,16 @@ const styles = StyleSheet.create({
     fontSize: 15,
     lineHeight: 21,
   },
-  bubbleTime: {
-    marginTop: 2,
+  bubbleMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
     alignSelf: 'flex-end',
+    marginTop: 2,
+  },
+  bubbleTime: {
+  },
+  readIndicator: {
+    marginLeft: 4,
   },
   footer: {
     flexDirection: 'row',

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -3,6 +3,7 @@ import {
   FlatList,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   StyleSheet,
   View,
 } from 'react-native';
@@ -68,22 +69,31 @@ export default function ChatScreen({ route }: { route: any }) {
 
   const isReadOnly = taskStatus === 'COMPLETED';
 
-  // Set header dynamically
+  // Set header dynamically — avatar tap navigates to public profile
   useEffect(() => {
     navigation.setOptions({
       title: taskTitle || 'Chat',
-      headerRight: () =>
-        recipientAvatar ? (
-          <Avatar.Image size={32} source={{ uri: recipientAvatar }} style={{ marginRight: spacing.md }} />
-        ) : (
-          <Avatar.Icon
-            size={32}
-            icon="account"
-            style={{ backgroundColor: brandColors.primaryMuted, marginRight: spacing.md }}
-          />
-        ),
+      headerRight: () => (
+        <Pressable
+          onPress={() => {
+            if (recipientId) {
+              (navigation as unknown as { navigate: (s: string, p: object) => void }).navigate('PublicProfile', { userId: recipientId });
+            }
+          }}
+        >
+          {recipientAvatar ? (
+            <Avatar.Image size={32} source={{ uri: recipientAvatar }} style={{ marginRight: spacing.md }} />
+          ) : (
+            <Avatar.Icon
+              size={32}
+              icon="account"
+              style={{ backgroundColor: brandColors.primaryMuted, marginRight: spacing.md }}
+            />
+          )}
+        </Pressable>
+      ),
     });
-  }, [navigation, taskTitle, recipientAvatar]);
+  }, [navigation, taskTitle, recipientAvatar, recipientId]);
 
   // Fetch current user's DB ID only when not provided via nav params (used for optimistic bubble recipient_id)
   useEffect(() => {
@@ -233,11 +243,19 @@ export default function ChatScreen({ route }: { route: any }) {
           return (
             <View style={[styles.bubbleRow, isMine ? styles.bubbleRowRight : styles.bubbleRowLeft]}>
               {!isMine && (
-                recipientAvatar ? (
-                  <Avatar.Image size={28} source={{ uri: recipientAvatar }} style={styles.bubbleAvatar} />
-                ) : (
-                  <Avatar.Icon size={28} icon="account" style={[styles.bubbleAvatar, { backgroundColor: brandColors.primaryMuted }]} />
-                )
+                <Pressable
+                  onPress={() => {
+                    if (recipientId) {
+                      (navigation as unknown as { navigate: (s: string, p: object) => void }).navigate('PublicProfile', { userId: recipientId });
+                    }
+                  }}
+                >
+                  {recipientAvatar ? (
+                    <Avatar.Image size={28} source={{ uri: recipientAvatar }} style={styles.bubbleAvatar} />
+                  ) : (
+                    <Avatar.Icon size={28} icon="account" style={[styles.bubbleAvatar, { backgroundColor: brandColors.primaryMuted }]} />
+                  )}
+                </Pressable>
               )}
               <View style={[styles.bubble, isMine ? styles.bubbleMine : styles.bubbleTheirs]}>
                 <Text style={[styles.bubbleText, { color: isMine ? brandColors.white : brandColors.textPrimary }]}>

--- a/frontend/src/screens/ConversationListScreen.tsx
+++ b/frontend/src/screens/ConversationListScreen.tsx
@@ -86,16 +86,23 @@ export default function ConversationListScreen() {
               })
             }
           >
-            {/* Avatar */}
-            {other?.avatar_url ? (
-              <Avatar.Image size={48} source={{ uri: other.avatar_url }} />
-            ) : (
-              <Avatar.Icon
-                size={48}
-                icon="account"
-                style={{ backgroundColor: brandColors.primaryMuted }}
-              />
-            )}
+            {/* Avatar — tap to view public profile */}
+            <Pressable
+              onPress={(e) => {
+                e.stopPropagation();
+                if (other?.id) navigation.navigate('PublicProfile', { userId: other.id });
+              }}
+            >
+              {other?.avatar_url ? (
+                <Avatar.Image size={48} source={{ uri: other.avatar_url }} />
+              ) : (
+                <Avatar.Icon
+                  size={48}
+                  icon="account"
+                  style={{ backgroundColor: brandColors.primaryMuted }}
+                />
+              )}
+            </Pressable>
 
             {/* Content */}
             <View style={styles.content}>

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -3,16 +3,19 @@ import {
   Alert,
   Image,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
   View,
   useWindowDimensions,
 } from 'react-native';
-import { Avatar, Text } from 'react-native-paper';
+import { Avatar, Divider, Switch, Text } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useFocusEffect } from '@react-navigation/native';
 import * as ImagePicker from 'expo-image-picker';
+import * as Notifications from 'expo-notifications';
+import Constants from 'expo-constants';
 import api from '../api/axiosInstance';
 import { uploadImage } from '../utils/uploadImage';
 import { FButton, FCard, FChip, FInput } from '../components/ui';
@@ -71,6 +74,8 @@ export default function FixerProfileScreen() {
   const [uploadingAvatar, setUploadingAvatar] = useState(false);
   const [uploadingPortfolio, setUploadingPortfolio] = useState(false);
   const [viewingAvatar, setViewingAvatar] = useState(false);
+  const [pushEnabled, setPushEnabled] = useState(false);
+  const [pushLoading, setPushLoading] = useState(false);
 
   const fetchProfile = React.useCallback(async () => {
     try {
@@ -423,6 +428,54 @@ export default function FixerProfileScreen() {
               >
                 Save Profile
               </FButton>
+
+              <Divider style={{ marginVertical: spacing.lg, backgroundColor: brandColors.outlineLight }} />
+
+              <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.md, flex: 1 }}>
+                  <View style={styles.sectionIcon}>
+                    <MaterialCommunityIcons name="bell-outline" size={18} color={brandColors.primary} />
+                  </View>
+                  <View style={{ flex: 1 }}>
+                    <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>
+                      Push Notifications
+                    </Text>
+                    <Text style={[typography.caption, { color: brandColors.textMuted }]}>
+                      Bid updates, messages, and task alerts
+                    </Text>
+                  </View>
+                </View>
+                <Switch
+                  value={pushEnabled}
+                  onValueChange={async (value) => {
+                    if (Platform.OS === 'web') {
+                      // On web, toggle locally (push tokens only work on mobile)
+                      setPushEnabled(value);
+                      return;
+                    }
+                    if (!value) { setPushEnabled(false); return; }
+                    setPushLoading(true);
+                    try {
+                      const { status } = await Notifications.requestPermissionsAsync();
+                      if (status !== 'granted') {
+                        Alert.alert('Permission denied', 'Enable notifications in your device settings.');
+                        return;
+                      }
+                      const projectId = Constants.expoConfig?.extra?.eas?.projectId as string;
+                      const tokenData = await Notifications.getExpoPushTokenAsync({ projectId });
+                      await api.post('/api/users/me/push-token', { token: tokenData.data });
+                      setPushEnabled(true);
+                    } catch (err) {
+                      Alert.alert('Error', err instanceof Error ? err.message : String(err));
+                    } finally {
+                      setPushLoading(false);
+                    }
+                  }}
+                  disabled={pushLoading}
+                  trackColor={{ true: brandColors.primary, false: brandColors.outlineLight }}
+                  thumbColor={brandColors.white}
+                />
+              </View>
             </FCard>
 
             <FCard style={styles.section} shadow="sm">

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -33,7 +33,8 @@ export default function SettingsScreen() {
 
   const handlePushToggle = async (value: boolean) => {
     if (Platform.OS === 'web') {
-      Alert.alert('Not supported', 'Push notifications are only available on mobile devices.');
+      // On web, toggle locally (push tokens only work on mobile)
+      setPushEnabled(value);
       return;
     }
     if (!value) {


### PR DESCRIPTION
## Summary
- Real-time read receipts for chat — sender sees ✓✓ blue when messages are read
- Messages tab with unread badge in both Requester and Fixer navigation bars
- Desktop nav redesign: icon on top + label below for all workspace tabs
- Avatar tap in chat → navigates to fixer's public profile
- Fix conversations endpoint to show correct names and include pending-bid fixers
- Push notification toggle in both Settings and Fixer Profile screens
- Remove `NEW_MESSAGE` from bell notifications (moved to dedicated Messages badge)

## Changes
### Backend
- `socket/index.ts` — `getIO()` export, `mark_read` event with `messages_read` broadcast
- `routes/messages.ts` — emit `messages_read` from REST endpoint, fix conversations query to include pending-bid fixers with correct `otherParty` names

### Frontend
- `hooks/useUnreadMessages.ts` — new hook tracking total unread message count
- `AppNavigator.tsx` — Messages tab in desktop nav, icon+label vertical layout
- `RequesterTabs.tsx` / `FixerTabs.tsx` — Messages tab badge
- `ChatScreen.tsx` — listen for `messages_read`, read indicators, avatar tap → profile
- `ConversationListScreen.tsx` — avatar tap → public profile
- `FixerProfileScreen.tsx` — push notification toggle
- `SettingsScreen.tsx` — fix web push toggle
- `NotificationContext.tsx` — remove `NEW_MESSAGE` from bell types

### Tests
- Backend: 4 new tests (read receipt idempotency, fixer conversations, correct names)
- Frontend: 5 new tests for `useUnreadMessages` hook

## Test plan
- [x] Backend tests pass (169/171 — 2 pre-existing Google Maps failures unrelated)
- [x] Frontend tests pass (118/118)
- [ ] Open chat as User A, send messages → User B opens chat → User A sees ✓✓ blue
- [ ] Messages tab shows unread badge count in both modes
- [ ] Tap avatar in chat → navigates to public profile
- [ ] Push notification toggle works (on/off)
- [ ] Bell icon no longer shows NEW_MESSAGE notifications

