### PR TITLE
fix: discovery filter pills always-on with default

### DIFF
--- a/frontend/src/screens/DiscoveryFeedScreen.tsx
+++ b/frontend/src/screens/DiscoveryFeedScreen.tsx
@@ -60,7 +60,7 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
   const [searchFocused, setSearchFocused] = useState(false);
   const [fixerGps, setFixerGps] = useState<{ lat: number; lng: number } | null>(null);
   const [bidTaskIds, setBidTaskIds] = useState<Set<string>>(new Set());
-  const [bidFilter, setBidFilter] = useState<'has_bid' | 'no_bid' | null>(null);
+  const [bidFilter, setBidFilter] = useState<'all' | 'has_bid' | 'no_bid'>('all');
   const [showFilterPanel, setShowFilterPanel] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
@@ -455,20 +455,23 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
         </View>
 
         <View style={[styles.workspaceStats, isWide && styles.workspaceStatsWide]}>
-          <View style={styles.workspaceStat}>
+          <Pressable
+            style={[styles.workspaceStat, bidFilter === 'all' && styles.workspaceStatActive]}
+            onPress={() => setBidFilter('all')}
+          >
             <Text style={styles.workspaceStatValue}>{loading ? '...' : rawTasks.filter((t) => !currentUserId || t.requesterId !== currentUserId).length}</Text>
             <Text style={styles.workspaceStatLabel}>{t('discovery.stats.openJobs')}</Text>
-          </View>
+          </Pressable>
           <Pressable
             style={[styles.workspaceStat, bidFilter === 'no_bid' && styles.workspaceStatActive]}
-            onPress={() => setBidFilter(bidFilter === 'no_bid' ? null : 'no_bid')}
+            onPress={() => setBidFilter('no_bid')}
           >
             <Text style={styles.workspaceStatValue}>{loading ? '...' : rawTasks.filter((task) => (!currentUserId || task.requesterId !== currentUserId) && !bidTaskIds.has(task.id)).length}</Text>
             <Text style={styles.workspaceStatLabel}>{t('discovery.stats.new')}</Text>
           </Pressable>
           <Pressable
             style={[styles.workspaceStat, bidFilter === 'has_bid' && styles.workspaceStatActive]}
-            onPress={() => setBidFilter(bidFilter === 'has_bid' ? null : 'has_bid')}
+            onPress={() => setBidFilter('has_bid')}
           >
             <Text style={styles.workspaceStatValue}>{bidTaskIds.size}</Text>
             <Text style={styles.workspaceStatLabel}>{t('discovery.stats.alreadyBid')}</Text>


### PR DESCRIPTION
## Summary
- Open jobs pill now clickable and selected by default on map screen
- One pill always stays selected (no toggle-off behavior)
- Clicking another pill switches filter instead of toggling

## Test plan
- [x] Open discovery map — "Open jobs" pill is selected
- [x] Click "New" — switches to it, "Open jobs" deselects
- [x] Click "Already bid" — switches, previous deselects
- [x] Cannot deselect all pills

