### PR TITLE
test: add frontend profanityFilter test to fix coverage

### DIFF
--- a/frontend/src/utils/__tests__/profanityFilter.test.ts
+++ b/frontend/src/utils/__tests__/profanityFilter.test.ts
@@ -1,0 +1,31 @@
+import { containsProfanity, PROFANITY_ERROR_MESSAGE } from '../profanityFilter';
+
+describe('profanityFilter (frontend)', () => {
+  it('detects English profanity', () => {
+    expect(containsProfanity('this is shit')).toBe(true);
+    expect(containsProfanity('What the fuck')).toBe(true);
+  });
+
+  it('detects Hebrew profanity', () => {
+    expect(containsProfanity('זונה')).toBe(true);
+    expect(containsProfanity('בןזונה')).toBe(true);
+  });
+
+  it('detects Hebrew profanity with spaces stripped', () => {
+    expect(containsProfanity('בן זו נה')).toBe(true);
+  });
+
+  it('allows clean text', () => {
+    expect(containsProfanity('Great job, very professional!')).toBe(false);
+    expect(containsProfanity('עבודה מצוינת')).toBe(false);
+  });
+
+  it('returns false for empty input', () => {
+    expect(containsProfanity('')).toBe(false);
+  });
+
+  it('exports a user-facing error message', () => {
+    expect(typeof PROFANITY_ERROR_MESSAGE).toBe('string');
+    expect(PROFANITY_ERROR_MESSAGE.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Added test for `frontend/src/utils/profanityFilter.ts` which had 0% coverage
- Fixes Frontend CI branch coverage failure (78.33% → 80.55%, threshold is 80%)

## Test plan
- [x] All 124 frontend tests pass
- [x] Branch coverage above 80%

🤖 Generated with [Claude Code](https://claude.com/claude-code)