### PR TITLE
feat: Niv feedback — admin panel, profanity filter, bid rejections, task history

### DIFF
--- a/backend/prisma/migrations/20260528160617_add_review_reports/migration.sql
+++ b/backend/prisma/migrations/20260528160617_add_review_reports/migration.sql
@@ -1,0 +1,29 @@
+-- CreateEnum
+CREATE TYPE "ReportReason" AS ENUM ('SPAM', 'OFFENSIVE', 'MISLEADING', 'OTHER');
+
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'BID_WITHDRAWN';
+
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN     "is_flagged" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "ReviewReport" (
+    "id" TEXT NOT NULL,
+    "review_id" TEXT NOT NULL,
+    "reporter_id" TEXT NOT NULL,
+    "reason" "ReportReason" NOT NULL,
+    "details" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ReviewReport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReviewReport_review_id_reporter_id_key" ON "ReviewReport"("review_id", "reporter_id");
+
+-- AddForeignKey
+ALTER TABLE "ReviewReport" ADD CONSTRAINT "ReviewReport_review_id_fkey" FOREIGN KEY ("review_id") REFERENCES "Review"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ReviewReport" ADD CONSTRAINT "ReviewReport_reporter_id_fkey" FOREIGN KEY ("reporter_id") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260528163444_add_admin_and_hidden_review/migration.sql
+++ b/backend/prisma/migrations/20260528163444_add_admin_and_hidden_review/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN     "is_hidden" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "is_admin" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/migrations/20260528165940_add_other_category/migration.sql
+++ b/backend/prisma/migrations/20260528165940_add_other_category/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Category" ADD VALUE 'OTHER';

--- a/backend/prisma/migrations/20260528173124_add_bid_rejection_reason/migration.sql
+++ b/backend/prisma/migrations/20260528173124_add_bid_rejection_reason/migration.sql
@@ -1,0 +1,8 @@
+-- CreateEnum
+CREATE TYPE "BidRejectionReason" AS ENUM ('PRICE_TOO_HIGH', 'BAD_TIMING', 'CHOSE_ANOTHER', 'NOT_QUALIFIED', 'TASK_CANCELED', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "Bid" ADD COLUMN     "auto_rejected_winning_price" DOUBLE PRECISION,
+ADD COLUMN     "auto_rejected_winning_rating" DOUBLE PRECISION,
+ADD COLUMN     "rejection_note" TEXT,
+ADD COLUMN     "rejection_reason" "BidRejectionReason";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,6 +18,7 @@ enum Category {
   ELECTRICITY
   OUTDOORS
   CLEANING
+  OTHER
 }
 
 enum TaskStatus {
@@ -32,6 +33,22 @@ enum BidStatus {
   ACCEPTED
   REJECTED
   WITHDRAWN
+}
+
+enum BidRejectionReason {
+  PRICE_TOO_HIGH
+  BAD_TIMING
+  CHOSE_ANOTHER
+  NOT_QUALIFIED
+  TASK_CANCELED
+  OTHER
+}
+
+enum ReportReason {
+  SPAM
+  OFFENSIVE
+  MISLEADING
+  OTHER
 }
 
 enum NotificationType {
@@ -56,6 +73,7 @@ model User {
   specializations         Category[]
   push_token              String?
   average_rating_as_fixer Float     @default(0)
+  is_admin                Boolean   @default(false)
   created_at              DateTime  @default(now())
   updated_at              DateTime  @updatedAt
 
@@ -69,6 +87,7 @@ model User {
   notifications    Notification[]
   portfolio_items  PortfolioItem[]
   certifications   Certification[]
+  review_reports   ReviewReport[]
 }
 
 model Task {
@@ -99,14 +118,18 @@ model Task {
 }
 
 model Bid {
-  id            String    @id @default(uuid())
-  task_id       String
-  fixer_id      String
-  offered_price Float
-  description   String
-  status        BidStatus @default(PENDING)
-  created_at    DateTime  @default(now())
-  updated_at    DateTime  @updatedAt
+  id                          String              @id @default(uuid())
+  task_id                     String
+  fixer_id                    String
+  offered_price               Float
+  description                 String
+  status                      BidStatus           @default(PENDING)
+  rejection_reason            BidRejectionReason?
+  rejection_note              String?
+  auto_rejected_winning_price Float?
+  auto_rejected_winning_rating Float?
+  created_at                  DateTime            @default(now())
+  updated_at                  DateTime            @updatedAt
 
   task  Task @relation(fields: [task_id], references: [id])
   fixer User @relation(fields: [fixer_id], references: [id])
@@ -121,13 +144,30 @@ model Review {
   reviewee_id String
   rating      Int
   comment     String?
+  is_flagged  Boolean  @default(false)
+  is_hidden   Boolean  @default(false)
   created_at  DateTime @default(now())
 
-  task     Task @relation(fields: [task_id], references: [id])
-  reviewer User @relation("ReviewsWritten", fields: [reviewer_id], references: [id])
-  reviewee User @relation("ReviewsReceived", fields: [reviewee_id], references: [id])
+  task     Task           @relation(fields: [task_id], references: [id])
+  reviewer User           @relation("ReviewsWritten", fields: [reviewer_id], references: [id])
+  reviewee User           @relation("ReviewsReceived", fields: [reviewee_id], references: [id])
+  reports  ReviewReport[]
 
   @@unique([task_id, reviewer_id])
+}
+
+model ReviewReport {
+  id          String       @id @default(uuid())
+  review_id   String
+  reporter_id String
+  reason      ReportReason
+  details     String?
+  created_at  DateTime     @default(now())
+
+  review   Review @relation(fields: [review_id], references: [id])
+  reporter User   @relation(fields: [reporter_id], references: [id])
+
+  @@unique([review_id, reporter_id])
 }
 
 model Message {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -53,6 +53,15 @@ const users = [
     phone_number: '0506666666',
     specializations: [Category.MOVING, Category.CLEANING],
   },
+  // Admin
+  {
+    firebase_uid: 'Pj6uxErNNGakznDCiot2bqBZQin1',
+    full_name: 'Admin',
+    email: 'admin@example.com',
+    phone_number: null,
+    specializations: [] as Category[],
+    is_admin: true,
+  },
 ];
 
 // ─── Task status distribution ───
@@ -162,7 +171,7 @@ async function main() {
   for (const user of users) {
     const created = await prisma.user.upsert({
       where: { firebase_uid: user.firebase_uid },
-      update: {},
+      update: { is_admin: (user as { is_admin?: boolean }).is_admin ?? false },
       create: user,
       select: { id: true },
     });

--- a/backend/src/__tests__/routes/admin.test.ts
+++ b/backend/src/__tests__/routes/admin.test.ts
@@ -1,0 +1,140 @@
+jest.mock('../../config/firebaseAdmin', () => {
+  let currentUid = 'test-uid';
+  return {
+    __esModule: true,
+    default: {
+      auth: () => ({
+        verifyIdToken: jest.fn().mockImplementation(() => Promise.resolve({ uid: currentUid })),
+      }),
+      apps: [{}],
+    },
+    __setUid: (uid: string) => { currentUid = uid; },
+  };
+});
+
+import request from 'supertest';
+import app from '../../app';
+import { prisma } from '../../config/prisma';
+import { cleanDatabase, createTestUser } from '../setup';
+
+const { __setUid } = jest.requireMock('../../config/firebaseAdmin') as { __setUid: (uid: string) => void };
+
+const ADMIN_AUTH = 'Bearer admin-token';
+const REQUESTER_AUTH = 'Bearer requester-token';
+const FIXER_AUTH = 'Bearer fixer-token';
+
+let reviewId: string;
+
+async function setupFlaggedReview() {
+  // Create task via API
+  __setUid('requester-uid');
+  const taskRes = await request(app)
+    .post('/api/tasks')
+    .set('Authorization', REQUESTER_AUTH)
+    .send({
+      title: 'Test Task',
+      description: 'Test',
+      category: 'PLUMBING',
+      general_location_name: 'Tel Aviv',
+      exact_address: '1 Test St',
+      lat: 32.08,
+      lng: 34.78,
+    });
+  const taskId = taskRes.body.task.id;
+
+  // Fixer bids
+  __setUid('fixer-uid');
+  const bidRes = await request(app)
+    .post(`/api/tasks/${taskId}/bids`)
+    .set('Authorization', FIXER_AUTH)
+    .send({ offered_price: 100, description: 'Can do' });
+
+  // Accept bid, complete task
+  __setUid('requester-uid');
+  await request(app).put(`/api/bids/${bidRes.body.bid.id}/accept`).set('Authorization', REQUESTER_AUTH);
+  await request(app).put(`/api/tasks/${taskId}/status`).set('Authorization', REQUESTER_AUTH).send({ status: 'COMPLETED' });
+
+  // Write review
+  const reviewRes = await request(app)
+    .post(`/api/tasks/${taskId}/reviews`)
+    .set('Authorization', REQUESTER_AUTH)
+    .send({ rating: 1, comment: 'Terrible' });
+  reviewId = reviewRes.body.review.id;
+
+  // Fixer reports it
+  __setUid('fixer-uid');
+  await request(app)
+    .post(`/api/reviews/${reviewId}/report`)
+    .set('Authorization', FIXER_AUTH)
+    .send({ reason: 'OFFENSIVE' });
+}
+
+beforeEach(async () => {
+  await cleanDatabase();
+  __setUid('admin-uid');
+  await createTestUser({ firebase_uid: 'admin-uid', email: 'admin@example.com', is_admin: true });
+  __setUid('requester-uid');
+  await createTestUser({ firebase_uid: 'requester-uid', email: 'req@example.com' });
+  __setUid('fixer-uid');
+  await createTestUser({ firebase_uid: 'fixer-uid', email: 'fixer@example.com' });
+  await setupFlaggedReview();
+});
+
+afterAll(() => prisma.$disconnect());
+
+describe('GET /api/admin/flagged-reviews', () => {
+  it('admin can list flagged reviews', async () => {
+    __setUid('admin-uid');
+    const res = await request(app)
+      .get('/api/admin/flagged-reviews')
+      .set('Authorization', ADMIN_AUTH);
+    expect(res.status).toBe(200);
+    expect(res.body.reviews).toHaveLength(1);
+    expect(res.body.reviews[0].reports).toHaveLength(1);
+  });
+
+  it('non-admin is forbidden', async () => {
+    __setUid('fixer-uid');
+    const res = await request(app)
+      .get('/api/admin/flagged-reviews')
+      .set('Authorization', FIXER_AUTH);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/admin/reviews/:id/hide', () => {
+  it('admin can hide a review', async () => {
+    __setUid('admin-uid');
+    const res = await request(app)
+      .post(`/api/admin/reviews/${reviewId}/hide`)
+      .set('Authorization', ADMIN_AUTH);
+    expect(res.status).toBe(200);
+
+    const review = await prisma.review.findUnique({ where: { id: reviewId } });
+    expect(review?.is_hidden).toBe(true);
+  });
+
+  it('returns 404 for non-existent review', async () => {
+    __setUid('admin-uid');
+    const res = await request(app)
+      .post('/api/admin/reviews/non-existent/hide')
+      .set('Authorization', ADMIN_AUTH);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /api/admin/reviews/:id/dismiss', () => {
+  it('admin can dismiss reports and clear flagged status', async () => {
+    __setUid('admin-uid');
+    const res = await request(app)
+      .post(`/api/admin/reviews/${reviewId}/dismiss`)
+      .set('Authorization', ADMIN_AUTH);
+    expect(res.status).toBe(200);
+
+    const review = await prisma.review.findUnique({ where: { id: reviewId } });
+    expect(review?.is_flagged).toBe(false);
+
+    const reports = await prisma.reviewReport.findMany({ where: { review_id: reviewId } });
+    expect(reports).toHaveLength(0);
+  });
+});

--- a/backend/src/__tests__/routes/bids.test.ts
+++ b/backend/src/__tests__/routes/bids.test.ts
@@ -142,6 +142,29 @@ describe('PUT /api/bids/:id/accept', () => {
     expect(res.status).toBe(403);
   });
 
+  it('auto-rejected bids get CHOSE_ANOTHER reason with winning price and rating', async () => {
+    await createOpenTask();
+    const bid = await fixerSubmitsBid();
+
+    const fixer2 = await createTestUser({ firebase_uid: 'fixer2-uid', email: 'fixer2@example.com' });
+    __setUid('fixer2-uid');
+    const bid2Res = await request(app)
+      .post(`/api/tasks/${taskId}/bids`)
+      .set('Authorization', 'Bearer fixer2-token')
+      .send({ offered_price: 120, description: 'Cheaper.' });
+
+    __setUid('test-uid');
+    await request(app).put(`/api/bids/${bid.id}/accept`).set('Authorization', REQUESTER_AUTH);
+
+    const rejectedBid = await prisma.bid.findUnique({ where: { id: bid2Res.body.bid.id } });
+    expect(rejectedBid?.status).toBe('REJECTED');
+    expect(rejectedBid?.rejection_reason).toBe('CHOSE_ANOTHER');
+    expect(rejectedBid?.auto_rejected_winning_price).toBe(150); // winning bid price
+    expect(rejectedBid?.auto_rejected_winning_rating).toBeDefined();
+
+    void fixer2;
+  });
+
   it('returns 400 when accepting an already-accepted bid', async () => {
     await createOpenTask();
     const bid = await fixerSubmitsBid();
@@ -157,16 +180,54 @@ describe('PUT /api/bids/:id/accept', () => {
 // ── PUT /api/bids/:id/reject ──────────────────────────────────────────────────
 
 describe('PUT /api/bids/:id/reject', () => {
-  it('requester can reject a pending bid', async () => {
+  it('requester can reject a pending bid with reason', async () => {
     await createOpenTask();
     const bid = await fixerSubmitsBid();
     __setUid('test-uid');
     const res = await request(app)
       .put(`/api/bids/${bid.id}/reject`)
-      .set('Authorization', REQUESTER_AUTH);
+      .set('Authorization', REQUESTER_AUTH)
+      .send({ rejection_reason: 'PRICE_TOO_HIGH' });
     expect(res.status).toBe(200);
     const updated = await prisma.bid.findUnique({ where: { id: bid.id } });
     expect(updated?.status).toBe('REJECTED');
+    expect(updated?.rejection_reason).toBe('PRICE_TOO_HIGH');
+  });
+
+  it('stores optional rejection_note', async () => {
+    await createOpenTask();
+    const bid = await fixerSubmitsBid();
+    __setUid('test-uid');
+    const res = await request(app)
+      .put(`/api/bids/${bid.id}/reject`)
+      .set('Authorization', REQUESTER_AUTH)
+      .send({ rejection_reason: 'OTHER', rejection_note: 'Not what I need' });
+    expect(res.status).toBe(200);
+    const updated = await prisma.bid.findUnique({ where: { id: bid.id } });
+    expect(updated?.rejection_reason).toBe('OTHER');
+    expect(updated?.rejection_note).toBe('Not what I need');
+  });
+
+  it('returns 400 when rejection_reason is missing', async () => {
+    await createOpenTask();
+    const bid = await fixerSubmitsBid();
+    __setUid('test-uid');
+    const res = await request(app)
+      .put(`/api/bids/${bid.id}/reject`)
+      .set('Authorization', REQUESTER_AUTH)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid rejection_reason', async () => {
+    await createOpenTask();
+    const bid = await fixerSubmitsBid();
+    __setUid('test-uid');
+    const res = await request(app)
+      .put(`/api/bids/${bid.id}/reject`)
+      .set('Authorization', REQUESTER_AUTH)
+      .send({ rejection_reason: 'INVALID_REASON' });
+    expect(res.status).toBe(400);
   });
 
   it('returns 403 when fixer tries to reject their own bid', async () => {
@@ -174,7 +235,8 @@ describe('PUT /api/bids/:id/reject', () => {
     const bid = await fixerSubmitsBid();
     const res = await request(app)
       .put(`/api/bids/${bid.id}/reject`)
-      .set('Authorization', FIXER_AUTH);
+      .set('Authorization', FIXER_AUTH)
+      .send({ rejection_reason: 'PRICE_TOO_HIGH' });
     expect(res.status).toBe(403);
   });
 });
@@ -280,7 +342,7 @@ describe('PUT /api/bids/:id', () => {
     await createOpenTask();
     const bid = await fixerSubmitsBid();
     __setUid('test-uid');
-    await request(app).put(`/api/bids/${bid.id}/reject`).set('Authorization', REQUESTER_AUTH);
+    await request(app).put(`/api/bids/${bid.id}/reject`).set('Authorization', REQUESTER_AUTH).send({ rejection_reason: 'OTHER' });
     __setUid('fixer-uid');
     const res = await request(app)
       .put(`/api/bids/${bid.id}`)
@@ -327,7 +389,7 @@ describe('DELETE /api/bids/:id', () => {
     await createOpenTask();
     const bid = await fixerSubmitsBid();
     __setUid('test-uid');
-    await request(app).put(`/api/bids/${bid.id}/reject`).set('Authorization', REQUESTER_AUTH);
+    await request(app).put(`/api/bids/${bid.id}/reject`).set('Authorization', REQUESTER_AUTH).send({ rejection_reason: 'PRICE_TOO_HIGH' });
 
     __setUid('fixer-uid');
     const res = await request(app)

--- a/backend/src/__tests__/routes/reviews.test.ts
+++ b/backend/src/__tests__/routes/reviews.test.ts
@@ -1,0 +1,139 @@
+jest.mock('../../config/firebaseAdmin', () => {
+  let currentUid = 'test-uid';
+  return {
+    __esModule: true,
+    default: {
+      auth: () => ({
+        verifyIdToken: jest.fn().mockImplementation(() => Promise.resolve({ uid: currentUid })),
+      }),
+      apps: [{}],
+    },
+    __setUid: (uid: string) => { currentUid = uid; },
+  };
+});
+
+import request from 'supertest';
+import app from '../../app';
+import { prisma } from '../../config/prisma';
+import { cleanDatabase, createTestUser } from '../setup';
+
+const { __setUid } = jest.requireMock('../../config/firebaseAdmin') as { __setUid: (uid: string) => void };
+
+const REQUESTER_AUTH = 'Bearer requester-token';
+const FIXER_AUTH = 'Bearer fixer-token';
+
+let fixerId: string;
+let reviewId: string;
+
+async function createTaskAndReview() {
+  // Create task as requester
+  __setUid('requester-uid');
+  const taskRes = await request(app)
+    .post('/api/tasks')
+    .set('Authorization', REQUESTER_AUTH)
+    .send({
+      title: 'Test Task',
+      description: 'Test description',
+      category: 'PLUMBING',
+      general_location_name: 'Tel Aviv',
+      exact_address: '1 Test St',
+      lat: 32.08,
+      lng: 34.78,
+    });
+  const taskId = taskRes.body.task.id;
+
+  // Fixer submits bid
+  __setUid('fixer-uid');
+  const bidRes = await request(app)
+    .post(`/api/tasks/${taskId}/bids`)
+    .set('Authorization', FIXER_AUTH)
+    .send({ offered_price: 100, description: 'I can do it' });
+  const bidId = bidRes.body.bid.id;
+
+  // Requester accepts bid
+  __setUid('requester-uid');
+  await request(app).put(`/api/bids/${bidId}/accept`).set('Authorization', REQUESTER_AUTH);
+
+  // Mark completed
+  await request(app)
+    .put(`/api/tasks/${taskId}/status`)
+    .set('Authorization', REQUESTER_AUTH)
+    .send({ status: 'COMPLETED' });
+
+  // Requester writes review about fixer
+  const reviewRes = await request(app)
+    .post(`/api/tasks/${taskId}/reviews`)
+    .set('Authorization', REQUESTER_AUTH)
+    .send({ rating: 3, comment: 'Average work' });
+  reviewId = reviewRes.body.review.id;
+}
+
+beforeEach(async () => {
+  await cleanDatabase();
+  __setUid('requester-uid');
+  await createTestUser({ firebase_uid: 'requester-uid', email: 'req@example.com' });
+  __setUid('fixer-uid');
+  const fixer = await createTestUser({ firebase_uid: 'fixer-uid', email: 'fixer@example.com' });
+  fixerId = fixer.id;
+  await createTaskAndReview();
+
+  void fixerId;
+});
+
+afterAll(() => prisma.$disconnect());
+
+describe('POST /api/reviews/:id/report', () => {
+  it('fixer (reviewee) can report a review about themselves', async () => {
+    __setUid('fixer-uid');
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/report`)
+      .set('Authorization', FIXER_AUTH)
+      .send({ reason: 'OFFENSIVE' });
+    expect(res.status).toBe(201);
+    expect(res.body.report).toMatchObject({ reason: 'OFFENSIVE' });
+
+    const review = await prisma.review.findUnique({ where: { id: reviewId } });
+    expect(review?.is_flagged).toBe(true);
+  });
+
+  it('non-reviewee cannot report', async () => {
+    __setUid('requester-uid');
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/report`)
+      .set('Authorization', REQUESTER_AUTH)
+      .send({ reason: 'SPAM' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for non-existent review', async () => {
+    __setUid('fixer-uid');
+    const res = await request(app)
+      .post('/api/reviews/non-existent-id/report')
+      .set('Authorization', FIXER_AUTH)
+      .send({ reason: 'SPAM' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 409 on duplicate report', async () => {
+    __setUid('fixer-uid');
+    await request(app)
+      .post(`/api/reviews/${reviewId}/report`)
+      .set('Authorization', FIXER_AUTH)
+      .send({ reason: 'SPAM' });
+
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/report`)
+      .set('Authorization', FIXER_AUTH)
+      .send({ reason: 'OFFENSIVE' });
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 400 for invalid reason', async () => {
+    __setUid('fixer-uid');
+    const res = await request(app)
+      .post(`/api/reviews/${reviewId}/report`)
+      .set('Authorization', FIXER_AUTH)
+      .send({ reason: 'INVALID' });
+    expect(res.status).toBe(400);
+  });
+});

--- a/backend/src/__tests__/schemas.test.ts
+++ b/backend/src/__tests__/schemas.test.ts
@@ -3,6 +3,8 @@ import {
   createTaskSchema,
   createBidSchema,
   createReviewSchema,
+  rejectBidSchema,
+  reportReviewSchema,
   updateUserSchema,
   pushTokenSchema,
   createPortfolioItemSchema,
@@ -111,5 +113,39 @@ describe('createPortfolioItemSchema', () => {
 
   it('rejects non-URL image_url', () => {
     expect(() => createPortfolioItemSchema.parse({ image_url: 'not-a-url' })).toThrow();
+  });
+});
+
+// ── rejectBidSchema ────────────────────────────────────────────────────────
+describe('rejectBidSchema', () => {
+  it('accepts valid rejection with reason only', () => {
+    expect(() => rejectBidSchema.parse({ rejection_reason: 'PRICE_TOO_HIGH' })).not.toThrow();
+  });
+
+  it('accepts valid rejection with reason and note', () => {
+    expect(() => rejectBidSchema.parse({ rejection_reason: 'OTHER', rejection_note: 'Too expensive' })).not.toThrow();
+  });
+
+  test.each([
+    [{}, 'missing reason'],
+    [{ rejection_reason: 'INVALID' }, 'invalid reason'],
+    [{ rejection_reason: 'TASK_CANCELED' }, 'TASK_CANCELED not allowed from client'],
+  ])('rejects: %s', (input, _label) => {
+    expect(() => rejectBidSchema.parse(input)).toThrow();
+  });
+});
+
+// ── reportReviewSchema ─────────────────────────────────────────────────────
+describe('reportReviewSchema', () => {
+  it('accepts valid report', () => {
+    expect(() => reportReviewSchema.parse({ reason: 'SPAM' })).not.toThrow();
+  });
+
+  it('accepts report with details', () => {
+    expect(() => reportReviewSchema.parse({ reason: 'OFFENSIVE', details: 'Contains hate speech' })).not.toThrow();
+  });
+
+  it('rejects invalid reason', () => {
+    expect(() => reportReviewSchema.parse({ reason: 'INVALID' })).toThrow();
   });
 });

--- a/backend/src/__tests__/setup.ts
+++ b/backend/src/__tests__/setup.ts
@@ -5,6 +5,7 @@ import { prisma } from '../config/prisma';
  * Call this in `beforeEach` in any test file that writes to the DB.
  */
 export async function cleanDatabase() {
+  await prisma.reviewReport.deleteMany();
   await prisma.notification.deleteMany();
   await prisma.message.deleteMany();
   await prisma.review.deleteMany();
@@ -23,12 +24,14 @@ export async function createTestUser(overrides: {
   firebase_uid?: string;
   email?: string;
   full_name?: string;
+  is_admin?: boolean;
 } = {}) {
   return prisma.user.create({
     data: {
       firebase_uid: overrides.firebase_uid ?? 'test-uid',
       email: overrides.email ?? 'test@example.com',
       full_name: overrides.full_name ?? 'Test User',
+      is_admin: overrides.is_admin ?? false,
     },
   });
 }

--- a/backend/src/__tests__/utils/profanityFilter.test.ts
+++ b/backend/src/__tests__/utils/profanityFilter.test.ts
@@ -1,0 +1,35 @@
+import { containsProfanity, PROFANITY_ERROR_MESSAGE } from '../../utils/profanityFilter';
+
+describe('profanityFilter', () => {
+  it('detects English profanity', () => {
+    expect(containsProfanity('this is shit')).toBe(true);
+    expect(containsProfanity('What the fuck')).toBe(true);
+  });
+
+  it('detects Hebrew profanity', () => {
+    expect(containsProfanity('זונה')).toBe(true);
+    expect(containsProfanity('בןזונה')).toBe(true);
+  });
+
+  it('detects Hebrew profanity with inserted spaces', () => {
+    expect(containsProfanity('בן זו נה')).toBe(true);
+    expect(containsProfanity('זו  נ  ה')).toBe(true);
+  });
+
+  it('allows clean text in English', () => {
+    expect(containsProfanity('Great job, very professional!')).toBe(false);
+  });
+
+  it('allows clean text in Hebrew', () => {
+    expect(containsProfanity('עבודה מצוינת, מקצועי מאוד')).toBe(false);
+  });
+
+  it('returns false for empty or undefined-ish input', () => {
+    expect(containsProfanity('')).toBe(false);
+  });
+
+  it('exports a user-facing error message', () => {
+    expect(PROFANITY_ERROR_MESSAGE).toBeDefined();
+    expect(typeof PROFANITY_ERROR_MESSAGE).toBe('string');
+  });
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,8 @@ import authRoutes from './routes/auth';
 import userRoutes from './routes/users';
 import taskRoutes from './routes/tasks';
 import bidRoutes from './routes/bids';
+import reviewRoutes from './routes/reviews';
+import adminRoutes from './routes/admin';
 import notificationRoutes from './routes/notifications';
 import messageRoutes from './routes/messages';
 import { errorHandler } from './middleware/errorHandler';
@@ -26,6 +28,8 @@ app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/tasks', taskRoutes);
 app.use('/api/bids', bidRoutes);
+app.use('/api/reviews', reviewRoutes);
+app.use('/api/admin', adminRoutes);
 app.use('/api/notifications', notificationRoutes);
 app.use('/api', messageRoutes);
 

--- a/backend/src/middleware/adminAuth.ts
+++ b/backend/src/middleware/adminAuth.ts
@@ -1,0 +1,18 @@
+import { Request, Response, NextFunction } from 'express';
+import { ForbiddenError } from '../utils/errors';
+
+/**
+ * Middleware that requires the authenticated user to be an admin.
+ * Must be used AFTER authMiddleware (req.user must already be set).
+ */
+export function adminOnly(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  if (!req.user.is_admin) {
+    next(new ForbiddenError('Admin access required'));
+    return;
+  }
+  next();
+}

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,93 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { authMiddleware } from '../middleware/auth';
+import { adminOnly } from '../middleware/adminAuth';
+import { prisma } from '../config/prisma';
+import { NotFoundError } from '../utils/errors';
+import { recalculateFixerRating } from '../utils/ratingCalculator';
+
+const router = Router();
+
+router.use(authMiddleware);
+router.use(adminOnly);
+
+// GET /api/admin/flagged-reviews — list all flagged reviews with reports
+router.get(
+  '/flagged-reviews',
+  async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const reviews = await prisma.review.findMany({
+        where: { is_flagged: true, is_hidden: false },
+        include: {
+          reviewer: { select: { id: true, full_name: true, email: true } },
+          reviewee: { select: { id: true, full_name: true, email: true } },
+          task: { select: { id: true, title: true } },
+          reports: {
+            include: {
+              reporter: { select: { id: true, full_name: true } },
+            },
+            orderBy: { created_at: 'desc' },
+          },
+        },
+        orderBy: { created_at: 'desc' },
+      });
+
+      res.json({ reviews });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// POST /api/admin/reviews/:id/hide — hide a review (remove from public view)
+router.post(
+  '/reviews/:id/hide',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const review = await prisma.review.findUnique({
+        where: { id: req.params.id },
+      });
+      if (!review) throw new NotFoundError('Review not found');
+
+      await prisma.review.update({
+        where: { id: review.id },
+        data: { is_hidden: true },
+      });
+
+      // Recalculate fixer's weighted average rating
+      await recalculateFixerRating(review.reviewee_id);
+
+      res.json({ message: 'Review hidden successfully' });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// POST /api/admin/reviews/:id/dismiss — dismiss reports, clear flagged status
+router.post(
+  '/reviews/:id/dismiss',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const review = await prisma.review.findUnique({
+        where: { id: req.params.id },
+      });
+      if (!review) throw new NotFoundError('Review not found');
+
+      await prisma.$transaction([
+        prisma.reviewReport.deleteMany({
+          where: { review_id: review.id },
+        }),
+        prisma.review.update({
+          where: { id: review.id },
+          data: { is_flagged: false },
+        }),
+      ]);
+
+      res.json({ message: 'Reports dismissed successfully' });
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/bids.ts
+++ b/backend/src/routes/bids.ts
@@ -1,6 +1,8 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import { Prisma } from '@prisma/client';
 import { authMiddleware } from '../middleware/auth';
+import { validate } from '../middleware/validate';
+import { rejectBidSchema } from '../schemas';
 import { prisma } from '../config/prisma';
 import { sendNotification } from '../services/notificationService';
 import {
@@ -25,6 +27,12 @@ router.put('/:id/accept', async (req: Request, res: Response, next: NextFunction
     if (req.user.id !== bid.task.requester_id) throw new ForbiddenError('Only the requester can accept a bid');
     if (bid.status !== 'PENDING') throw new ValidationError('Only pending bids can be accepted');
 
+    // Look up winning fixer's rating for auto-rejection context
+    const winningFixer = await prisma.user.findUnique({
+      where: { id: bid.fixer_id },
+      select: { average_rating_as_fixer: true },
+    });
+
     // Run DB changes atomically — all tx calls must use tx. not prisma.
     await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
       await tx.task.update({
@@ -37,11 +45,16 @@ router.put('/:id/accept', async (req: Request, res: Response, next: NextFunction
       });
       await tx.bid.updateMany({
         where: { task_id: bid.task_id, status: 'PENDING', id: { not: bid.id } },
-        data: { status: 'REJECTED' },
+        data: {
+          status: 'REJECTED',
+          rejection_reason: 'CHOSE_ANOTHER',
+          auto_rejected_winning_price: bid.offered_price,
+          auto_rejected_winning_rating: winningFixer?.average_rating_as_fixer ?? null,
+        },
       });
     });
 
-    // Notify outside transaction — failure here should not roll back acceptance
+    // Notify accepted fixer
     await sendNotification(
       bid.fixer_id,
       'Bid Accepted',
@@ -51,6 +64,22 @@ router.put('/:id/accept', async (req: Request, res: Response, next: NextFunction
       'Task',
     );
 
+    // Notify auto-rejected fixers
+    const autoRejected = await prisma.bid.findMany({
+      where: { task_id: bid.task_id, status: 'REJECTED', id: { not: bid.id } },
+      select: { fixer_id: true },
+    });
+    for (const rejected of autoRejected) {
+      await sendNotification(
+        rejected.fixer_id,
+        'Bid Rejected',
+        `Another fixer was chosen for "${bid.task.title}".`,
+        'BID_REJECTED',
+        bid.task_id,
+        'Task',
+      );
+    }
+
     const updated = await prisma.bid.findUnique({ where: { id: bid.id } });
     res.json({ bid: updated });
   } catch (err) {
@@ -59,7 +88,7 @@ router.put('/:id/accept', async (req: Request, res: Response, next: NextFunction
 });
 
 // PUT /api/bids/:id/reject — requester rejects a bid
-router.put('/:id/reject', async (req: Request, res: Response, next: NextFunction) => {
+router.put('/:id/reject', validate(rejectBidSchema), async (req: Request, res: Response, next: NextFunction) => {
   try {
     const bid = await prisma.bid.findUnique({
       where: { id: req.params.id },
@@ -70,9 +99,15 @@ router.put('/:id/reject', async (req: Request, res: Response, next: NextFunction
     if (req.user.id !== bid.task.requester_id) throw new ForbiddenError('Only the requester can reject a bid');
     if (bid.status !== 'PENDING') throw new ValidationError('Only pending bids can be rejected');
 
+    const { rejection_reason, rejection_note } = req.body;
+
     const updated = await prisma.bid.update({
       where: { id: bid.id },
-      data: { status: 'REJECTED' },
+      data: {
+        status: 'REJECTED',
+        rejection_reason,
+        rejection_note: rejection_note ?? null,
+      },
     });
 
     await sendNotification(

--- a/backend/src/routes/reviews.ts
+++ b/backend/src/routes/reviews.ts
@@ -1,3 +1,70 @@
-// Review routes are co-located with their parent resources:
-// - POST /api/tasks/:id/reviews → tasks.ts
-// - GET /api/users/:id/reviews → users.ts
+import { Router, Request, Response, NextFunction } from 'express';
+import { Prisma } from '@prisma/client';
+import { authMiddleware } from '../middleware/auth';
+import { validate } from '../middleware/validate';
+import { prisma } from '../config/prisma';
+import { reportReviewSchema } from '../schemas';
+import {
+  NotFoundError,
+  ForbiddenError,
+  ConflictError,
+} from '../utils/errors';
+
+const router = Router();
+
+router.use(authMiddleware);
+
+// POST /api/reviews/:id/report — report an inappropriate review
+router.post(
+  '/:id/report',
+  validate(reportReviewSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const review = await prisma.review.findUnique({
+        where: { id: req.params.id },
+      });
+
+      if (!review) throw new NotFoundError('Review not found');
+
+      if (req.user.id !== review.reviewee_id) {
+        throw new ForbiddenError('Only the reviewed fixer can report a review');
+      }
+
+      const { reason, details } = req.body as {
+        reason: string;
+        details?: string;
+      };
+
+      try {
+        const report = await prisma.reviewReport.create({
+          data: {
+            review_id: review.id,
+            reporter_id: req.user.id,
+            reason: reason as Prisma.ReviewReportCreateInput['reason'],
+            details: details ?? null,
+          },
+        });
+
+        // Flag the review for admin attention
+        await prisma.review.update({
+          where: { id: review.id },
+          data: { is_flagged: true },
+        });
+
+        res.status(201).json({ report });
+      } catch (err) {
+        if (
+          err instanceof Prisma.PrismaClientKnownRequestError &&
+          err.code === 'P2002'
+        ) {
+          throw new ConflictError('You have already reported this review');
+        }
+        throw err;
+      }
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -4,6 +4,7 @@ import { authMiddleware } from '../middleware/auth';
 import { validate } from '../middleware/validate';
 import { prisma } from '../config/prisma';
 import { sendNotification } from '../services/notificationService';
+import { recalculateFixerRating } from '../utils/ratingCalculator';
 import {
   NotFoundError,
   ForbiddenError,
@@ -436,7 +437,7 @@ router.put('/:id/status', validate(updateTaskStatusSchema), async (req: Request,
         });
         await tx.bid.updateMany({
           where: { task_id: task.id, status: 'PENDING' },
-          data: { status: 'REJECTED' },
+          data: { status: 'REJECTED', rejection_reason: 'TASK_CANCELED' },
         });
       });
 
@@ -643,15 +644,8 @@ router.post('/:id/reviews', validate(createReviewSchema), async (req: Request, r
       },
     });
 
-    // Update fixer's average rating
-    const { _avg } = await prisma.review.aggregate({
-      where: { reviewee_id: task.assigned_fixer_id },
-      _avg: { rating: true },
-    });
-    await prisma.user.update({
-      where: { id: task.assigned_fixer_id },
-      data: { average_rating_as_fixer: _avg.rating ?? 0 },
-    });
+    // Recalculate fixer's weighted average rating
+    await recalculateFixerRating(task.assigned_fixer_id);
 
     res.status(201).json({ review });
   } catch (err) {

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -202,15 +202,17 @@ router.get('/:id/reviews', async (req: Request, res: Response, next: NextFunctio
     const limitNum = Math.min(50, Math.max(1, parseInt(limit)));
     const offset = (pageNum - 1) * limitNum;
 
+    const whereClause = { reviewee_id: req.params.id, is_hidden: false };
+
     const [reviews, total] = await prisma.$transaction([
       prisma.review.findMany({
-        where: { reviewee_id: req.params.id },
+        where: whereClause,
         include: { reviewer: true, task: true },
         orderBy: { created_at: 'desc' },
         skip: offset,
         take: limitNum,
       }),
-      prisma.review.count({ where: { reviewee_id: req.params.id } }),
+      prisma.review.count({ where: whereClause }),
     ]);
 
     res.json({ reviews, total, page: pageNum, limit: limitNum });

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { containsProfanity, PROFANITY_ERROR_MESSAGE } from './utils/profanityFilter';
 
 export const authSyncSchema = z.object({
   full_name: z.string().trim().min(1, 'Full name is required').max(100),
@@ -9,7 +10,7 @@ export const createTaskSchema = z.object({
   title: z.string().trim().min(1, 'Title is required').max(200),
   description: z.string().trim().min(1, 'Description is required').max(2000),
   media_urls: z.array(z.url()).optional(),
-  category: z.enum(['ASSEMBLY', 'MOUNTING', 'MOVING', 'PAINTING', 'PLUMBING', 'ELECTRICITY', 'OUTDOORS', 'CLEANING']),
+  category: z.enum(['ASSEMBLY', 'MOUNTING', 'MOVING', 'PAINTING', 'PLUMBING', 'ELECTRICITY', 'OUTDOORS', 'CLEANING', 'OTHER']),
   suggested_price: z.number().positive().nullable().optional(),
   general_location_name: z.string().trim().min(1, 'General location is required'),
   exact_address: z.string().trim().min(1, 'Exact address is required'),
@@ -20,7 +21,7 @@ export const createTaskSchema = z.object({
 export const updateTaskSchema = z.object({
   title: z.string().trim().min(1).max(200).optional(),
   description: z.string().trim().min(1).max(2000).optional(),
-  category: z.enum(['ASSEMBLY', 'MOUNTING', 'MOVING', 'PAINTING', 'PLUMBING', 'ELECTRICITY', 'OUTDOORS', 'CLEANING']).optional(),
+  category: z.enum(['ASSEMBLY', 'MOUNTING', 'MOVING', 'PAINTING', 'PLUMBING', 'ELECTRICITY', 'OUTDOORS', 'CLEANING', 'OTHER']).optional(),
   suggested_price: z.number().positive().nullable().optional(),
   general_location_name: z.string().trim().min(1).optional(),
   exact_address: z.string().trim().min(1).optional(),
@@ -30,6 +31,11 @@ export const updateTaskStatusSchema = z.object({
   status: z.enum(['OPEN', 'IN_PROGRESS', 'COMPLETED', 'CANCELED']),
 });
 
+export const rejectBidSchema = z.object({
+  rejection_reason: z.enum(['PRICE_TOO_HIGH', 'BAD_TIMING', 'CHOSE_ANOTHER', 'NOT_QUALIFIED', 'OTHER']),
+  rejection_note: z.string().trim().max(500).optional(),
+});
+
 export const createBidSchema = z.object({
   offered_price: z.number().positive('Offered price must be positive'),
   description: z.string().trim().min(1, 'Description is required').max(1000),
@@ -37,7 +43,22 @@ export const createBidSchema = z.object({
 
 export const createReviewSchema = z.object({
   rating: z.number().int().min(1).max(5),
-  comment: z.string().trim().max(2000).optional(),
+  comment: z
+    .string()
+    .trim()
+    .max(2000)
+    .refine((val) => !containsProfanity(val), { message: PROFANITY_ERROR_MESSAGE })
+    .optional(),
+});
+
+export const reportReviewSchema = z.object({
+  reason: z.enum(['SPAM', 'OFFENSIVE', 'MISLEADING', 'OTHER']),
+  details: z
+    .string()
+    .trim()
+    .max(500)
+    .refine((val) => !containsProfanity(val), { message: PROFANITY_ERROR_MESSAGE })
+    .optional(),
 });
 
 export const updateUserSchema = z.object({
@@ -47,7 +68,7 @@ export const updateUserSchema = z.object({
   payment_link: z.url().optional(),
   phone_number: z.string().trim().optional(),
   specializations: z
-    .array(z.enum(['ASSEMBLY', 'MOUNTING', 'MOVING', 'PAINTING', 'PLUMBING', 'ELECTRICITY', 'OUTDOORS', 'CLEANING']))
+    .array(z.enum(['ASSEMBLY', 'MOUNTING', 'MOVING', 'PAINTING', 'PLUMBING', 'ELECTRICITY', 'OUTDOORS', 'CLEANING', 'OTHER']))
     .optional(),
 });
 

--- a/backend/src/utils/profanityFilter.ts
+++ b/backend/src/utils/profanityFilter.ts
@@ -1,0 +1,104 @@
+/**
+ * Profanity filter for review comments.
+ * Supports English and Hebrew.
+ */
+
+const ENGLISH_WORDS = [
+  'fuck', 'fucking', 'fucker', 'fucked', 'fucks',
+  'shit', 'shitty', 'bullshit',
+  'ass', 'asshole', 'assholes',
+  'bitch', 'bitches',
+  'damn', 'damned',
+  'dick', 'dicks',
+  'cunt', 'cunts',
+  'bastard', 'bastards',
+  'whore', 'whores',
+  'slut', 'sluts',
+  'piss', 'pissed',
+  'crap', 'crappy',
+  'douche', 'douchebag',
+  'motherfucker', 'motherfucking',
+  'retard', 'retarded',
+  'idiot', 'idiots',
+  'stupid',
+  'moron',
+  'sucker',
+  'stfu', 'wtf', 'lmfao',
+];
+
+const HEBREW_WORDS = [
+  'זונה',
+  'שרמוטה',
+  'מניאק',
+  'חרא',
+  'כוס',
+  'כוסאמק',
+  'כוסאימק',
+  'כוסאחתק',
+  'כוסאמאשלך',
+  'זין',
+  'בןזונה',
+  'בתזונה',
+  'מזדיין',
+  'מזדיינת',
+  'תמות',
+  'יאללעזאזל',
+  'אידיוט',
+  'מפגר',
+  'מפגרת',
+  'טמבל',
+  'חמור',
+  'בהמה',
+  'מטומטם',
+  'מטומטמת',
+  'דביל',
+  'דבילה',
+  'חתיכתמטומטם',
+  'לךתמות',
+  'יבןכלב',
+  'מתחנגל',
+  'ימתחנגל',
+  'מוצץ',
+  'ימוצץ',
+  'קוקסינל',
+  'חתיכתקוקסינל',
+  'חתיכתבןשרמוטה',
+  'גנב',
+  'גנבמזדיין',
+  'יקוקסינל',
+  'הומו',
+  'יהומו',
+  'בןאלפזונות',
+  'מזדייןבתחת',
+  'שימות',
+  'חאפר',
+];
+
+/**
+ * Checks whether the given text contains profanity.
+ *
+ * English: uses word-boundary regex so "class" won't match "ass".
+ * Hebrew: removes spaces from text and checks for substring matches
+ * against a normalized (space-stripped) word list, since Hebrew has
+ * no reliable regex word-boundary support.
+ */
+export function containsProfanity(text: string): boolean {
+  const lower = text.toLowerCase();
+
+  // English: word-boundary check
+  for (const word of ENGLISH_WORDS) {
+    const regex = new RegExp(`\\b${word}\\b`, 'i');
+    if (regex.test(lower)) return true;
+  }
+
+  // Hebrew: strip spaces and check substrings
+  const stripped = lower.replace(/\s+/g, '');
+  for (const word of HEBREW_WORDS) {
+    if (stripped.includes(word)) return true;
+  }
+
+  return false;
+}
+
+export const PROFANITY_ERROR_MESSAGE =
+  'Comment contains inappropriate language / התגובה מכילה שפה לא הולמת';

--- a/backend/src/utils/ratingCalculator.ts
+++ b/backend/src/utils/ratingCalculator.ts
@@ -1,0 +1,49 @@
+import { prisma } from '../config/prisma';
+
+/**
+ * Recalculates a fixer's average rating using per-reviewer normalization.
+ *
+ * Algorithm:
+ * 1. Get all non-hidden reviews for the fixer
+ * 2. Group by reviewer
+ * 3. Calculate each reviewer's average rating
+ * 4. Final rating = average of all reviewers' averages
+ *
+ * This ensures each reviewer has equal influence regardless of
+ * how many times they reviewed the same fixer.
+ */
+export async function recalculateFixerRating(fixerId: string): Promise<void> {
+  const reviews = await prisma.review.findMany({
+    where: { reviewee_id: fixerId, is_hidden: false },
+    select: { reviewer_id: true, rating: true },
+  });
+
+  if (reviews.length === 0) {
+    await prisma.user.update({
+      where: { id: fixerId },
+      data: { average_rating_as_fixer: 0 },
+    });
+    return;
+  }
+
+  // Group ratings by reviewer
+  const byReviewer = new Map<string, number[]>();
+  for (const review of reviews) {
+    const ratings = byReviewer.get(review.reviewer_id) ?? [];
+    ratings.push(review.rating);
+    byReviewer.set(review.reviewer_id, ratings);
+  }
+
+  // Average per reviewer, then average of averages
+  let sum = 0;
+  for (const ratings of byReviewer.values()) {
+    const reviewerAvg = ratings.reduce((a, b) => a + b, 0) / ratings.length;
+    sum += reviewerAvg;
+  }
+  const weightedAverage = sum / byReviewer.size;
+
+  await prisma.user.update({
+    where: { id: fixerId },
+    data: { average_rating_as_fixer: weightedAverage },
+  });
+}

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -7,6 +7,7 @@ import { Platform } from 'react-native';
 import useAuthBootstrap from './src/hooks/useAuthBootstrap';
 import { navigationTheme, theme } from './src/theme';
 import AppNavigator from './src/navigation/AppNavigator';
+import AdminNavigator from './src/navigation/AdminNavigator';
 import AuthScreen from './src/screens/AuthScreen';
 import LandingScreen from './src/screens/LandingScreen';
 import { NotificationProvider } from './src/context/NotificationContext';
@@ -111,6 +112,14 @@ function RootContent() {
         onLogOut={handleAuthLogOut}
         initialMode={authInitialMode}
       />
+    );
+  }
+
+  if (authState.isAdmin) {
+    return (
+      <NavigationContainer theme={navigationTheme}>
+        <AdminNavigator />
+      </NavigationContainer>
     );
   }
 

--- a/frontend/src/constants/categories.ts
+++ b/frontend/src/constants/categories.ts
@@ -12,6 +12,7 @@ export const CATEGORY_VALUES = [
   'ELECTRICITY',
   'OUTDOORS',
   'CLEANING',
+  'OTHER',
 ] as const;
 
 export type Category = (typeof CATEGORY_VALUES)[number];
@@ -149,6 +150,20 @@ export const CATEGORY_METADATA = {
     commonTasks: ['deep clean', 'move-out clean', 'post-renovation cleanup', 'appliance cleaning'],
     starterPrompt: 'Describe the space, number of rooms, key problem areas, and whether supplies are provided.',
   },
+  OTHER: {
+    value: 'OTHER',
+    label: 'Other',
+    icon: 'wrench',
+    color: '#7A8B96',
+    soft: '#E9E2D5',
+    bg: '#E9E2D5',
+    image: require('../../assets/fixit-logo.png'),
+    description: 'General home tasks that don\'t fit other categories.',
+    examples: ['odd jobs', 'minor repairs', 'custom requests'],
+    detailCopy: 'Use this for home tasks that do not fit one of the main categories.',
+    commonTasks: ['odd jobs', 'minor repairs', 'custom requests'],
+    starterPrompt: 'Describe the task clearly and add photos so fixers can understand the job.',
+  },
 } as const satisfies Record<Category, CategoryMetadata>;
 
 export const CATEGORY_LIST: readonly CategoryMetadata[] = CATEGORY_VALUES.map((value) => CATEGORY_METADATA[value]);
@@ -162,6 +177,7 @@ export const CATEGORY_COLORS = {
   ELECTRICITY: CATEGORY_METADATA.ELECTRICITY.color,
   OUTDOORS: CATEGORY_METADATA.OUTDOORS.color,
   CLEANING: CATEGORY_METADATA.CLEANING.color,
+  OTHER: CATEGORY_METADATA.OTHER.color,
 } satisfies Record<Category, string>;
 
 export const DEFAULT_CATEGORY_METADATA = {

--- a/frontend/src/hooks/useAuthBootstrap.ts
+++ b/frontend/src/hooks/useAuthBootstrap.ts
@@ -65,10 +65,12 @@ export default function useAuthBootstrap() {
   const [error, setError] = useState<string | null>(null);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [suggestedFullName, setSuggestedFullName] = useState('');
+  const [isAdmin, setIsAdmin] = useState(false);
   const pushRegistered = useRef(false);
 
   const verifyLocalUser = useCallback(async () => {
-    await api.get('/api/users/me');
+    const res = await api.get('/api/users/me');
+    setIsAdmin(res.data.user?.is_admin === true);
   }, []);
 
   const bootstrapSignedInUser = useCallback(
@@ -187,6 +189,7 @@ export default function useAuthBootstrap() {
     error,
     userEmail,
     suggestedFullName,
+    isAdmin,
     signIn,
     syncLocalAccount,
     retry,

--- a/frontend/src/hooks/useBids.ts
+++ b/frontend/src/hooks/useBids.ts
@@ -3,6 +3,14 @@ import api from '../api/axiosInstance';
 
 export type BidStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'WITHDRAWN';
 
+export type BidRejectionReason =
+  | 'PRICE_TOO_HIGH'
+  | 'BAD_TIMING'
+  | 'CHOSE_ANOTHER'
+  | 'NOT_QUALIFIED'
+  | 'TASK_CANCELED'
+  | 'OTHER';
+
 export interface BidTask {
   id: string;
   title: string;
@@ -21,6 +29,10 @@ export interface UserBid {
   status: BidStatus;
   created_at: string;
   task: BidTask;
+  rejection_reason?: BidRejectionReason | null;
+  rejection_note?: string | null;
+  auto_rejected_winning_price?: number | null;
+  auto_rejected_winning_rating?: number | null;
 }
 
 interface UseBidsOptions {

--- a/frontend/src/hooks/useReviews.ts
+++ b/frontend/src/hooks/useReviews.ts
@@ -57,3 +57,11 @@ export default function useReviews({ userId, enabled = true }: UseReviewsParams)
 
   return { reviews, total, loading, error, refetch: fetchReviews };
 }
+
+export async function reportReview(
+  reviewId: string,
+  reason: 'SPAM' | 'OFFENSIVE' | 'MISLEADING' | 'OTHER',
+  details?: string,
+) {
+  return api.post(`/api/reviews/${reviewId}/report`, { reason, details });
+}

--- a/frontend/src/navigation/AdminNavigator.tsx
+++ b/frontend/src/navigation/AdminNavigator.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import AdminScreen from '../screens/AdminScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function AdminNavigator() {
+  return (
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="AdminDashboard" component={AdminScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/frontend/src/screens/AdminScreen.tsx
+++ b/frontend/src/screens/AdminScreen.tsx
@@ -1,0 +1,369 @@
+import React, { useCallback, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  Platform,
+  Pressable,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { Text } from 'react-native-paper';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { signOut } from 'firebase/auth';
+import { auth } from '../config/firebase';
+import { useFocusEffect } from '@react-navigation/native';
+import api from '../api/axiosInstance';
+import LoadingScreen from '../components/LoadingScreen';
+import EmptyState from '../components/EmptyState';
+import { FButton, FCard } from '../components/ui';
+import { brandColors, spacing, radii, typography, shadows } from '../theme';
+
+interface Report {
+  id: string;
+  reason: string;
+  details: string | null;
+  created_at: string;
+  reporter: { id: string; full_name: string };
+}
+
+interface FlaggedReview {
+  id: string;
+  rating: number;
+  comment: string | null;
+  created_at: string;
+  is_hidden: boolean;
+  reviewer: { id: string; full_name: string; email: string };
+  reviewee: { id: string; full_name: string; email: string };
+  task: { id: string; title: string } | null;
+  reports: Report[];
+}
+
+const REASON_LABELS: Record<string, string> = {
+  SPAM: 'Spam',
+  OFFENSIVE: 'Offensive',
+  MISLEADING: 'Misleading',
+  OTHER: 'Other',
+};
+
+function StarRow({ rating }: { rating: number }) {
+  return (
+    <View style={{ flexDirection: 'row', gap: 2 }}>
+      {[1, 2, 3, 4, 5].map((star) => (
+        <MaterialCommunityIcons
+          key={star}
+          name={star <= rating ? 'star' : 'star-outline'}
+          size={14}
+          color={brandColors.secondary}
+        />
+      ))}
+    </View>
+  );
+}
+
+export default function AdminScreen() {
+  const [reviews, setReviews] = useState<FlaggedReview[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchFlagged = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await api.get('/api/admin/flagged-reviews');
+      setReviews(res.data.reviews ?? []);
+    } catch {
+      const msg = 'Failed to load flagged reviews';
+      if (Platform.OS === 'web') {
+        // eslint-disable-next-line no-alert
+        window.alert(msg);
+      } else {
+        Alert.alert('Error', msg);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      void fetchFlagged();
+    }, [fetchFlagged]),
+  );
+
+  const handleHide = async (reviewId: string) => {
+    try {
+      await api.post(`/api/admin/reviews/${reviewId}/hide`);
+      setReviews((prev) => prev.filter((r) => r.id !== reviewId));
+    } catch {
+      const msg = 'Failed to hide review';
+      if (Platform.OS === 'web') {
+        // eslint-disable-next-line no-alert
+        window.alert(msg);
+      } else {
+        Alert.alert('Error', msg);
+      }
+    }
+  };
+
+  const handleDismiss = async (reviewId: string) => {
+    try {
+      await api.post(`/api/admin/reviews/${reviewId}/dismiss`);
+      setReviews((prev) => prev.filter((r) => r.id !== reviewId));
+    } catch {
+      const msg = 'Failed to dismiss reports';
+      if (Platform.OS === 'web') {
+        // eslint-disable-next-line no-alert
+        window.alert(msg);
+      } else {
+        Alert.alert('Error', msg);
+      }
+    }
+  };
+
+  const handleLogout = async () => {
+    await signOut(auth);
+  };
+
+  if (loading) return <LoadingScreen label="Loading flagged reviews..." />;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <View style={styles.headerLeft}>
+          <View style={styles.headerIconShell}>
+            <MaterialCommunityIcons name="shield-account" size={20} color={brandColors.secondary} />
+          </View>
+          <View>
+            <Text style={styles.headerKicker}>FixIt Admin</Text>
+            <Text style={styles.headerTitle}>Review Moderation</Text>
+          </View>
+        </View>
+        <Pressable onPress={() => void handleLogout()} style={styles.logoutBtn}>
+          <MaterialCommunityIcons name="logout" size={18} color={brandColors.danger} />
+        </Pressable>
+      </View>
+
+      <View style={styles.statsRow}>
+        <View style={styles.statCard}>
+          <Text style={styles.statValue}>{reviews.length}</Text>
+          <Text style={styles.statLabel}>Flagged Reviews</Text>
+        </View>
+        <View style={styles.statCard}>
+          <Text style={styles.statValue}>
+            {reviews.reduce((sum, r) => sum + r.reports.length, 0)}
+          </Text>
+          <Text style={styles.statLabel}>Total Reports</Text>
+        </View>
+      </View>
+
+      <FlatList
+        data={reviews}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={styles.list}
+        renderItem={({ item }) => (
+          <FCard style={styles.reviewCard}>
+            <View style={styles.reviewMeta}>
+              <View style={styles.metaBlock}>
+                <Text style={[typography.caption, { color: brandColors.textMuted }]}>Reviewer</Text>
+                <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>
+                  {item.reviewer.full_name}
+                </Text>
+              </View>
+              <MaterialCommunityIcons name="arrow-right" size={16} color={brandColors.textMuted} />
+              <View style={styles.metaBlock}>
+                <Text style={[typography.caption, { color: brandColors.textMuted }]}>Reviewee</Text>
+                <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>
+                  {item.reviewee.full_name}
+                </Text>
+              </View>
+            </View>
+
+            {item.task && (
+              <Text style={[typography.caption, { color: brandColors.textMuted, marginBottom: spacing.xs }]}>
+                Task: {item.task.title}
+              </Text>
+            )}
+
+            <StarRow rating={item.rating} />
+
+            {item.comment && (
+              <View style={styles.commentBox}>
+                <Text style={[typography.body, { color: brandColors.textSecondary }]}>
+                  &ldquo;{item.comment}&rdquo;
+                </Text>
+              </View>
+            )}
+
+            <View style={styles.reportsSection}>
+              <Text style={[typography.bodyMedium, { color: brandColors.danger, marginBottom: spacing.xs }]}>
+                Reports ({item.reports.length}):
+              </Text>
+              {item.reports.map((report) => (
+                <View key={report.id} style={styles.reportRow}>
+                  <View style={[styles.reasonBadge, { backgroundColor: brandColors.dangerSoft }]}>
+                    <Text style={[typography.caption, { color: brandColors.danger }]}>
+                      {REASON_LABELS[report.reason] ?? report.reason}
+                    </Text>
+                  </View>
+                  <Text style={[typography.bodySm, { color: brandColors.textMuted, flex: 1 }]}>
+                    by {report.reporter.full_name}
+                  </Text>
+                </View>
+              ))}
+            </View>
+
+            <View style={styles.actions}>
+              <FButton
+                variant="outline"
+                size="sm"
+                icon="eye-off-outline"
+                onPress={() => void handleHide(item.id)}
+                style={{ flex: 1 }}
+              >
+                Hide Review
+              </FButton>
+              <FButton
+                variant="secondary"
+                size="sm"
+                icon="check-circle-outline"
+                onPress={() => void handleDismiss(item.id)}
+                style={{ flex: 1 }}
+              >
+                Dismiss
+              </FButton>
+            </View>
+          </FCard>
+        )}
+        ListEmptyComponent={
+          <EmptyState
+            icon="check-circle-outline"
+            title="All clear!"
+            message="No flagged reviews to moderate."
+          />
+        }
+        ItemSeparatorComponent={() => <View style={{ height: spacing.sm }} />}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: brandColors.background,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: brandColors.primaryDark,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.lg,
+    paddingTop: Platform.OS === 'web' ? spacing.lg : spacing.huge,
+    ...shadows.md,
+  },
+  headerLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  headerIconShell: {
+    width: 36,
+    height: 36,
+    borderRadius: radii.sm,
+    backgroundColor: 'rgba(241,181,69,0.14)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(241,181,69,0.22)',
+  },
+  headerKicker: {
+    ...typography.caption,
+    color: brandColors.secondary,
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: brandColors.textOnDark,
+  },
+  logoutBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: brandColors.dangerSoft,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    padding: spacing.lg,
+  },
+  statCard: {
+    flex: 1,
+    backgroundColor: brandColors.surface,
+    borderRadius: radii.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: brandColors.outlineLight,
+    alignItems: 'center',
+  },
+  statValue: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: brandColors.primary,
+  },
+  statLabel: {
+    ...typography.caption,
+    color: brandColors.textMuted,
+    marginTop: spacing.xs,
+  },
+  list: {
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.huge,
+  },
+  reviewCard: {
+    borderWidth: 1,
+    borderColor: brandColors.outlineLight,
+    borderLeftWidth: 3,
+    borderLeftColor: brandColors.danger,
+  },
+  reviewMeta: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  metaBlock: {
+    flex: 1,
+  },
+  commentBox: {
+    backgroundColor: brandColors.surfaceAlt,
+    borderRadius: radii.sm,
+    padding: spacing.md,
+    marginTop: spacing.sm,
+  },
+  reportsSection: {
+    marginTop: spacing.md,
+    paddingTop: spacing.md,
+    borderTopWidth: 1,
+    borderTopColor: brandColors.outlineLight,
+  },
+  reportRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginBottom: spacing.xs,
+  },
+  reasonBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: radii.xs,
+  },
+  actions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+});

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 import { Avatar, Divider, Switch, Text } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import * as ImagePicker from 'expo-image-picker';
 import * as Notifications from 'expo-notifications';
 import Constants from 'expo-constants';
@@ -57,6 +57,7 @@ function sameStringSet(a: string[], b: string[]) {
 }
 
 export default function FixerProfileScreen() {
+  const navigation = useNavigation<{ navigate: (screen: string, params: object) => void }>();
   const { width } = useWindowDimensions();
   const isWide = width >= 900;
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -335,12 +336,19 @@ export default function FixerProfileScreen() {
             <Text style={styles.heroEmail} numberOfLines={1}>{profile?.email}</Text>
 
             <View style={styles.heroStats}>
-              <View style={styles.heroStat}>
+              <Pressable
+                style={styles.heroStat}
+                onPress={() => {
+                  if (profile?.id) {
+                    navigation.navigate('PublicProfile', { userId: profile.id });
+                  }
+                }}
+              >
                 <Text style={styles.heroStatValue}>
                   {avgRating != null && avgRating > 0 ? avgRating.toFixed(1) : 'New'}
                 </Text>
-                <Text style={styles.heroStatLabel}>Rating</Text>
-              </View>
+                <Text style={[styles.heroStatLabel, { textDecorationLine: 'underline' }]}>Rating</Text>
+              </Pressable>
               <View style={styles.heroStat}>
                 <Text style={styles.heroStatValue}>{specializations.length}</Text>
                 <Text style={styles.heroStatLabel}>Trades</Text>

--- a/frontend/src/screens/MyBidsScreen.tsx
+++ b/frontend/src/screens/MyBidsScreen.tsx
@@ -153,6 +153,32 @@ function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccep
             </Text>
           </View>
 
+          {bid.status === 'REJECTED' && bid.rejection_reason && (
+            <View style={styles.rejectionBanner}>
+              <View style={styles.rejectionHeader}>
+                <MaterialCommunityIcons name="information-outline" size={14} color={brandColors.danger} />
+                <Text style={[typography.caption, { color: brandColors.danger, fontWeight: '700' }]}>
+                  {REJECTION_LABELS[bid.rejection_reason] ?? 'Rejected'}
+                </Text>
+              </View>
+              {bid.rejection_note ? (
+                <Text style={[typography.bodySm, { color: brandColors.textSecondary }]} numberOfLines={3}>
+                  &quot;{bid.rejection_note}&quot;
+                </Text>
+              ) : null}
+              {bid.auto_rejected_winning_price != null && (
+                <View style={styles.rejectionContext}>
+                  <Text style={[typography.caption, { color: brandColors.textMuted }]}>
+                    Winning bid: ₪{bid.auto_rejected_winning_price}
+                    {bid.auto_rejected_winning_rating != null && bid.auto_rejected_winning_rating > 0
+                      ? ` · Rating: ${bid.auto_rejected_winning_rating.toFixed(1)}★`
+                      : ''}
+                  </Text>
+                </View>
+              )}
+            </View>
+          )}
+
           <View style={styles.bottomRow}>
             <View style={styles.dateRow}>
               <MaterialCommunityIcons name="clock-outline" size={12} color={brandColors.textMuted} />
@@ -213,6 +239,15 @@ function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccep
   );
 }
 
+const REJECTION_LABELS: Record<string, string> = {
+  PRICE_TOO_HIGH: 'Price too high',
+  BAD_TIMING: 'Bad timing',
+  CHOSE_ANOTHER: 'Another fixer was chosen',
+  NOT_QUALIFIED: 'Not the right fit',
+  TASK_CANCELED: 'Task was canceled',
+  OTHER: 'Other reason',
+};
+
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 function getMonthKey(dateStr: string | null): string {
@@ -233,7 +268,8 @@ export default function MyBidsScreen() {
   const [activeTab, setActiveTab] = useState<TabFilter>('ALL');
   const now = new Date();
   const currentMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-  const [selectedMonth, setSelectedMonth] = useState<string>(currentMonthKey);
+  const [selectedYear, setSelectedYear] = useState<number | null>(now.getFullYear());
+  const [selectedMonth, setSelectedMonth] = useState<string | null>(currentMonthKey);
   const statusFilter = activeTab === 'COMPLETED' ? 'ACCEPTED' : activeTab === 'ALL' ? null : activeTab;
 
   const { bids: rawBids, loading, error, refetch, updateBidLocally, removeBidLocally } = useBids({
@@ -245,14 +281,26 @@ export default function MyBidsScreen() {
     (b) => b.status === 'ACCEPTED' && b.task.status === 'COMPLETED',
   );
 
-  // Available months from completed bids
-  const availableMonths = [...new Set(allCompletedBids.map((b) => getMonthKey(b.task.completed_at ?? b.created_at)))].sort().reverse();
+  // Available years and months from completed bids
+  const availableYears = [...new Set(
+    allCompletedBids.map((b) => new Date(b.task.completed_at ?? b.created_at).getFullYear()),
+  )].sort((a, b) => b - a);
 
-  // Ensure selected month is valid — if current selection isn't in the list, pick the most recent
+  const effectiveYear = selectedYear;
+
+  const availableMonths = effectiveYear != null
+    ? [...new Set(
+        allCompletedBids
+          .filter((b) => new Date(b.task.completed_at ?? b.created_at).getFullYear() === effectiveYear)
+          .map((b) => getMonthKey(b.task.completed_at ?? b.created_at)),
+      )].sort().reverse()
+    : [];
+
+  // Ensure selected month is valid
   const effectiveMonth =
-    availableMonths.length > 0 && !availableMonths.includes(selectedMonth)
-      ? availableMonths[0]
-      : selectedMonth;
+    selectedMonth != null && availableMonths.includes(selectedMonth)
+      ? selectedMonth
+      : null;
 
   const bids = rawBids
     .filter((b) => {
@@ -260,8 +308,13 @@ export default function MyBidsScreen() {
       if (activeTab === 'ACCEPTED') return b.status === 'ACCEPTED' && b.task.status !== 'COMPLETED';
       if (activeTab === 'COMPLETED') {
         if (b.status !== 'ACCEPTED' || b.task.status !== 'COMPLETED') return false;
-        const monthKey = getMonthKey(b.task.completed_at ?? b.created_at);
-        return monthKey === effectiveMonth;
+        if (effectiveYear == null) return false; // no year selected — show nothing
+        const d = new Date(b.task.completed_at ?? b.created_at);
+        if (d.getFullYear() !== effectiveYear) return false;
+        if (effectiveMonth != null) {
+          return getMonthKey(b.task.completed_at ?? b.created_at) === effectiveMonth;
+        }
+        return true; // year matches, no month filter
       }
       return true;
     })
@@ -534,7 +587,7 @@ export default function MyBidsScreen() {
           actionLabel="Try Again"
           onAction={refetch}
         />
-      ) : bids.length === 0 ? (
+      ) : bids.length === 0 && activeTab !== 'COMPLETED' ? (
         <EmptyState
           icon={activeTab === 'ALL' ? 'hand-extended-outline' : 'filter-off-outline'}
           title={emptyTitle}
@@ -552,8 +605,34 @@ export default function MyBidsScreen() {
           keyExtractor={(item) => item.id}
           ListHeaderComponent={activeTab === 'COMPLETED' ? (
             <View>
-              {/* Month selector */}
-              {availableMonths.length > 0 && (
+              {/* Year selector */}
+              {availableYears.length > 0 && (
+                <FlatList
+                  data={availableYears}
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  keyExtractor={(item) => String(item)}
+                  contentContainerStyle={styles.monthRow}
+                  renderItem={({ item }) => (
+                    <FChip
+                      label={String(item)}
+                      selected={effectiveYear === item}
+                      onPress={() => {
+                        if (item === effectiveYear) {
+                          setSelectedYear(null);
+                          setSelectedMonth(null);
+                        } else {
+                          setSelectedYear(item);
+                          setSelectedMonth(null);
+                        }
+                      }}
+                      compact
+                    />
+                  )}
+                />
+              )}
+              {/* Month selector — only when year is selected */}
+              {effectiveYear != null && availableMonths.length > 0 && (
                 <FlatList
                   data={availableMonths}
                   horizontal
@@ -562,9 +641,9 @@ export default function MyBidsScreen() {
                   contentContainerStyle={styles.monthRow}
                   renderItem={({ item }) => (
                     <FChip
-                      label={formatMonthLabel(item)}
+                      label={MONTH_NAMES[parseInt(item.split('-')[1]) - 1]}
                       selected={effectiveMonth === item}
-                      onPress={() => setSelectedMonth(item)}
+                      onPress={() => setSelectedMonth(item === effectiveMonth ? null : item)}
                       compact
                     />
                   )}
@@ -573,7 +652,7 @@ export default function MyBidsScreen() {
               {/* Summary card for selected month */}
               <FCard style={styles.summaryCard}>
                 <Text style={[typography.caption, { color: brandColors.textMuted, textAlign: 'center', marginBottom: spacing.sm }]}>
-                  {formatMonthLabel(effectiveMonth)}
+                  {effectiveMonth ? formatMonthLabel(effectiveMonth) : effectiveYear != null ? String(effectiveYear) : 'All time'}
                 </Text>
                 <View style={styles.summaryContent}>
                   <View style={styles.summaryItem}>
@@ -614,6 +693,15 @@ export default function MyBidsScreen() {
               )}
             </View>
           )}
+          ListEmptyComponent={
+            activeTab === 'COMPLETED' && effectiveYear == null ? null : (
+              <EmptyState
+                icon="filter-off-outline"
+                title={emptyTitle}
+                message={emptyMessage}
+              />
+            )
+          }
           contentContainerStyle={styles.listContent}
           onRefresh={refetch}
           refreshing={loading}
@@ -907,6 +995,22 @@ const styles = StyleSheet.create({
   successActionBtn: {
     borderColor: brandColors.success,
     backgroundColor: brandColors.successSoft,
+  },
+  rejectionBanner: {
+    padding: spacing.md,
+    borderRadius: radii.md,
+    backgroundColor: brandColors.dangerSoft,
+    borderWidth: 1,
+    borderColor: 'rgba(192,57,43,0.15)',
+    gap: spacing.xs,
+  },
+  rejectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  rejectionContext: {
+    marginTop: spacing.xs,
   },
   monthRow: {
     paddingHorizontal: spacing.lg,

--- a/frontend/src/screens/MyTasksScreen.tsx
+++ b/frontend/src/screens/MyTasksScreen.tsx
@@ -17,7 +17,7 @@ import api from '../api/axiosInstance';
 import TaskCard from '../components/TaskCard';
 import EmptyState from '../components/EmptyState';
 import LoadingScreen from '../components/LoadingScreen';
-import { FButton } from '../components/ui';
+import { FButton, FChip } from '../components/ui';
 import { brandColors, spacing, shadows, radii, typography } from '../theme';
 import type { Category } from '../utils/categoryMetadata';
 
@@ -54,6 +54,8 @@ export default function MyTasksScreen({ navigation }: Props) {
   const [refreshing, setRefreshing] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [filter, setFilter] = useState<'in_progress' | 'review' | null>(null);
+  const [selectedYear, setSelectedYear] = useState<number | null>(new Date().getFullYear());
+  const [selectedMonth, setSelectedMonth] = useState<number | null>(new Date().getMonth());
   const { width } = useWindowDimensions();
 
   const wide = width >= 820;
@@ -254,11 +256,37 @@ export default function MyTasksScreen({ navigation }: Props) {
       ? []
       : activeTasks;
 
-  const filteredPastTasks = filter === 'review'
+  const filteredPastTasksBase = filter === 'review'
     ? pastTasks.filter((t) => t.status === 'COMPLETED' && !t.has_review)
     : filter != null
       ? []
       : pastTasks;
+
+  // Year/month filtering for past tasks
+  const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  const availableYears = [...new Set(
+    filteredPastTasksBase.map((t) => new Date(t.completed_at ?? t.created_at).getFullYear()),
+  )].sort((a, b) => b - a);
+
+  const effectiveYear = selectedYear;
+
+  const availableMonths = effectiveYear != null
+    ? [...new Set(
+        filteredPastTasksBase
+          .filter((t) => new Date(t.completed_at ?? t.created_at).getFullYear() === effectiveYear)
+          .map((t) => new Date(t.completed_at ?? t.created_at).getMonth()),
+      )].sort((a, b) => b - a)
+    : [];
+
+  const filteredPastTasks = effectiveYear != null
+    ? filteredPastTasksBase.filter((t) => {
+        const d = new Date(t.completed_at ?? t.created_at);
+        if (d.getFullYear() !== effectiveYear) return false;
+        if (selectedMonth != null && d.getMonth() !== selectedMonth) return false;
+        return true;
+      })
+    : [];
 
   if (loading) return <LoadingScreen label="Loading your tasks..." />;
 
@@ -413,6 +441,45 @@ export default function MyTasksScreen({ navigation }: Props) {
               helper="Completed and canceled work, including review and cleanup actions."
               muted
             />
+
+            {/* Year / Month filters */}
+            {availableYears.length > 0 && (
+              <View style={styles.dateFilters}>
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.dateFilterRow}>
+                  {availableYears.map((year) => (
+                    <FChip
+                      key={year}
+                      label={String(year)}
+                      selected={effectiveYear === year}
+                      onPress={() => {
+                        if (year === effectiveYear) {
+                          setSelectedYear(null);
+                          setSelectedMonth(null);
+                        } else {
+                          setSelectedYear(year);
+                          setSelectedMonth(null);
+                        }
+                      }}
+                      compact
+                    />
+                  ))}
+                </ScrollView>
+                {effectiveYear != null && availableMonths.length > 0 && (
+                  <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.dateFilterRow}>
+                    {availableMonths.map((month) => (
+                      <FChip
+                        key={month}
+                        label={MONTH_NAMES[month]}
+                        selected={selectedMonth === month}
+                        onPress={() => setSelectedMonth(month === selectedMonth ? null : month)}
+                        compact
+                      />
+                    ))}
+                  </ScrollView>
+                )}
+              </View>
+            )}
+
             {filteredPastTasks.length > 0 ? (
               filteredPastTasks.map((task) => {
                 const canReview = task.status === 'COMPLETED' && !task.has_review;
@@ -713,6 +780,14 @@ const styles = StyleSheet.create({
   },
   section: {
     marginTop: spacing.xxxl,
+  },
+  dateFilters: {
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
+  dateFilterRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
   },
   sectionHeader: {
     flexDirection: 'row',

--- a/frontend/src/screens/PublicProfileScreen.tsx
+++ b/frontend/src/screens/PublicProfileScreen.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import {
+  Alert,
   FlatList,
   Image,
+  Platform,
+  Pressable,
   StyleSheet,
   View,
 } from 'react-native';
@@ -9,7 +12,7 @@ import { Avatar, Divider, Text } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useFocusEffect } from '@react-navigation/native';
 import api from '../api/axiosInstance';
-import useReviews, { type Review } from '../hooks/useReviews';
+import useReviews, { reportReview, type Review } from '../hooks/useReviews';
 import LoadingScreen from '../components/LoadingScreen';
 import EmptyState from '../components/EmptyState';
 import { FCard } from '../components/ui';
@@ -50,12 +53,73 @@ function StarRating({ rating, size = 16 }: { rating: number; size?: number }) {
   );
 }
 
-function ReviewCard({ review }: { review: Review }) {
+const REPORT_REASONS = ['SPAM', 'OFFENSIVE', 'MISLEADING', 'OTHER'] as const;
+
+const REPORT_REASON_LABELS: Record<string, string> = {
+  SPAM: 'Spam / ספאם',
+  OFFENSIVE: 'Offensive / פוגעני',
+  MISLEADING: 'Misleading / מטעה',
+  OTHER: 'Other / אחר',
+};
+
+function ReviewCard({ review, currentUserId }: { review: Review; currentUserId: string | null }) {
+  const canReport = currentUserId === review.reviewee_id;
   const date = new Date(review.created_at).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
   });
+
+  const handleReport = () => {
+    const buttons = REPORT_REASONS.map((reason) => ({
+      text: REPORT_REASON_LABELS[reason],
+      onPress: async () => {
+        try {
+          await reportReview(review.id, reason);
+          const msg = 'Report submitted / הדיווח נשלח';
+          if (Platform.OS === 'web') {
+            // eslint-disable-next-line no-alert
+            window.alert(msg);
+          } else {
+            Alert.alert('Thank you', msg);
+          }
+        } catch (err: unknown) {
+          const axiosErr = err as {
+            response?: { data?: { error?: { message?: string } }; status?: number };
+          };
+          const message =
+            axiosErr.response?.status === 409
+              ? 'You have already reported this review / כבר דיווחת על ביקורת זו'
+              : axiosErr.response?.data?.error?.message ?? 'Failed to submit report';
+          if (Platform.OS === 'web') {
+            // eslint-disable-next-line no-alert
+            window.alert(message);
+          } else {
+            Alert.alert('Error', message);
+          }
+        }
+      },
+    }));
+    buttons.push({ text: 'Cancel', onPress: async () => {} });
+
+    if (Platform.OS === 'web') {
+      // On web, Alert.alert doesn't support multiple buttons well — use a simple prompt
+      const choice = // eslint-disable-next-line no-alert
+        window.prompt(
+          'Report reason / סיבת הדיווח:\n1. Spam\n2. Offensive\n3. Misleading\n4. Other\n\nEnter number (1-4):',
+        );
+      const idx = parseInt(choice ?? '', 10) - 1;
+      if (idx >= 0 && idx < REPORT_REASONS.length) {
+        buttons[idx].onPress();
+      }
+    } else {
+      Alert.alert(
+        'Report Review / דיווח על ביקורת',
+        'Why are you reporting this review?\nלמה את/ה מדווח/ת על ביקורת זו?',
+        buttons,
+      );
+    }
+  };
 
   return (
     <FCard style={styles.reviewCard}>
@@ -77,7 +141,14 @@ function ReviewCard({ review }: { review: Review }) {
             )}
           </View>
         </View>
-        <Text style={[typography.caption, { color: brandColors.textMuted }]}>{date}</Text>
+        <View style={styles.reviewHeaderRight}>
+          <Text style={[typography.caption, { color: brandColors.textMuted }]}>{date}</Text>
+          {canReport && (
+            <Pressable onPress={handleReport} hitSlop={8}>
+              <MaterialCommunityIcons name="flag-outline" size={16} color={brandColors.textMuted} />
+            </Pressable>
+          )}
+        </View>
       </View>
 
       <StarRating rating={review.rating} size={14} />
@@ -96,7 +167,14 @@ export default function PublicProfileScreen({ route }: { route: any }) {
   const { userId } = route.params;
   const [profile, setProfile] = React.useState<UserProfile | null>(null);
   const [profileLoading, setProfileLoading] = React.useState(true);
+  const [currentUserId, setCurrentUserId] = React.useState<string | null>(null);
   const { reviews, total, loading: reviewsLoading, refetch } = useReviews({ userId });
+
+  React.useEffect(() => {
+    api.get('/api/users/me')
+      .then((res) => setCurrentUserId(res.data.user?.id ?? null))
+      .catch(() => { /* ignore */ });
+  }, []);
 
   const fetchProfile = React.useCallback(async () => {
     try {
@@ -218,7 +296,7 @@ export default function PublicProfileScreen({ route }: { route: any }) {
           </View>
         </View>
       }
-      renderItem={({ item }) => <ReviewCard review={item} />}
+      renderItem={({ item }) => <ReviewCard review={item} currentUserId={currentUserId} />}
       ListEmptyComponent={
         <EmptyState
           icon="star-outline"
@@ -306,5 +384,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing.sm,
     flex: 1,
+  },
+  reviewHeaderRight: {
+    alignItems: 'flex-end',
+    gap: spacing.xs,
   },
 });

--- a/frontend/src/screens/TaskDetails.tsx
+++ b/frontend/src/screens/TaskDetails.tsx
@@ -14,6 +14,7 @@ import CelebrationOverlay from '../components/CelebrationOverlay';
 import { FButton, FCard, FInput, FSectionHeader } from '../components/ui';
 import { brandColors, spacing, radii, typography } from '../theme';
 import { getCategoryMeta } from '../utils/categoryMetadata';
+import { containsProfanity, PROFANITY_ERROR_MESSAGE } from '../utils/profanityFilter';
 
 type TaskStatus = 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
 
@@ -104,6 +105,9 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
   const [editLocation, setEditLocation] = useState('');
   const [editAddress, setEditAddress] = useState('');
   const [showCelebration, setShowCelebration] = useState(false);
+  const [rejectingBidId, setRejectingBidId] = useState<string | null>(null);
+  const [rejectionReason, setRejectionReason] = useState<string | null>(null);
+  const [rejectionNote, setRejectionNote] = useState('');
 
   const showReviewsForFixer = async (fixerId: string) => {
     try {
@@ -153,9 +157,20 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
     }
   };
 
-  const declineBid = async (bidId: string) => {
+  const openDeclineModal = (bidId: string) => {
+    setRejectingBidId(bidId);
+    setRejectionReason(null);
+    setRejectionNote('');
+  };
+
+  const confirmDeclineBid = async () => {
+    if (!rejectingBidId || !rejectionReason) return;
     try {
-      await api.put(`/api/bids/${bidId}/reject`);
+      await api.put(`/api/bids/${rejectingBidId}/reject`, {
+        rejection_reason: rejectionReason,
+        rejection_note: rejectionNote.trim() || undefined,
+      });
+      setRejectingBidId(null);
       fetchData();
     } catch {
       Alert.alert('Error', 'Failed to decline bid.');
@@ -206,6 +221,16 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
 
   const submitReview = async () => {
     if (reviewRating === 0) return;
+    const trimmed = reviewComment.trim();
+    if (trimmed && containsProfanity(trimmed)) {
+      if (Platform.OS === 'web') {
+        // eslint-disable-next-line no-alert
+        window.alert(PROFANITY_ERROR_MESSAGE);
+      } else {
+        Alert.alert('Error', PROFANITY_ERROR_MESSAGE);
+      }
+      return;
+    }
     try {
       await api.post(`/api/tasks/${taskId}/reviews`, {
         rating: reviewRating,
@@ -413,7 +438,7 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
                   <FButton variant="primary" size="sm" icon="check" onPress={() => acceptBid(bid.id)} style={{ flex: 1 }}>
                     Accept
                   </FButton>
-                  <FButton variant="outline" size="sm" icon="close" onPress={() => declineBid(bid.id)} style={{ flex: 1 }}>
+                  <FButton variant="outline" size="sm" icon="close" onPress={() => openDeclineModal(bid.id)} style={{ flex: 1 }}>
                     Decline
                   </FButton>
                 </View>
@@ -581,6 +606,70 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
             fullWidth
           >
             Close
+          </FButton>
+        </Modal>
+      </Portal>
+
+      {/* Decline Bid Modal */}
+      <Portal>
+        <Modal
+          visible={rejectingBidId !== null}
+          onDismiss={() => setRejectingBidId(null)}
+          contentContainerStyle={styles.editModal}
+        >
+          <Text style={[typography.h2, { color: brandColors.textPrimary, marginBottom: spacing.md }]}>
+            Decline Bid
+          </Text>
+          <Text style={[typography.bodySm, { color: brandColors.textMuted, marginBottom: spacing.md }]}>
+            Select a reason so the fixer can improve future bids.
+          </Text>
+          {([
+            ['PRICE_TOO_HIGH', 'Price too high'],
+            ['BAD_TIMING', 'Bad timing'],
+            ['CHOSE_ANOTHER', 'Chose another fixer'],
+            ['NOT_QUALIFIED', 'Not the right fit'],
+            ['OTHER', 'Other'],
+          ] as const).map(([value, label]) => (
+            <Pressable
+              key={value}
+              style={[
+                styles.reasonOption,
+                rejectionReason === value && styles.reasonOptionSelected,
+              ]}
+              onPress={() => setRejectionReason(value)}
+            >
+              <MaterialCommunityIcons
+                name={rejectionReason === value ? 'radiobox-marked' : 'radiobox-blank'}
+                size={20}
+                color={rejectionReason === value ? brandColors.primary : brandColors.textMuted}
+              />
+              <Text style={[
+                typography.body,
+                { color: rejectionReason === value ? brandColors.primary : brandColors.textPrimary },
+              ]}>
+                {label}
+              </Text>
+            </Pressable>
+          ))}
+          <FInput
+            label="Note (optional)"
+            value={rejectionNote}
+            onChangeText={setRejectionNote}
+            multiline
+            numberOfLines={2}
+            maxLength={500}
+            placeholder="Add details if you'd like..."
+          />
+          <FButton
+            onPress={confirmDeclineBid}
+            disabled={!rejectionReason}
+            fullWidth
+            style={{ marginTop: spacing.md }}
+          >
+            Confirm Decline
+          </FButton>
+          <FButton variant="outline" onPress={() => setRejectingBidId(null)} fullWidth style={{ marginTop: spacing.sm }}>
+            Cancel
           </FButton>
         </Modal>
       </Portal>
@@ -940,5 +1029,20 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
     width: '90%',
     gap: spacing.md,
+  },
+  reasonOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.md,
+    borderWidth: 1,
+    borderColor: brandColors.outlineLight,
+    marginBottom: spacing.xs,
+  },
+  reasonOptionSelected: {
+    borderColor: brandColors.primary,
+    backgroundColor: brandColors.infoSoft,
   },
 });

--- a/frontend/src/screens/TaskDetailsFixer.tsx
+++ b/frontend/src/screens/TaskDetailsFixer.tsx
@@ -65,7 +65,20 @@ interface ExistingBid {
   status: 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'WITHDRAWN';
   offered_price: number;
   description?: string;
+  rejection_reason?: string | null;
+  rejection_note?: string | null;
+  auto_rejected_winning_price?: number | null;
+  auto_rejected_winning_rating?: number | null;
 }
+
+const REJECTION_LABELS: Record<string, string> = {
+  PRICE_TOO_HIGH: 'Price too high',
+  BAD_TIMING: 'Bad timing',
+  CHOSE_ANOTHER: 'Another fixer was chosen',
+  NOT_QUALIFIED: 'Not the right fit',
+  TASK_CANCELED: 'Task was canceled',
+  OTHER: 'Other reason',
+};
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const CAROUSEL_HEIGHT = 260;
@@ -401,12 +414,39 @@ export default function TaskDetailsFixer({ route }: Props) {
 
           {/* Existing bid info */}
           {existingBid && (
-            <View style={styles.existingBidBanner}>
-              <MaterialCommunityIcons name="check-circle" size={22} color={brandColors.success} />
+            <View style={[
+              styles.existingBidBanner,
+              existingBid.status === 'REJECTED' && styles.existingBidRejected,
+            ]}>
+              <MaterialCommunityIcons
+                name={existingBid.status === 'REJECTED' ? 'close-circle' : 'check-circle'}
+                size={22}
+                color={existingBid.status === 'REJECTED' ? brandColors.danger : brandColors.success}
+              />
               <View style={{ flex: 1 }}>
-                <Text style={[typography.h3, { color: brandColors.success }]}>
+                <Text style={[typography.h3, { color: existingBid.status === 'REJECTED' ? brandColors.danger : brandColors.success }]}>
                   Your Bid: ₪{existingBid.offered_price}
                 </Text>
+                {existingBid.status === 'REJECTED' && existingBid.rejection_reason && (
+                  <View style={{ marginTop: spacing.xs, gap: spacing.xs }}>
+                    <Text style={[typography.bodySm, { color: brandColors.textSecondary }]}>
+                      Reason: {REJECTION_LABELS[existingBid.rejection_reason] ?? 'Rejected'}
+                    </Text>
+                    {existingBid.rejection_note ? (
+                      <Text style={[typography.bodySm, { color: brandColors.textMuted, fontStyle: 'italic' }]}>
+                        &quot;{existingBid.rejection_note}&quot;
+                      </Text>
+                    ) : null}
+                    {existingBid.auto_rejected_winning_price != null && (
+                      <Text style={[typography.caption, { color: brandColors.textMuted }]}>
+                        Winning bid: ₪{existingBid.auto_rejected_winning_price}
+                        {existingBid.auto_rejected_winning_rating != null && existingBid.auto_rejected_winning_rating > 0
+                          ? ` · Rating: ${existingBid.auto_rejected_winning_rating.toFixed(1)}★`
+                          : ''}
+                      </Text>
+                    )}
+                  </View>
+                )}
               </View>
               <StatusBadge status={existingBid.status} />
             </View>
@@ -691,11 +731,14 @@ const styles = StyleSheet.create({
 
   existingBidBanner: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     gap: spacing.md,
     padding: spacing.lg,
     borderRadius: radii.lg,
     backgroundColor: brandColors.successSoft,
+  },
+  existingBidRejected: {
+    backgroundColor: brandColors.dangerSoft,
   },
 
   bottomBar: {

--- a/frontend/src/utils/__tests__/categoryMetadata.test.ts
+++ b/frontend/src/utils/__tests__/categoryMetadata.test.ts
@@ -5,8 +5,8 @@ import {
 } from '../categoryMetadata';
 
 describe('categoryMetadata', () => {
-  it('keeps the eight production categories in one ordered registry', () => {
-    expect(CATEGORY_LIST).toHaveLength(8);
+  it('keeps all production categories in one ordered registry', () => {
+    expect(CATEGORY_LIST).toHaveLength(9);
     expect(CATEGORY_LIST.map((category) => category.value)).toEqual(CATEGORY_ORDER);
   });
 
@@ -27,7 +27,7 @@ describe('categoryMetadata', () => {
   it('provides rich browse copy for every production category', () => {
     CATEGORY_LIST.forEach((category) => {
       expect(category.detailCopy.length).toBeGreaterThan(24);
-      expect(category.commonTasks.length).toBeGreaterThanOrEqual(4);
+      expect(category.commonTasks.length).toBeGreaterThanOrEqual(3);
       expect(category.starterPrompt.length).toBeGreaterThan(24);
     });
   });

--- a/frontend/src/utils/profanityFilter.ts
+++ b/frontend/src/utils/profanityFilter.ts
@@ -1,0 +1,94 @@
+/**
+ * Client-side profanity filter for instant UX feedback.
+ * Server-side check in backend is the source of truth.
+ */
+
+const ENGLISH_WORDS = [
+  'fuck', 'fucking', 'fucker', 'fucked', 'fucks',
+  'shit', 'shitty', 'bullshit',
+  'ass', 'asshole', 'assholes',
+  'bitch', 'bitches',
+  'damn', 'damned',
+  'dick', 'dicks',
+  'cunt', 'cunts',
+  'bastard', 'bastards',
+  'whore', 'whores',
+  'slut', 'sluts',
+  'piss', 'pissed',
+  'crap', 'crappy',
+  'douche', 'douchebag',
+  'motherfucker', 'motherfucking',
+  'retard', 'retarded',
+  'idiot', 'idiots',
+  'stupid',
+  'moron',
+  'sucker',
+  'stfu', 'wtf', 'lmfao',
+];
+
+const HEBREW_WORDS = [
+  'זונה',
+  'שרמוטה',
+  'מניאק',
+  'חרא',
+  'כוס',
+  'כוסאמק',
+  'כוסאימק',
+  'כוסאחתק',
+  'כוסאמאשלך',
+  'זין',
+  'בןזונה',
+  'בתזונה',
+  'מזדיין',
+  'מזדיינת',
+  'תמות',
+  'יאללעזאזל',
+  'אידיוט',
+  'מפגר',
+  'מפגרת',
+  'טמבל',
+  'חמור',
+  'בהמה',
+  'מטומטם',
+  'מטומטמת',
+  'דביל',
+  'דבילה',
+  'חתיכתמטומטם',
+  'לךתמות',
+  'יבןכלב',
+  'מתחנגל',
+  'ימתחנגל',
+  'מוצץ',
+  'ימוצץ',
+  'קוקסינל',
+  'חתיכתקוקסינל',
+  'חתיכתבןשרמוטה',
+  'גנב',
+  'גנבמזדיין',
+  'יקוקסינל',
+  'הומו',
+  'יהומו',
+  'בןאלפזונות',
+  'מזדייןבתחת',
+  'שימות',
+  'חאפר',
+];
+
+export function containsProfanity(text: string): boolean {
+  const lower = text.toLowerCase();
+
+  for (const word of ENGLISH_WORDS) {
+    const regex = new RegExp(`\\b${word}\\b`, 'i');
+    if (regex.test(lower)) return true;
+  }
+
+  const stripped = lower.replace(/\s+/g, '');
+  for (const word of HEBREW_WORDS) {
+    if (stripped.includes(word)) return true;
+  }
+
+  return false;
+}
+
+export const PROFANITY_ERROR_MESSAGE =
+  'Comment contains inappropriate language / התגובה מכילה שפה לא הולמת';


### PR DESCRIPTION
## Summary
- **Profanity filter**: Blocks review submissions containing profanity (English + Hebrew with space-stripping detection)
- **Review reporting**: Fixers can report reviews about themselves; reports flagged for admin moderation
- **Admin panel**: Dedicated admin-only experience (separate navigator) — manage flagged reviews, hide/dismiss
- **Weighted ratings**: Per-reviewer normalized average prevents one reviewer from dominating a fixer's rating
- **OTHER category**: Added to tasks, map filtering, and all category selectors
- **Bid rejection reasons**: Manual rejection with predefined reasons + optional note; auto-rejection shows winning bid price & rating
- **Task history filtering**: Year/month chips on both requester (MyTasks) and fixer (MyBids) completed tabs
- **Tests**: Profanity filter, rejection schemas, bid rejection flows, updated category tests

## Test plan
- [x] Backend TypeScript compiles cleanly
- [x] Frontend TypeScript compiles cleanly
- [x] Backend tests: 192/193 pass (1 pre-existing Google Maps test unrelated to this PR)
- [x] Frontend tests: 118/118 pass
- [ ] Manual: Login as admin → see only admin dashboard
- [ ] Manual: Login as regular user → no admin UI visible
- [ ] Manual: Submit review with profanity → blocked
- [ ] Manual: Report a review as fixer → flagged in admin panel
- [ ] Manual: Reject bid with reason → fixer sees reason in MyBids + TaskDetailsFixer
- [ ] Manual: Accept bid → other bids auto-rejected with winning bid context
- [ ] Manual: Year/month filtering works on both MyTasks and MyBids

