### PR TITLE
feat: UI polish — misc improvements 

### DIFF
--- a/backend/src/__tests__/routes/messages.test.ts
+++ b/backend/src/__tests__/routes/messages.test.ts
@@ -474,4 +474,71 @@ describe('GET /api/conversations', () => {
       .set('Authorization', FIXER_AUTH);
     expect(fixRes.body.conversations[0].otherParty?.full_name).toBe('Requester');
   });
+
+  it('filters conversations by mode=requester', async () => {
+    const task = await createTaskInProgress();
+    await seedMessages(task.id);
+
+    // Requester in requester mode sees conversations (they own the task)
+    __setUid('requester-uid');
+    const res = await request(app)
+      .get('/api/conversations?mode=requester')
+      .set('Authorization', REQUESTER_AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toHaveLength(1);
+
+    // Fixer in requester mode sees nothing (they don't own the task)
+    __setUid('fixer-uid');
+    const fixRes = await request(app)
+      .get('/api/conversations?mode=requester')
+      .set('Authorization', FIXER_AUTH);
+    expect(fixRes.status).toBe(200);
+    expect(fixRes.body.conversations).toHaveLength(0);
+  });
+
+  it('filters conversations by mode=fixer', async () => {
+    const task = await createTaskInProgress();
+    await seedMessages(task.id);
+
+    // Fixer in fixer mode sees conversations (they are not the requester)
+    __setUid('fixer-uid');
+    const res = await request(app)
+      .get('/api/conversations?mode=fixer')
+      .set('Authorization', FIXER_AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toHaveLength(1);
+
+    // Requester in fixer mode sees nothing (they own the task)
+    __setUid('requester-uid');
+    const reqRes = await request(app)
+      .get('/api/conversations?mode=fixer')
+      .set('Authorization', REQUESTER_AUTH);
+    expect(reqRes.status).toBe(200);
+    expect(reqRes.body.conversations).toHaveLength(0);
+  });
+});
+
+// ── Messages deleted on task completion ──────────────────────────────────────
+
+describe('Task completion deletes messages', () => {
+  it('deletes all messages when requester marks task as COMPLETED', async () => {
+    const task = await createTaskInProgress();
+    await seedMessages(task.id);
+
+    // Verify messages exist
+    const before = await prisma.message.count({ where: { task_id: task.id } });
+    expect(before).toBe(3);
+
+    // Complete the task
+    __setUid('requester-uid');
+    const res = await request(app)
+      .put(`/api/tasks/${task.id}/status`)
+      .set('Authorization', REQUESTER_AUTH)
+      .send({ status: 'COMPLETED' });
+    expect(res.status).toBe(200);
+
+    // Messages should be gone
+    const after = await prisma.message.count({ where: { task_id: task.id } });
+    expect(after).toBe(0);
+  });
 });

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -81,6 +81,7 @@ router.get('/conversations', async (req: Request, res: Response, next: NextFunct
           take: 1,
           include: {
             sender: { select: { id: true, full_name: true, avatar_url: true } },
+            recipient: { select: { id: true, full_name: true, avatar_url: true } },
           },
         },
       },
@@ -101,18 +102,18 @@ router.get('/conversations', async (req: Request, res: Response, next: NextFunct
 
     const conversations = tasks
       .map((task) => {
-        // Determine the other party: if user is requester, show fixer (or last message sender)
-        // If user is fixer/bidder, show requester
+        // Determine the other party
         let otherParty: { id: string; full_name: string; avatar_url: string | null } | null = null;
+        const lastMsg = task.messages[0];
         if (task.requester_id === userId) {
-          otherParty = task.fixer ?? task.messages[0]?.sender ?? null;
+          // User is requester — show fixer, or message counterpart
+          otherParty = task.fixer ?? (lastMsg?.sender?.id !== userId ? lastMsg?.sender : lastMsg?.recipient) ?? null;
         } else {
           otherParty = task.requester;
         }
-        // Make sure we don't show ourselves as the "other party"
-        if (otherParty?.id === userId && task.messages[0]?.sender) {
-          // Last message was from us — look at recipient side
-          otherParty = task.requester_id === userId ? task.fixer : task.requester;
+        // Final safety: never show ourselves
+        if (otherParty?.id === userId) {
+          otherParty = lastMsg?.sender?.id !== userId ? lastMsg?.sender ?? null : lastMsg?.recipient ?? null;
         }
 
         const lastMessage = task.messages[0] ?? null;

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -49,13 +49,24 @@ router.get('/tasks/:id/messages', async (req: Request, res: Response, next: Next
 });
 
 // GET /api/conversations — conversation summaries for the authenticated user (sorted by most recent)
+// Optional query param: ?mode=requester|fixer — filters by role in the task
 router.get('/conversations', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const userId = req.user!.id;
+    const mode = req.query.mode as string | undefined;
+
+    // Build role filter based on mode
+    const roleFilter =
+      mode === 'requester'
+        ? { requester_id: userId }
+        : mode === 'fixer'
+          ? { NOT: { requester_id: userId } }
+          : {};
 
     // Find all tasks where the user has sent or received messages
     const tasks = await prisma.task.findMany({
       where: {
+        ...roleFilter,
         messages: {
           some: {
             OR: [{ sender_id: userId }, { recipient_id: userId }],

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -451,9 +451,13 @@ router.put('/:id/status', validate(updateTaskStatusSchema), async (req: Request,
         );
       }
     } else if (task.status === 'IN_PROGRESS' && newStatus === 'COMPLETED') {
-      await prisma.task.update({
-        where: { id: task.id },
-        data: { status: 'COMPLETED', completed_at: new Date() },
+      await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        await tx.task.update({
+          where: { id: task.id },
+          data: { status: 'COMPLETED', completed_at: new Date() },
+        });
+        // Delete chat messages once the task is completed
+        await tx.message.deleteMany({ where: { task_id: task.id } });
       });
 
       if (task.assigned_fixer_id) {

--- a/frontend/src/components/AppLogo.tsx
+++ b/frontend/src/components/AppLogo.tsx
@@ -110,8 +110,8 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
   markCompact: {
-    width: 44,
-    aspectRatio: MARK_ASPECT_RATIO,
+    width: 32,
+    height: 32,
   },
   markStandalone: {
     width: 96,
@@ -135,10 +135,10 @@ const styles = StyleSheet.create({
     lineHeight: 36,
   },
   wordmarkCompact: {
-    fontSize: 17,
+    fontSize: 22,
     fontWeight: '800',
     letterSpacing: 0,
-    lineHeight: 20,
+    lineHeight: 26,
   },
   tagline: {
     marginTop: 2,
@@ -148,9 +148,9 @@ const styles = StyleSheet.create({
   },
   taglineCompact: {
     marginTop: 1,
-    fontSize: 7,
-    fontWeight: '600',
-    letterSpacing: 0.9,
+    fontSize: 8,
+    fontWeight: '700',
+    letterSpacing: 1,
   },
   heroSilhouette: {
     width: 460,

--- a/frontend/src/components/AppLogo.tsx
+++ b/frontend/src/components/AppLogo.tsx
@@ -43,7 +43,7 @@ export default function AppLogo({
   const wordmark = (
     <View style={[styles.textStack, !compact && styles.textStackCentered]}>
       <Text style={[compact ? styles.wordmarkCompact : styles.wordmark, { color: wordmarkColor }]}>
-        Fix<Text style={{ color: brandColors.secondary }}>I</Text>t
+        Fix<Text style={{ color: brandColors.secondaryDark }}>I</Text>t
       </Text>
       {showTagline && (
         <Text style={[compact ? styles.taglineCompact : styles.tagline, { color: taglineColor }]}>

--- a/frontend/src/components/AppLogo.tsx
+++ b/frontend/src/components/AppLogo.tsx
@@ -43,7 +43,7 @@ export default function AppLogo({
   const wordmark = (
     <View style={[styles.textStack, !compact && styles.textStackCentered]}>
       <Text style={[compact ? styles.wordmarkCompact : styles.wordmark, { color: wordmarkColor }]}>
-        FixIt
+        Fix<Text style={{ color: brandColors.secondary }}>i</Text>t
       </Text>
       {showTagline && (
         <Text style={[compact ? styles.taglineCompact : styles.tagline, { color: taglineColor }]}>

--- a/frontend/src/components/AppLogo.tsx
+++ b/frontend/src/components/AppLogo.tsx
@@ -43,7 +43,7 @@ export default function AppLogo({
   const wordmark = (
     <View style={[styles.textStack, !compact && styles.textStackCentered]}>
       <Text style={[compact ? styles.wordmarkCompact : styles.wordmark, { color: wordmarkColor }]}>
-        Fix<Text style={{ color: brandColors.secondaryDark }}>I</Text>t
+        Fix<Text style={{ color: brandColors.secondaryDark, fontWeight: '900' }}>I</Text>t
       </Text>
       {showTagline && (
         <Text style={[compact ? styles.taglineCompact : styles.tagline, { color: taglineColor }]}>

--- a/frontend/src/components/AppLogo.tsx
+++ b/frontend/src/components/AppLogo.tsx
@@ -43,7 +43,7 @@ export default function AppLogo({
   const wordmark = (
     <View style={[styles.textStack, !compact && styles.textStackCentered]}>
       <Text style={[compact ? styles.wordmarkCompact : styles.wordmark, { color: wordmarkColor }]}>
-        Fix<Text style={{ color: brandColors.secondary }}>i</Text>t
+        Fix<Text style={{ color: brandColors.secondary }}>I</Text>t
       </Text>
       {showTagline && (
         <Text style={[compact ? styles.taglineCompact : styles.tagline, { color: taglineColor }]}>

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -41,6 +41,8 @@ interface FilterBarProps {
   hasActiveFilters?: boolean;
   onClearFilters?: () => void;
   compact?: boolean;
+  /** When true, force the filter panel open externally */
+  forceExpanded?: boolean;
 }
 
 // --- Single-thumb slider for distance ---
@@ -237,10 +239,12 @@ export default function FilterBar({
   hasActiveFilters = false,
   onClearFilters,
   compact,
+  forceExpanded,
 }: FilterBarProps) {
   const { width } = useWindowDimensions();
   const isCompact = compact ?? (Platform.OS === 'web' && width >= 900);
   const [expanded, setExpanded] = useState(false);
+  const isExpanded = forceExpanded || expanded;
   const budgetSummary =
     priceMin === PRICE_MIN && priceMax >= PRICE_MAX
       ? 'Budget: Any'
@@ -294,17 +298,17 @@ export default function FilterBar({
 
         {/* Expand/collapse button for sliders */}
         <Pressable
-          style={[styles.filterToggle, isCompact && styles.filterToggleCompact, expanded && styles.filterToggleActive]}
+          style={[styles.filterToggle, isCompact && styles.filterToggleCompact, isExpanded && styles.filterToggleActive]}
           onPress={() => setExpanded((p) => !p)}
           accessibilityRole="button"
           accessibilityLabel="Adjust distance and budget filters"
-          accessibilityState={{ expanded }}
+          accessibilityState={{ expanded: isExpanded }}
         >
-          <Feather name="sliders" size={14} color={expanded ? brandColors.primary : brandColors.textMuted} />
-          <Text style={[typography.caption, { color: expanded ? brandColors.primary : brandColors.textMuted }]}>
+          <Feather name="sliders" size={14} color={isExpanded ? brandColors.primary : brandColors.textMuted} />
+          <Text style={[typography.caption, { color: isExpanded ? brandColors.primary : brandColors.textMuted }]}>
             {radius} km · {budgetSummary}
           </Text>
-          <Feather name={expanded ? 'chevron-up' : 'chevron-down'} size={14} color={brandColors.textMuted} />
+          <Feather name={isExpanded ? 'chevron-up' : 'chevron-down'} size={14} color={brandColors.textMuted} />
         </Pressable>
 
         {hasActiveFilters && onClearFilters && (
@@ -334,7 +338,7 @@ export default function FilterBar({
       </ScrollView>
 
       {/* Expandable slider panel */}
-      {expanded && (
+      {isExpanded && (
         <View style={[styles.sliderPanel, isCompact && styles.sliderPanelCompact]}>
           <DistanceSlider value={radius} onChange={onRadiusChange} />
           <PriceRangeSlider minValue={priceMin} maxValue={priceMax} onChange={onPriceChange} />

--- a/frontend/src/context/AccessibilityContext.tsx
+++ b/frontend/src/context/AccessibilityContext.tsx
@@ -67,7 +67,6 @@ function injectWebStyles() {
     html.a11y-high-contrast #root * {
       color: #fff !important;
       border-color: #555 !important;
-      background-color: transparent !important;
     }
     html.a11y-high-contrast #root [role="banner"],
     html.a11y-high-contrast #root [role="navigation"],

--- a/frontend/src/context/AccessibilityContext.tsx
+++ b/frontend/src/context/AccessibilityContext.tsx
@@ -68,6 +68,15 @@ function injectWebStyles() {
       color: #fff !important;
       border-color: #555 !important;
     }
+    /* Preserve hidden/inactive screens */
+    html.a11y-high-contrast #root [aria-hidden="true"],
+    html.a11y-high-contrast #root [style*="display: none"],
+    html.a11y-high-contrast #root [style*="display:none"] {
+      display: none !important;
+    }
+    html.a11y-high-contrast #root [style*="opacity: 0"] {
+      opacity: 0 !important;
+    }
     html.a11y-high-contrast #root [role="banner"],
     html.a11y-high-contrast #root [role="navigation"],
     html.a11y-high-contrast #root [data-testid] {

--- a/frontend/src/navigation/FixerTabs.tsx
+++ b/frontend/src/navigation/FixerTabs.tsx
@@ -67,6 +67,7 @@ export default function FixerTabs() {
       <Tab.Screen
         name="Messages"
         component={ConversationListScreen}
+        initialParams={{ mode: 'fixer' }}
         options={{
           tabBarLabel: 'Messages',
           tabBarBadge: unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : undefined,

--- a/frontend/src/navigation/RequesterTabs.tsx
+++ b/frontend/src/navigation/RequesterTabs.tsx
@@ -71,6 +71,7 @@ export default function RequesterTabs() {
       <Tab.Screen
         name="Messages"
         component={ConversationListScreen}
+        initialParams={{ mode: 'requester' }}
         options={{
           tabBarLabel: 'Messages',
           tabBarBadge: unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : undefined,

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -69,10 +69,20 @@ export default function ChatScreen({ route }: { route: any }) {
 
   const isReadOnly = taskStatus === 'COMPLETED';
 
-  // Set header dynamically — avatar tap navigates to public profile
+  // Set header dynamically — title tap opens task, avatar tap navigates to public profile
   useEffect(() => {
     navigation.setOptions({
-      title: taskTitle || 'Chat',
+      headerTitle: () => (
+        <Pressable
+          onPress={() => {
+            (navigation as unknown as { navigate: (s: string, p: object) => void }).navigate('TaskDetails', { taskId });
+          }}
+        >
+          <Text style={{ fontSize: 17, fontWeight: '600', color: brandColors.textPrimary }} numberOfLines={1}>
+            {taskTitle || 'Chat'}
+          </Text>
+        </Pressable>
+      ),
       headerRight: () => (
         <Pressable
           onPress={() => {
@@ -93,7 +103,7 @@ export default function ChatScreen({ route }: { route: any }) {
         </Pressable>
       ),
     });
-  }, [navigation, taskTitle, recipientAvatar, recipientId]);
+  }, [navigation, taskId, taskTitle, recipientAvatar, recipientId]);
 
   // Fetch current user's DB ID only when not provided via nav params (used for optimistic bubble recipient_id)
   useEffect(() => {

--- a/frontend/src/screens/ConversationListScreen.tsx
+++ b/frontend/src/screens/ConversationListScreen.tsx
@@ -33,22 +33,24 @@ function formatTime(dateStr: string): string {
   return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
-export default function ConversationListScreen() {
+export default function ConversationListScreen({ route }: { route?: { params?: { mode?: string } } }) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const navigation = useNavigation<any>();
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
+  const mode = route?.params?.mode;
 
   const load = useCallback(async () => {
     try {
-      const res = await api.get('/api/conversations');
+      const params = mode ? { mode } : {};
+      const res = await api.get('/api/conversations', { params });
       setConversations(res.data.conversations ?? []);
     } catch {
       // non-fatal
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [mode]);
 
   useFocusEffect(useCallback(() => {
     setLoading(true);

--- a/frontend/src/screens/DiscoveryFeedScreen.tsx
+++ b/frontend/src/screens/DiscoveryFeedScreen.tsx
@@ -58,7 +58,7 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
   const [searchFocused, setSearchFocused] = useState(false);
   const [fixerGps, setFixerGps] = useState<{ lat: number; lng: number } | null>(null);
   const [bidTaskIds, setBidTaskIds] = useState<Set<string>>(new Set());
-  const [bidFilter, setBidFilter] = useState<'has_bid' | null>(null);
+  const [bidFilter, setBidFilter] = useState<'has_bid' | 'no_bid' | null>(null);
   const [showFilterPanel, setShowFilterPanel] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
@@ -105,9 +105,11 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
     if (selectedCategories.length > 1) {
       filtered = filtered.filter((t) => selectedCategories.includes(t.category));
     }
-    // Apply bid filter from stats pill
+    // Apply bid filter from stats pills
     if (bidFilter === 'has_bid') {
       filtered = filtered.filter((t) => bidTaskIds.has(t.id));
+    } else if (bidFilter === 'no_bid') {
+      filtered = filtered.filter((t) => !bidTaskIds.has(t.id));
     }
     return filtered;
   }, [rawTasks, selectedCategories, currentUserId, bidFilter, bidTaskIds]);
@@ -455,6 +457,13 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
             <Text style={styles.workspaceStatValue}>{loading ? '...' : rawTasks.filter((t) => !currentUserId || t.requesterId !== currentUserId).length}</Text>
             <Text style={styles.workspaceStatLabel}>Open jobs</Text>
           </View>
+          <Pressable
+            style={[styles.workspaceStat, bidFilter === 'no_bid' && styles.workspaceStatActive]}
+            onPress={() => setBidFilter(bidFilter === 'no_bid' ? null : 'no_bid')}
+          >
+            <Text style={styles.workspaceStatValue}>{loading ? '...' : rawTasks.filter((t) => (!currentUserId || t.requesterId !== currentUserId) && !bidTaskIds.has(t.id)).length}</Text>
+            <Text style={styles.workspaceStatLabel}>New</Text>
+          </Pressable>
           <Pressable
             style={[styles.workspaceStat, bidFilter === 'has_bid' && styles.workspaceStatActive]}
             onPress={() => setBidFilter(bidFilter === 'has_bid' ? null : 'has_bid')}

--- a/frontend/src/screens/DiscoveryFeedScreen.tsx
+++ b/frontend/src/screens/DiscoveryFeedScreen.tsx
@@ -58,6 +58,8 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
   const [searchFocused, setSearchFocused] = useState(false);
   const [fixerGps, setFixerGps] = useState<{ lat: number; lng: number } | null>(null);
   const [bidTaskIds, setBidTaskIds] = useState<Set<string>>(new Set());
+  const [bidFilter, setBidFilter] = useState<'has_bid' | 'no_bid' | null>(null);
+  const [showFilterPanel, setShowFilterPanel] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
   // Fetch current user ID once on mount to filter out own tasks
@@ -103,8 +105,14 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
     if (selectedCategories.length > 1) {
       filtered = filtered.filter((t) => selectedCategories.includes(t.category));
     }
+    // Apply bid filter from stats pills
+    if (bidFilter === 'has_bid') {
+      filtered = filtered.filter((t) => bidTaskIds.has(t.id));
+    } else if (bidFilter === 'no_bid') {
+      filtered = filtered.filter((t) => !bidTaskIds.has(t.id));
+    }
     return filtered;
-  }, [rawTasks, selectedCategories, currentUserId]);
+  }, [rawTasks, selectedCategories, currentUserId, bidFilter, bidTaskIds]);
 
   const selectedTask = useMemo(
     () => tasks.find((task) => task.id === selectedTaskId) ?? null,
@@ -445,18 +453,27 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
         </View>
 
         <View style={[styles.workspaceStats, isWide && styles.workspaceStatsWide]}>
-          <View style={styles.workspaceStat}>
+          <Pressable
+            style={[styles.workspaceStat, bidFilter === 'no_bid' && styles.workspaceStatActive]}
+            onPress={() => setBidFilter(bidFilter === 'no_bid' ? null : 'no_bid')}
+          >
             <Text style={styles.workspaceStatValue}>{loading ? '...' : tasks.length}</Text>
             <Text style={styles.workspaceStatLabel}>Open jobs</Text>
-          </View>
-          <View style={styles.workspaceStat}>
+          </Pressable>
+          <Pressable
+            style={[styles.workspaceStat, bidFilter === 'has_bid' && styles.workspaceStatActive]}
+            onPress={() => setBidFilter(bidFilter === 'has_bid' ? null : 'has_bid')}
+          >
             <Text style={styles.workspaceStatValue}>{bidTaskIds.size}</Text>
             <Text style={styles.workspaceStatLabel}>Active bids</Text>
-          </View>
-          <View style={styles.workspaceStat}>
+          </Pressable>
+          <Pressable
+            style={[styles.workspaceStat, showFilterPanel && styles.workspaceStatActive]}
+            onPress={() => setShowFilterPanel(!showFilterPanel)}
+          >
             <Text style={styles.workspaceStatValue}>{radius} km</Text>
             <Text style={styles.workspaceStatLabel}>Range</Text>
-          </View>
+          </Pressable>
         </View>
       </View>
 
@@ -473,6 +490,7 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
         onPriceChange={(min, max) => { setPriceMin(min); setPriceMax(max); }}
         hasActiveFilters={hasActiveFilters}
         onClearFilters={handleClearFilters}
+        forceExpanded={showFilterPanel}
       />
 
       {/* Work-area search uses Google Places on web; native keeps GPS/default centers only. */}
@@ -752,6 +770,11 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(255,252,246,0.08)',
     borderWidth: 1,
     borderColor: 'rgba(255,252,246,0.14)',
+  },
+  workspaceStatActive: {
+    borderColor: brandColors.secondary,
+    borderWidth: 2,
+    backgroundColor: 'rgba(241,181,69,0.12)',
   },
   workspaceStatValue: {
     fontSize: 16,

--- a/frontend/src/screens/DiscoveryFeedScreen.tsx
+++ b/frontend/src/screens/DiscoveryFeedScreen.tsx
@@ -58,7 +58,7 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
   const [searchFocused, setSearchFocused] = useState(false);
   const [fixerGps, setFixerGps] = useState<{ lat: number; lng: number } | null>(null);
   const [bidTaskIds, setBidTaskIds] = useState<Set<string>>(new Set());
-  const [bidFilter, setBidFilter] = useState<'has_bid' | 'no_bid' | null>(null);
+  const [bidFilter, setBidFilter] = useState<'has_bid' | null>(null);
   const [showFilterPanel, setShowFilterPanel] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
@@ -105,11 +105,9 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
     if (selectedCategories.length > 1) {
       filtered = filtered.filter((t) => selectedCategories.includes(t.category));
     }
-    // Apply bid filter from stats pills
+    // Apply bid filter from stats pill
     if (bidFilter === 'has_bid') {
       filtered = filtered.filter((t) => bidTaskIds.has(t.id));
-    } else if (bidFilter === 'no_bid') {
-      filtered = filtered.filter((t) => !bidTaskIds.has(t.id));
     }
     return filtered;
   }, [rawTasks, selectedCategories, currentUserId, bidFilter, bidTaskIds]);
@@ -453,19 +451,16 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
         </View>
 
         <View style={[styles.workspaceStats, isWide && styles.workspaceStatsWide]}>
-          <Pressable
-            style={[styles.workspaceStat, bidFilter === 'no_bid' && styles.workspaceStatActive]}
-            onPress={() => setBidFilter(bidFilter === 'no_bid' ? null : 'no_bid')}
-          >
-            <Text style={styles.workspaceStatValue}>{loading ? '...' : tasks.length}</Text>
+          <View style={styles.workspaceStat}>
+            <Text style={styles.workspaceStatValue}>{loading ? '...' : rawTasks.filter((t) => !currentUserId || t.requesterId !== currentUserId).length}</Text>
             <Text style={styles.workspaceStatLabel}>Open jobs</Text>
-          </Pressable>
+          </View>
           <Pressable
             style={[styles.workspaceStat, bidFilter === 'has_bid' && styles.workspaceStatActive]}
             onPress={() => setBidFilter(bidFilter === 'has_bid' ? null : 'has_bid')}
           >
             <Text style={styles.workspaceStatValue}>{bidTaskIds.size}</Text>
-            <Text style={styles.workspaceStatLabel}>Active bids</Text>
+            <Text style={styles.workspaceStatLabel}>Already bid</Text>
           </Pressable>
           <Pressable
             style={[styles.workspaceStat, showFilterPanel && styles.workspaceStatActive]}

--- a/frontend/src/screens/MyTasksScreen.tsx
+++ b/frontend/src/screens/MyTasksScreen.tsx
@@ -53,7 +53,7 @@ export default function MyTasksScreen({ navigation }: Props) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [filter, setFilter] = useState<'open' | 'in_progress' | 'bids' | 'review' | null>(null);
+  const [filter, setFilter] = useState<'in_progress' | 'review' | null>(null);
   const { width } = useWindowDimensions();
 
   const wide = width >= 820;
@@ -248,15 +248,11 @@ export default function MyTasksScreen({ navigation }: Props) {
   const reviewCount = pastTasks.filter((task) => task.status === 'COMPLETED' && !task.has_review).length;
 
   // Apply pill filter
-  const filteredActiveTasks = filter === 'open'
-    ? activeTasks.filter((t) => t.status === 'OPEN')
-    : filter === 'in_progress'
-      ? activeTasks.filter((t) => t.status === 'IN_PROGRESS')
-      : filter === 'bids'
-        ? activeTasks.filter((t) => (t.bid_count || 0) > 0)
-        : filter === 'review'
-          ? []
-          : activeTasks;
+  const filteredActiveTasks = filter === 'in_progress'
+    ? activeTasks.filter((t) => t.status === 'IN_PROGRESS')
+    : filter === 'review'
+      ? []
+      : activeTasks;
 
   const filteredPastTasks = filter === 'review'
     ? pastTasks.filter((t) => t.status === 'COMPLETED' && !t.has_review)
@@ -468,8 +464,8 @@ function WorkspaceHeader({
   inProgressCount: number;
   pendingBidCount: number;
   reviewCount: number;
-  activeFilter: 'open' | 'in_progress' | 'bids' | 'review' | null;
-  onPillPress: (filter: 'open' | 'in_progress' | 'bids' | 'review') => void;
+  activeFilter: 'in_progress' | 'review' | null;
+  onPillPress: (filter: 'in_progress' | 'review') => void;
 }) {
   return (
     <LinearGradient
@@ -496,8 +492,6 @@ function WorkspaceHeader({
           value={openTasksCount}
           color={brandColors.success}
           wide={wide}
-          active={activeFilter === 'open'}
-          onPress={() => onPillPress('open')}
         />
         <SummaryPill
           icon="progress-wrench"
@@ -514,8 +508,6 @@ function WorkspaceHeader({
           value={pendingBidCount}
           color={brandColors.secondaryLight}
           wide={wide}
-          active={activeFilter === 'bids'}
-          onPress={() => onPillPress('bids')}
         />
         <SummaryPill
           icon="star-outline"

--- a/frontend/src/screens/MyTasksScreen.tsx
+++ b/frontend/src/screens/MyTasksScreen.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import {
   Alert,
   Platform,
+  Pressable,
   RefreshControl,
   ScrollView,
   StyleSheet,
@@ -52,6 +53,7 @@ export default function MyTasksScreen({ navigation }: Props) {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<'open' | 'in_progress' | 'bids' | 'review' | null>(null);
   const { width } = useWindowDimensions();
 
   const wide = width >= 820;
@@ -245,6 +247,23 @@ export default function MyTasksScreen({ navigation }: Props) {
   const pendingBidCount = activeTasks.reduce((sum, task) => sum + (task.bid_count || 0), 0);
   const reviewCount = pastTasks.filter((task) => task.status === 'COMPLETED' && !task.has_review).length;
 
+  // Apply pill filter
+  const filteredActiveTasks = filter === 'open'
+    ? activeTasks.filter((t) => t.status === 'OPEN')
+    : filter === 'in_progress'
+      ? activeTasks.filter((t) => t.status === 'IN_PROGRESS')
+      : filter === 'bids'
+        ? activeTasks.filter((t) => (t.bid_count || 0) > 0)
+        : filter === 'review'
+          ? []
+          : activeTasks;
+
+  const filteredPastTasks = filter === 'review'
+    ? pastTasks.filter((t) => t.status === 'COMPLETED' && !t.has_review)
+    : filter != null
+      ? []
+      : pastTasks;
+
   if (loading) return <LoadingScreen label="Loading your tasks..." />;
 
   if (loadError && tasks.length === 0) {
@@ -269,6 +288,8 @@ export default function MyTasksScreen({ navigation }: Props) {
               inProgressCount={0}
               pendingBidCount={0}
               reviewCount={0}
+              activeFilter={filter}
+              onPillPress={(f) => setFilter(filter === f ? null : f)}
             />
             <View style={styles.emptyPanel}>
               <EmptyState
@@ -307,6 +328,8 @@ export default function MyTasksScreen({ navigation }: Props) {
               inProgressCount={0}
               pendingBidCount={0}
               reviewCount={0}
+              activeFilter={filter}
+              onPillPress={(f) => setFilter(filter === f ? null : f)}
             />
             <View style={styles.emptyPanel}>
               <EmptyState
@@ -344,17 +367,19 @@ export default function MyTasksScreen({ navigation }: Props) {
             inProgressCount={inProgressCount}
             pendingBidCount={pendingBidCount}
             reviewCount={reviewCount}
+            activeFilter={filter}
+            onPillPress={(f) => setFilter(filter === f ? null : f)}
           />
           {loadError && <ErrorBanner message={loadError} onRetry={retryTasks} />}
 
           <View style={styles.section}>
             <SectionHeader
               label="Active tasks"
-              count={activeTasks.length}
+              count={filteredActiveTasks.length}
               helper="Open requests and jobs currently assigned to a Fixer."
             />
-            {activeTasks.length > 0 ? (
-              activeTasks.map((task) => (
+            {filteredActiveTasks.length > 0 ? (
+              filteredActiveTasks.map((task) => (
                 <TaskCard
                   key={task.id}
                   title={task.title}
@@ -388,12 +413,12 @@ export default function MyTasksScreen({ navigation }: Props) {
           <View style={styles.section}>
             <SectionHeader
               label="Past tasks"
-              count={pastTasks.length}
+              count={filteredPastTasks.length}
               helper="Completed and canceled work, including review and cleanup actions."
               muted
             />
-            {pastTasks.length > 0 ? (
-              pastTasks.map((task) => {
+            {filteredPastTasks.length > 0 ? (
+              filteredPastTasks.map((task) => {
                 const canReview = task.status === 'COMPLETED' && !task.has_review;
                 return (
                   <TaskCard
@@ -435,12 +460,16 @@ function WorkspaceHeader({
   inProgressCount,
   pendingBidCount,
   reviewCount,
+  activeFilter,
+  onPillPress,
 }: {
   wide: boolean;
   openTasksCount: number;
   inProgressCount: number;
   pendingBidCount: number;
   reviewCount: number;
+  activeFilter: 'open' | 'in_progress' | 'bids' | 'review' | null;
+  onPillPress: (filter: 'open' | 'in_progress' | 'bids' | 'review') => void;
 }) {
   return (
     <LinearGradient
@@ -467,6 +496,8 @@ function WorkspaceHeader({
           value={openTasksCount}
           color={brandColors.success}
           wide={wide}
+          active={activeFilter === 'open'}
+          onPress={() => onPillPress('open')}
         />
         <SummaryPill
           icon="progress-wrench"
@@ -474,6 +505,8 @@ function WorkspaceHeader({
           value={inProgressCount}
           color={brandColors.secondary}
           wide={wide}
+          active={activeFilter === 'in_progress'}
+          onPress={() => onPillPress('in_progress')}
         />
         <SummaryPill
           icon="hand-extended-outline"
@@ -481,6 +514,8 @@ function WorkspaceHeader({
           value={pendingBidCount}
           color={brandColors.secondaryLight}
           wide={wide}
+          active={activeFilter === 'bids'}
+          onPress={() => onPillPress('bids')}
         />
         <SummaryPill
           icon="star-outline"
@@ -488,6 +523,8 @@ function WorkspaceHeader({
           value={reviewCount}
           color={brandColors.warning}
           wide={wide}
+          active={activeFilter === 'review'}
+          onPress={() => onPillPress('review')}
         />
       </View>
     </LinearGradient>
@@ -500,15 +537,22 @@ function SummaryPill({
   value,
   color,
   wide,
+  active,
+  onPress,
 }: {
   icon: string;
   label: string;
   value: number;
   color: string;
   wide: boolean;
+  active?: boolean;
+  onPress?: () => void;
 }) {
   return (
-    <View style={[styles.summaryPill, wide && styles.summaryPillWide]}>
+    <Pressable
+      onPress={onPress}
+      style={[styles.summaryPill, wide && styles.summaryPillWide, active && { borderColor: color, borderWidth: 2 }]}
+    >
       <View style={styles.summaryIcon}>
         <MaterialCommunityIcons name={icon as never} size={16} color={color} />
       </View>
@@ -516,7 +560,7 @@ function SummaryPill({
         <Text style={styles.summaryValue}>{value}</Text>
         <Text style={styles.summaryLabel}>{label}</Text>
       </View>
-    </View>
+    </Pressable>
   );
 }
 

--- a/frontend/src/screens/MyTasksScreen.tsx
+++ b/frontend/src/screens/MyTasksScreen.tsx
@@ -269,7 +269,6 @@ export default function MyTasksScreen({ navigation }: Props) {
               inProgressCount={0}
               pendingBidCount={0}
               reviewCount={0}
-              onCreate={() => navigation.navigate('CreateTask')}
             />
             <View style={styles.emptyPanel}>
               <EmptyState
@@ -308,7 +307,6 @@ export default function MyTasksScreen({ navigation }: Props) {
               inProgressCount={0}
               pendingBidCount={0}
               reviewCount={0}
-              onCreate={() => navigation.navigate('CreateTask')}
             />
             <View style={styles.emptyPanel}>
               <EmptyState
@@ -346,7 +344,6 @@ export default function MyTasksScreen({ navigation }: Props) {
             inProgressCount={inProgressCount}
             pendingBidCount={pendingBidCount}
             reviewCount={reviewCount}
-            onCreate={() => navigation.navigate('CreateTask')}
           />
           {loadError && <ErrorBanner message={loadError} onRetry={retryTasks} />}
 
@@ -438,14 +435,12 @@ function WorkspaceHeader({
   inProgressCount,
   pendingBidCount,
   reviewCount,
-  onCreate,
 }: {
   wide: boolean;
   openTasksCount: number;
   inProgressCount: number;
   pendingBidCount: number;
   reviewCount: number;
-  onCreate: () => void;
 }) {
   return (
     <LinearGradient
@@ -463,15 +458,6 @@ function WorkspaceHeader({
             of the way.
           </Text>
         </View>
-        <FButton
-          onPress={onCreate}
-          variant="secondary"
-          size="md"
-          icon="plus"
-          style={!wide ? styles.headerButtonFull : undefined}
-        >
-          Post Task
-        </FButton>
       </View>
 
       <View style={[styles.summaryRail, wide && styles.summaryRailWide]}>
@@ -648,9 +634,6 @@ const styles = StyleSheet.create({
     ...typography.bodySm,
     color: brandColors.textOnDarkMuted,
     maxWidth: 560,
-  },
-  headerButtonFull: {
-    width: '100%',
   },
   summaryRail: {
     marginTop: spacing.xl,

--- a/frontend/src/screens/RequesterDashboard.tsx
+++ b/frontend/src/screens/RequesterDashboard.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import {
   View,
   ScrollView,
+  FlatList,
+  Image,
   StyleSheet,
   Pressable,
   useWindowDimensions,
@@ -17,6 +19,7 @@ import {
   CATEGORY_LIST,
   type Category,
 } from '../utils/categoryMetadata';
+import { CATEGORY_METADATA } from '../constants/categories';
 
 interface Props {
   navigation: { navigate: (screen: string, params?: Record<string, unknown>) => void };
@@ -55,12 +58,6 @@ export default function RequesterDashboard({ navigation }: Props) {
   const wide = width >= 900;
   const tablet = width >= 680;
   const horizontalPadding = wide ? spacing.xxxl : spacing.lg;
-  const contentWidth = Math.min(width, 1120);
-  const categoryColumns = wide ? 4 : tablet ? 3 : 2;
-  const categoryGap = spacing.md;
-  const availableContentWidth = Math.max(0, contentWidth - horizontalPadding * 2);
-  const categoryCellWidth =
-    Math.max(0, (availableContentWidth - categoryGap * (categoryColumns - 1)) / categoryColumns);
 
   const user = auth.currentUser;
   const firstName = user?.displayName?.split(' ')[0] ?? null;
@@ -271,39 +268,38 @@ export default function RequesterDashboard({ navigation }: Props) {
             </View>
           </View>
 
-          <View style={styles.categoryGrid}>
-            {CATEGORY_LIST.map((category) => (
+          <FlatList
+            data={CATEGORY_LIST}
+            keyExtractor={(item) => item.value}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.categoryCarousel}
+            renderItem={({ item: category }) => (
               <Pressable
-                key={category.value}
                 onPress={() => navigateToCreate(category.value)}
                 accessibilityRole="button"
                 accessibilityLabel={`Post a ${category.label} task`}
                 style={({ pressed }) => [
-                  styles.categoryTile,
-                  {
-                    width: categoryCellWidth,
-                    opacity: pressed ? 0.88 : 1,
-                    transform: [{ scale: pressed ? 0.97 : 1 }],
-                  },
+                  styles.categoryCard,
+                  { opacity: pressed ? 0.88 : 1, transform: [{ scale: pressed ? 0.97 : 1 }] },
                 ]}
               >
-                <View style={styles.categoryTopRow}>
-                  <View style={[styles.categoryIcon, { backgroundColor: category.bg }]}>
-                    <MaterialCommunityIcons name={category.icon as never} size={20} color={category.color} />
-                  </View>
-                  <MaterialCommunityIcons name="chevron-right" size={18} color={brandColors.textMuted} />
-                </View>
-                <View style={styles.categoryCopy}>
-                  <Text style={[typography.label, styles.categoryLabel]} numberOfLines={1}>
+                <Image
+                  source={CATEGORY_METADATA[category.value as keyof typeof CATEGORY_METADATA].image}
+                  style={styles.categoryImage}
+                />
+                <LinearGradient
+                  colors={['transparent', 'rgba(0,0,0,0.65)']}
+                  style={styles.categoryOverlay}
+                />
+                <View style={styles.categoryCardContent}>
+                  <Text style={styles.categoryCardLabel} numberOfLines={1}>
                     {category.label}
-                  </Text>
-                  <Text style={[typography.caption, styles.categoryDescription]} numberOfLines={2}>
-                    {category.description}
                   </Text>
                 </View>
               </Pressable>
-            ))}
-          </View>
+            )}
+          />
         </View>
 
         <View style={styles.section}>
@@ -571,41 +567,40 @@ const styles = StyleSheet.create({
     flex: 1,
     gap: spacing.xs,
   },
-  categoryGrid: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
+  categoryCarousel: {
     gap: spacing.md,
+    paddingRight: spacing.lg,
   },
-  categoryTile: {
-    minHeight: 124,
-    padding: spacing.lg,
+  categoryCard: {
+    width: 140,
+    height: 180,
     borderRadius: radii.lg,
-    backgroundColor: brandColors.surface,
-    borderWidth: 1,
-    borderColor: brandColors.outlineLight,
-    justifyContent: 'space-between',
-    gap: spacing.md,
+    overflow: 'hidden',
+    position: 'relative',
   },
-  categoryTopRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+  categoryImage: {
+    width: '100%',
+    height: '100%',
+    resizeMode: 'cover',
   },
-  categoryIcon: {
-    width: 42,
-    height: 42,
-    borderRadius: radii.md,
-    alignItems: 'center',
-    justifyContent: 'center',
+  categoryOverlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: '50%',
   },
-  categoryCopy: {
-    gap: spacing.xs,
+  categoryCardContent: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    padding: spacing.md,
   },
-  categoryLabel: {
-    color: brandColors.textPrimary,
-  },
-  categoryDescription: {
-    color: brandColors.textMuted,
+  categoryCardLabel: {
+    color: brandColors.white,
+    fontWeight: '700',
+    fontSize: 14,
   },
   stepGrid: {
     gap: spacing.md,


### PR DESCRIPTION
## Summary
- Delete chat messages when task is completed (privacy)
- Category carousel with real images on RequesterDashboard (horizontal scroll)
- Remove "Post Task" button from MyTasksScreen
- AppLogo "I" in yellow/bold matching landing page exactly
- Separate conversations by mode (requester sees client chats, fixer sees fixer chats)
- Fix high contrast accessibility mode revealing inactive screens
- Chat title taps navigate to TaskDetails
- MyTasksScreen: In Progress & To Review pills filter task list
- Fixer discovery: Open jobs (display), New (filter unbid), Already bid (filter bid), Range (open filters)
- Tests for mode filter and message deletion on completion

## Test plan
- [x] Backend: 173/174 pass (1 pre-existing failure unrelated to this PR)
- [x] Frontend: 118/118 pass
- [ ] Manual: verify category carousel scrolls horizontally with images
- [ ] Manual: verify logo matches landing page (32px icon, 22px bold text, gold "I")
- [ ] Manual: verify chat title tap opens task details
- [ ] Manual: verify fixer discovery pills filter correctly

