### PR TITLE
UX: Rethink requester/fixer navigation and workspace distinction

### DIFF
--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -10,7 +10,9 @@ import {
 import { Text } from 'react-native-paper';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { useTranslation } from 'react-i18next';
 import AppLogo from './AppLogo';
+import { useLanguage } from '../context/LanguageContext';
 import { brandColors, radii, shadows, spacing, typography } from '../theme';
 
 const DRAWER_WIDTH = 320;
@@ -53,21 +55,23 @@ export default function HamburgerMenu({
   notificationCount = 0,
 }: HamburgerMenuProps) {
   const insets = useSafeAreaInsets();
-  const slideAnim = useRef(new Animated.Value(-DRAWER_WIDTH)).current;
+  const { t } = useTranslation();
+  const { isRTL } = useLanguage();
+  const slideAnim = useRef(new Animated.Value(isRTL ? DRAWER_WIDTH : -DRAWER_WIDTH)).current;
 
   useEffect(() => {
     Animated.timing(slideAnim, {
-      toValue: visible ? 0 : -DRAWER_WIDTH,
+      toValue: visible ? 0 : (isRTL ? DRAWER_WIDTH : -DRAWER_WIDTH),
       duration: 260,
       useNativeDriver: true,
     }).start();
-  }, [visible, slideAnim]);
+  }, [visible, slideAnim, isRTL]);
 
-  if (!visible && (slideAnim as Animated.Value & { _value: number })._value === -DRAWER_WIDTH) return null;
+  const hiddenOffset = isRTL ? DRAWER_WIDTH : -DRAWER_WIDTH;
+  if (!visible && (slideAnim as Animated.Value & { _value: number })._value === hiddenOffset) return null;
 
   return (
     <Modal transparent visible={visible} onRequestClose={onClose} animationType="none">
-      {/* backdrop */}
       <Pressable
         accessibilityRole="button"
         accessibilityLabel="Close navigation menu"
@@ -75,11 +79,11 @@ export default function HamburgerMenu({
         onPress={onClose}
       />
 
-      {/* drawer */}
       <Animated.View
         accessibilityViewIsModal
         style={[
           styles.drawer,
+          isRTL ? styles.drawerRTL : styles.drawerLTR,
           {
             paddingTop: insets.top + spacing.lg,
             paddingBottom: insets.bottom + spacing.xl,
@@ -87,11 +91,10 @@ export default function HamburgerMenu({
           },
         ]}
       >
-        {/* close button */}
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Close navigation menu"
-          style={[styles.closeBtn, { top: insets.top + spacing.sm }]}
+          style={[styles.closeBtn, isRTL ? styles.closeBtnRTL : styles.closeBtnLTR, { top: insets.top + spacing.sm }]}
           onPress={onClose}
           hitSlop={8}
         >
@@ -105,9 +108,9 @@ export default function HamburgerMenu({
           <View style={styles.brandBlock}>
             <AppLogo compact />
             {currentMode === 'fixer' && (
-              <View style={styles.currentModeChip}>
+              <View style={[styles.currentModeChip, { flexDirection: isRTL ? 'row-reverse' : 'row' }]}>
                 <MaterialCommunityIcons name="wrench-outline" size={13} color={brandColors.secondaryDark} />
-                <Text style={[typography.caption, styles.currentModeText]}>Fixer Workspace</Text>
+                <Text style={[typography.caption, styles.currentModeText]}>{t('menu.fixerWorkspace')}</Text>
               </View>
             )}
           </View>
@@ -115,60 +118,71 @@ export default function HamburgerMenu({
           {currentMode === 'fixer' ? (
             <>
               <MenuRow
-                icon="chevron-left"
-                label="Open Requester"
-                description="Switch to your requester dashboard"
+                icon={isRTL ? 'chevron-right' : 'chevron-left'}
+                label={t('menu.openRequester')}
+                description={t('menu.backToRequester')}
+                isRTL={isRTL}
                 onPress={() => { onModeChange('requester'); (onRequesterHomePress ?? (() => {}))(); onClose(); }}
               />
 
               <View style={styles.divider} />
 
-              <Text style={[typography.eyebrow, styles.sectionLabel]}>Fixer Workspace</Text>
+              <Text style={[typography.eyebrow, styles.sectionLabel, { textAlign: isRTL ? 'right' : 'left' }]}>
+                {t('menu.fixerSection')}
+              </Text>
 
               <MenuRow
                 icon="map-search-outline"
-                label="Find Jobs"
-                description="Browse and bid on tasks near you"
+                label={t('menu.findJobs')}
+                description={t('menu.findJobsDesc')}
+                isRTL={isRTL}
                 onPress={() => { (onFixerHomePress ?? (() => {}))(); onClose(); }}
               />
 
               <MenuRow
                 icon="format-list-bulleted"
-                label="My Bids"
-                description="Track pending and accepted offers"
+                label={t('menu.myBids')}
+                description={t('menu.myBidsDesc')}
+                isRTL={isRTL}
                 onPress={() => { (onFixerBidsPress ?? (() => {}))(); onClose(); }}
               />
 
               <MenuRow
                 icon="account-hard-hat"
-                label="Fixer Profile"
-                description="Skills, portfolio, and payment details"
+                label={t('menu.fixerProfile')}
+                description={t('menu.fixerProfileDesc')}
+                isRTL={isRTL}
                 onPress={() => { (onFixerProfilePress ?? (() => {}))(); onClose(); }}
               />
             </>
           ) : (
             <>
-              <Text style={[typography.eyebrow, styles.sectionLabel]}>My Workspace</Text>
+              <Text style={[typography.eyebrow, styles.sectionLabel, { textAlign: isRTL ? 'right' : 'left' }]}>
+                {t('menu.requesterSection')}
+              </Text>
 
               <MenuRow
                 icon="view-dashboard-outline"
-                label="Home"
-                description="Dashboard and task shortcuts"
+                label={t('menu.requesterHome')}
+                description={t('menu.requesterHomeDesc')}
+                isRTL={isRTL}
                 onPress={() => { (onRequesterHomePress ?? (() => {}))(); onClose(); }}
               />
 
               <MenuRow
                 icon="clipboard-list-outline"
-                label="My Tasks"
-                description="Review bids and manage posted tasks"
+                label={t('menu.requesterTasks')}
+                description={t('menu.requesterTasksDesc')}
+                isRTL={isRTL}
                 onPress={() => { (onRequesterTasksPress ?? (() => {}))(); onClose(); }}
               />
 
               {onPostTaskPress && (
                 <MenuRow
                   icon="plus-circle-outline"
-                  label="Post a Task"
-                  description="Create a new task"
+                  label={t('menu.postTask')}
+                  description={t('menu.postTaskDesc')}
+                  isRTL={isRTL}
                   onPress={() => { onPostTaskPress(); onClose(); }}
                 />
               )}
@@ -178,17 +192,19 @@ export default function HamburgerMenu({
           {onNotificationsPress && (
             <MenuRow
               icon="bell-outline"
-              label="Notifications"
-              description={notificationCount > 0 ? `${notificationCount} unread update${notificationCount === 1 ? '' : 's'}` : 'No unread updates'}
+              label={t('nav.notifications', 'Notifications')}
+              description={notificationCount > 0 ? `${notificationCount} unread` : ''}
               badge={notificationCount > 0 ? (notificationCount > 9 ? '9+' : String(notificationCount)) : undefined}
+              isRTL={isRTL}
               onPress={() => { onNotificationsPress(); onClose(); }}
             />
           )}
 
           <MenuRow
             icon="cog-outline"
-            label="Settings"
-            description="Password, phone, and notification controls"
+            label={t('nav.settings', 'Settings')}
+            description={t('settings.subtitle', '')}
+            isRTL={isRTL}
             onPress={() => { onSettingsPress(); onClose(); }}
           />
 
@@ -197,9 +213,10 @@ export default function HamburgerMenu({
               <View style={styles.divider} />
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel={fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+                accessibilityLabel={fixerActivated ? t('menu.openFixerWorkspace') : t('menu.becomeFixer')}
                 style={({ pressed }) => [
                   styles.fixerWorkspaceEntry,
+                  { flexDirection: isRTL ? 'row-reverse' : 'row' },
                   !fixerActivated && styles.fixerWorkspaceEntryPrimary,
                   pressed && styles.fixerWorkspaceEntryPressed,
                 ]}
@@ -208,23 +225,23 @@ export default function HamburgerMenu({
                 <View style={[styles.fixerWorkspaceEntryIcon, !fixerActivated && styles.fixerWorkspaceEntryIconPrimary]}>
                   <MaterialCommunityIcons name="wrench-outline" size={20} color="#fff" />
                 </View>
-                <View style={styles.modeText}>
+                <View style={[styles.modeText, { alignItems: isRTL ? 'flex-end' : 'flex-start' }]}>
                   <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>
-                    {fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+                    {fixerActivated ? t('menu.openFixerWorkspace') : t('menu.becomeFixer')}
                   </Text>
                   <Text style={[typography.caption, { color: brandColors.textMuted }]}>
-                    {fixerActivated ? 'Find jobs and earn money' : 'Set up your profile and start earning'}
+                    {fixerActivated ? t('menu.fixerWorkspaceDesc') : t('menu.becomeFixerDesc')}
                   </Text>
                 </View>
-                <MaterialCommunityIcons name="chevron-right" size={20} color={brandColors.textMuted} />
+                <MaterialCommunityIcons name={isRTL ? 'chevron-left' : 'chevron-right'} size={20} color={brandColors.textMuted} />
               </Pressable>
             </>
           )}
 
-          <View style={styles.footerNote}>
+          <View style={[styles.footerNote, { flexDirection: isRTL ? 'row-reverse' : 'row' }]}>
             <MaterialCommunityIcons name="shield-check-outline" size={16} color={brandColors.success} />
-            <Text style={[typography.caption, styles.footerText]}>
-              Your workspace, payments, and alerts stay tied to this account.
+            <Text style={[typography.caption, styles.footerText, { textAlign: isRTL ? 'right' : 'left' }]}>
+              {t('menu.footer')}
             </Text>
           </View>
         </ScrollView>
@@ -238,34 +255,36 @@ function MenuRow({
   label,
   description,
   badge,
+  isRTL = false,
   onPress,
 }: {
   icon: string;
   label: string;
   description: string;
   badge?: string;
+  isRTL?: boolean;
   onPress: () => void;
 }) {
   return (
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={badge ? `${label}, ${badge}. ${description}` : `${label}. ${description}`}
-      style={({ pressed }) => [styles.menuRow, pressed && styles.menuRowPressed]}
+      style={({ pressed }) => [styles.menuRow, { flexDirection: isRTL ? 'row-reverse' : 'row' }, pressed && styles.menuRowPressed]}
       onPress={onPress}
     >
       <View style={styles.menuIcon}>
         <MaterialCommunityIcons name={icon as never} size={21} color={brandColors.primaryMuted} />
       </View>
-      <View style={styles.menuText}>
+      <View style={[styles.menuText, { alignItems: isRTL ? 'flex-end' : 'flex-start' }]}>
         <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>{label}</Text>
-        <Text style={[typography.caption, { color: brandColors.textMuted }]}>{description}</Text>
+        {description ? <Text style={[typography.caption, { color: brandColors.textMuted }]}>{description}</Text> : null}
       </View>
       {badge ? (
         <View style={styles.menuBadge}>
           <Text style={styles.menuBadgeText}>{badge}</Text>
         </View>
       ) : (
-        <MaterialCommunityIcons name="chevron-right" size={20} color={brandColors.textMuted} />
+        <MaterialCommunityIcons name={isRTL ? 'chevron-left' : 'chevron-right'} size={20} color={brandColors.textMuted} />
       )}
     </Pressable>
   );
@@ -279,7 +298,6 @@ const styles = StyleSheet.create({
   drawer: {
     position: 'absolute',
     top: 0,
-    left: 0,
     bottom: 0,
     width: DRAWER_WIDTH,
     backgroundColor: brandColors.surface,
@@ -287,14 +305,25 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     ...shadows.lg,
   },
+  drawerLTR: {
+    left: 0,
+  },
+  drawerRTL: {
+    right: 0,
+  },
   drawerContent: {
     paddingBottom: spacing.xl,
   },
   closeBtn: {
     position: 'absolute',
-    right: spacing.lg,
     padding: spacing.xs,
     zIndex: 1,
+  },
+  closeBtnLTR: {
+    right: spacing.lg,
+  },
+  closeBtnRTL: {
+    left: spacing.lg,
   },
   brandBlock: {
     paddingRight: spacing.xl,

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -25,6 +25,7 @@ interface HamburgerMenuProps {
   onRequesterHomePress?: () => void;
   onRequesterTasksPress?: () => void;
   onPostTaskPress?: () => void;
+  onFixerWorkspacePress?: () => void;
   onFixerHomePress?: () => void;
   onFixerBidsPress?: () => void;
   onFixerProfilePress?: () => void;
@@ -41,6 +42,7 @@ export default function HamburgerMenu({
   onRequesterHomePress,
   onRequesterTasksPress,
   onPostTaskPress,
+  onFixerWorkspacePress,
   onFixerHomePress,
   onFixerBidsPress,
   onFixerProfilePress,
@@ -195,7 +197,7 @@ export default function HamburgerMenu({
                 accessibilityRole="button"
                 accessibilityLabel="Open Fixer Workspace"
                 style={({ pressed }) => [styles.fixerWorkspaceEntry, pressed && styles.fixerWorkspaceEntryPressed]}
-                onPress={() => { onModeChange('fixer'); (onFixerHomePress ?? (() => {}))(); onClose(); }}
+                onPress={() => { (onFixerWorkspacePress ?? (() => { onModeChange('fixer'); (onFixerHomePress ?? (() => {}))(); }))(); onClose(); }}
               >
                 <View style={styles.fixerWorkspaceEntryIcon}>
                   <MaterialCommunityIcons name="wrench-outline" size={20} color={brandColors.secondaryDark} />

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -30,7 +30,6 @@ interface HamburgerMenuProps {
   onFixerProfilePress?: () => void;
   onNotificationsPress?: () => void;
   onSettingsPress: () => void;
-  onLandingPress?: () => void;
   notificationCount?: number;
 }
 
@@ -47,7 +46,6 @@ export default function HamburgerMenu({
   onFixerProfilePress,
   onNotificationsPress,
   onSettingsPress,
-  onLandingPress,
   notificationCount = 0,
 }: HamburgerMenuProps) {
   const insets = useSafeAreaInsets();
@@ -102,117 +100,76 @@ export default function HamburgerMenu({
         >
           <View style={styles.brandBlock}>
             <AppLogo compact />
-            <View style={styles.currentModeChip}>
-              <MaterialCommunityIcons
-                name={currentMode === 'fixer' ? 'wrench-outline' : 'home-outline'}
-                size={13}
-                color={brandColors.primary}
-              />
-              <Text style={[typography.caption, styles.currentModeText]}>
-                {currentMode === 'fixer' ? 'Fixer Workspace' : 'Requester Workspace'}
-              </Text>
-            </View>
+            {currentMode === 'fixer' && (
+              <View style={styles.currentModeChip}>
+                <MaterialCommunityIcons name="wrench-outline" size={13} color={brandColors.secondaryDark} />
+                <Text style={[typography.caption, styles.currentModeText]}>Fixer Workspace</Text>
+              </View>
+            )}
           </View>
 
-          <Text style={[typography.eyebrow, styles.sectionLabel]}>Switch workspace</Text>
-
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Switch to requester workspace"
-            accessibilityState={{ selected: currentMode === 'requester' }}
-            style={[styles.modeCard, currentMode === 'requester' && styles.modeCardActive]}
-            onPress={() => { onModeChange('requester'); onClose(); }}
-          >
-            <View style={[styles.modeIcon, currentMode === 'requester' && styles.modeIconActive]}>
-              <MaterialCommunityIcons
-                name="home-outline"
-                size={22}
-                color={currentMode === 'requester' ? '#fff' : brandColors.primaryMuted}
+          {currentMode === 'fixer' ? (
+            <>
+              <MenuRow
+                icon="arrow-left"
+                label="Back to Home"
+                description="Return to your requester dashboard"
+                onPress={() => { onModeChange('requester'); (onRequesterHomePress ?? (() => {}))(); onClose(); }}
               />
-            </View>
-            <View style={styles.modeText}>
-              <Text style={[typography.h3, { color: currentMode === 'requester' ? brandColors.textPrimary : brandColors.textMuted }]}>
-                Requester
-              </Text>
-              <Text style={[typography.bodySm, { color: brandColors.textMuted }]}>Post tasks, get help</Text>
-            </View>
-            {currentMode === 'requester' && (
-              <MaterialCommunityIcons name="check-circle" size={20} color={brandColors.secondary} />
-            )}
-          </Pressable>
 
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Switch to fixer workspace"
-            accessibilityState={{ selected: currentMode === 'fixer' }}
-            style={[styles.modeCard, currentMode === 'fixer' && styles.modeCardActive]}
-            onPress={() => { onModeChange('fixer'); onClose(); }}
-          >
-            <View style={[styles.modeIcon, currentMode === 'fixer' && styles.modeIconActive]}>
-              <MaterialCommunityIcons
-                name="wrench-outline"
-                size={22}
-                color={currentMode === 'fixer' ? '#fff' : brandColors.primaryMuted}
+              <View style={styles.divider} />
+
+              <Text style={[typography.eyebrow, styles.sectionLabel]}>Fixer Workspace</Text>
+
+              <MenuRow
+                icon="map-search-outline"
+                label="Find Jobs"
+                description="Browse and bid on tasks near you"
+                onPress={() => { (onFixerHomePress ?? (() => {}))(); onClose(); }}
               />
-            </View>
-            <View style={styles.modeText}>
-              <Text style={[typography.h3, { color: currentMode === 'fixer' ? brandColors.textPrimary : brandColors.textMuted }]}>
-                Fixer
-              </Text>
-              <Text style={[typography.bodySm, { color: brandColors.textMuted }]}>Find jobs, earn money</Text>
-            </View>
-            {currentMode === 'fixer' && (
-              <MaterialCommunityIcons name="check-circle" size={20} color={brandColors.secondary} />
-            )}
-          </Pressable>
 
-          <View style={styles.divider} />
+              <MenuRow
+                icon="format-list-bulleted"
+                label="My Bids"
+                description="Track pending and accepted offers"
+                onPress={() => { (onFixerBidsPress ?? (() => {}))(); onClose(); }}
+              />
 
-          <Text style={[typography.eyebrow, styles.sectionLabel]}>Workspace</Text>
+              <MenuRow
+                icon="account-hard-hat"
+                label="Fixer Profile"
+                description="Skills, portfolio, and payment details"
+                onPress={() => { (onFixerProfilePress ?? (() => {}))(); onClose(); }}
+              />
+            </>
+          ) : (
+            <>
+              <Text style={[typography.eyebrow, styles.sectionLabel]}>My Workspace</Text>
 
-          <MenuRow
-            icon="view-dashboard-outline"
-            label="Requester Workspace"
-            description="Dashboard, task shortcuts, and active work"
-            onPress={() => { (onRequesterHomePress ?? (() => onModeChange('requester')))(); onClose(); }}
-          />
+              <MenuRow
+                icon="view-dashboard-outline"
+                label="Home"
+                description="Dashboard and task shortcuts"
+                onPress={() => { (onRequesterHomePress ?? (() => {}))(); onClose(); }}
+              />
 
-          <MenuRow
-            icon="clipboard-list-outline"
-            label="My Tasks"
-            description="Review bids and manage posted tasks"
-            onPress={() => { (onRequesterTasksPress ?? (() => onModeChange('requester')))(); onClose(); }}
-          />
+              <MenuRow
+                icon="clipboard-list-outline"
+                label="My Tasks"
+                description="Review bids and manage posted tasks"
+                onPress={() => { (onRequesterTasksPress ?? (() => {}))(); onClose(); }}
+              />
 
-          {onPostTaskPress && (
-            <MenuRow
-              icon="plus-circle-outline"
-              label="Post a Task"
-              description="Create a new requester task"
-              onPress={() => { onPostTaskPress(); onClose(); }}
-            />
+              {onPostTaskPress && (
+                <MenuRow
+                  icon="plus-circle-outline"
+                  label="Post a Task"
+                  description="Create a new task"
+                  onPress={() => { onPostTaskPress(); onClose(); }}
+                />
+              )}
+            </>
           )}
-
-          <MenuRow
-            icon="map-search-outline"
-            label="Find Jobs"
-            description="Open fixer discovery"
-            onPress={() => { (onFixerHomePress ?? (() => onModeChange('fixer')))(); onClose(); }}
-          />
-
-          <MenuRow
-            icon="format-list-bulleted"
-            label="My Bids"
-            description="Track pending and accepted offers"
-            onPress={() => { (onFixerBidsPress ?? (() => onModeChange('fixer')))(); onClose(); }}
-          />
-
-          <MenuRow
-            icon="account-hard-hat"
-            label="Fixer Profile"
-            description="Skills, portfolio, and payment details"
-            onPress={() => { (onFixerProfilePress ?? (() => onModeChange('fixer')))(); onClose(); }}
-          />
 
           {onNotificationsPress && (
             <MenuRow
@@ -231,13 +188,25 @@ export default function HamburgerMenu({
             onPress={() => { onSettingsPress(); onClose(); }}
           />
 
-          {onLandingPress && (
-            <MenuRow
-              icon="home-search-outline"
-              label="Back to Landing"
-              description="Return to the public FixIt home page"
-              onPress={() => { onLandingPress(); onClose(); }}
-            />
+          {currentMode === 'requester' && (
+            <>
+              <View style={styles.divider} />
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Open Fixer Workspace"
+                style={({ pressed }) => [styles.fixerWorkspaceEntry, pressed && styles.fixerWorkspaceEntryPressed]}
+                onPress={() => { onModeChange('fixer'); (onFixerHomePress ?? (() => {}))(); onClose(); }}
+              >
+                <View style={styles.fixerWorkspaceEntryIcon}>
+                  <MaterialCommunityIcons name="wrench-outline" size={20} color={brandColors.secondaryDark} />
+                </View>
+                <View style={styles.modeText}>
+                  <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>Fixer Workspace</Text>
+                  <Text style={[typography.caption, { color: brandColors.textMuted }]}>Find jobs and earn money</Text>
+                </View>
+                <MaterialCommunityIcons name="chevron-right" size={20} color={brandColors.textMuted} />
+              </Pressable>
+            </>
           )}
 
           <View style={styles.footerNote}>
@@ -328,42 +297,39 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.xs,
     borderRadius: radii.pill,
-    backgroundColor: brandColors.infoSoft,
+    backgroundColor: brandColors.warningSoft,
+    borderWidth: 1,
+    borderColor: brandColors.secondary,
   },
   currentModeText: {
-    color: brandColors.primary,
+    color: brandColors.secondaryDark,
     fontWeight: '700',
   },
-  sectionLabel: {
-    color: brandColors.textMuted,
-    marginBottom: spacing.md,
-  },
-  modeCard: {
+  fixerWorkspaceEntry: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.md,
     paddingVertical: spacing.md,
-    paddingHorizontal: spacing.md,
+    paddingHorizontal: spacing.sm,
     borderRadius: radii.lg,
-    marginBottom: spacing.sm,
     borderWidth: 1,
-    borderColor: brandColors.outlineLight,
-    backgroundColor: brandColors.background,
-  },
-  modeCardActive: {
     borderColor: brandColors.secondary,
     backgroundColor: brandColors.warningSoft,
   },
-  modeIcon: {
+  fixerWorkspaceEntryPressed: {
+    opacity: 0.82,
+  },
+  fixerWorkspaceEntryIcon: {
     width: 40,
     height: 40,
     borderRadius: radii.md,
-    backgroundColor: brandColors.surfaceAlt,
+    backgroundColor: brandColors.secondary,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  modeIconActive: {
-    backgroundColor: brandColors.primary,
+  sectionLabel: {
+    color: brandColors.textMuted,
+    marginBottom: spacing.md,
   },
   modeText: {
     flex: 1,

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -25,6 +25,7 @@ interface HamburgerMenuProps {
   onRequesterHomePress?: () => void;
   onRequesterTasksPress?: () => void;
   onPostTaskPress?: () => void;
+  fixerActivated?: boolean;
   onFixerWorkspacePress?: () => void;
   onFixerHomePress?: () => void;
   onFixerBidsPress?: () => void;
@@ -42,6 +43,7 @@ export default function HamburgerMenu({
   onRequesterHomePress,
   onRequesterTasksPress,
   onPostTaskPress,
+  fixerActivated = true,
   onFixerWorkspacePress,
   onFixerHomePress,
   onFixerBidsPress,
@@ -195,16 +197,24 @@ export default function HamburgerMenu({
               <View style={styles.divider} />
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel="Open Fixer Workspace"
-                style={({ pressed }) => [styles.fixerWorkspaceEntry, pressed && styles.fixerWorkspaceEntryPressed]}
+                accessibilityLabel={fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+                style={({ pressed }) => [
+                  styles.fixerWorkspaceEntry,
+                  !fixerActivated && styles.fixerWorkspaceEntryPrimary,
+                  pressed && styles.fixerWorkspaceEntryPressed,
+                ]}
                 onPress={() => { (onFixerWorkspacePress ?? (() => { onModeChange('fixer'); (onFixerHomePress ?? (() => {}))(); }))(); onClose(); }}
               >
-                <View style={styles.fixerWorkspaceEntryIcon}>
-                  <MaterialCommunityIcons name="wrench-outline" size={20} color={brandColors.secondaryDark} />
+                <View style={[styles.fixerWorkspaceEntryIcon, !fixerActivated && styles.fixerWorkspaceEntryIconPrimary]}>
+                  <MaterialCommunityIcons name="wrench-outline" size={20} color="#fff" />
                 </View>
                 <View style={styles.modeText}>
-                  <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>Fixer Workspace</Text>
-                  <Text style={[typography.caption, { color: brandColors.textMuted }]}>Find jobs and earn money</Text>
+                  <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>
+                    {fixerActivated ? 'Fixer Workspace' : 'Become a Fixer'}
+                  </Text>
+                  <Text style={[typography.caption, { color: brandColors.textMuted }]}>
+                    {fixerActivated ? 'Find jobs and earn money' : 'Set up your profile and start earning'}
+                  </Text>
                 </View>
                 <MaterialCommunityIcons name="chevron-right" size={20} color={brandColors.textMuted} />
               </Pressable>
@@ -318,6 +328,10 @@ const styles = StyleSheet.create({
     borderColor: brandColors.secondary,
     backgroundColor: brandColors.warningSoft,
   },
+  fixerWorkspaceEntryPrimary: {
+    borderColor: brandColors.secondaryDark,
+    backgroundColor: brandColors.warningSoft,
+  },
   fixerWorkspaceEntryPressed: {
     opacity: 0.82,
   },
@@ -328,6 +342,9 @@ const styles = StyleSheet.create({
     backgroundColor: brandColors.secondary,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  fixerWorkspaceEntryIconPrimary: {
+    backgroundColor: brandColors.secondaryDark,
   },
   sectionLabel: {
     color: brandColors.textMuted,

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -115,9 +115,9 @@ export default function HamburgerMenu({
           {currentMode === 'fixer' ? (
             <>
               <MenuRow
-                icon="arrow-left"
-                label="← Home"
-                description="Return to your requester dashboard"
+                icon="chevron-left"
+                label="Open Requester"
+                description="Switch to your requester dashboard"
                 onPress={() => { onModeChange('requester'); (onRequesterHomePress ?? (() => {}))(); onClose(); }}
               />
 

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -116,7 +116,7 @@ export default function HamburgerMenu({
             <>
               <MenuRow
                 icon="arrow-left"
-                label="Back to Home"
+                label="← Home"
                 description="Return to your requester dashboard"
                 onPress={() => { onModeChange('requester'); (onRequesterHomePress ?? (() => {}))(); onClose(); }}
               />
@@ -210,7 +210,7 @@ export default function HamburgerMenu({
                 </View>
                 <View style={styles.modeText}>
                   <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>
-                    {fixerActivated ? 'Fixer Workspace' : 'Become a Fixer'}
+                    {fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
                   </Text>
                   <Text style={[typography.caption, { color: brandColors.textMuted }]}>
                     {fixerActivated ? 'Find jobs and earn money' : 'Set up your profile and start earning'}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -11,6 +11,13 @@
     "mode": {
       "requester": "Requester",
       "fixer": "Fixer"
+    },
+    "workspace": {
+      "requesterBadge": "Requester",
+      "fixerBadge": "Fixer Workspace",
+      "openFixer": "Open Fixer Workspace",
+      "openRequester": "Open Requester Workspace",
+      "becomeFixer": "Become a Fixer"
     }
   },
   "categories": {
@@ -95,7 +102,7 @@
       "emailPlaceholder": "Please enter your email address",
       "submit": "Send Reset Link",
       "backToSignIn": "Back to Sign In",
-      "sentDescription": "Check your inbox — we sent a reset link to {{email}}.",
+      "sentDescription": "Check your inbox â€” we sent a reset link to {{email}}.",
       "failed": "Failed to send reset email"
     },
     "needsSync": {
@@ -319,7 +326,7 @@
     "header": {
       "kicker": "Fixer Workspace",
       "title": "Bid pipeline",
-      "sub": "{{tab}} bids · {{pending}} pending · {{active}} active jobs"
+      "sub": "{{tab}} bids Â· {{pending}} pending Â· {{active}} active jobs"
     },
     "tabs": {
       "active": "Active",
@@ -349,7 +356,7 @@
     },
     "editModal": {
       "title": "Edit Bid",
-      "offer": "Offer (₪)",
+      "offer": "Offer (â‚ª)",
       "description": "Description",
       "save": "Save Changes",
       "cancel": "Cancel"
@@ -401,7 +408,7 @@
     "header": {
       "kicker": "Fixer Workspace",
       "title": "Find jobs",
-      "sub": "Open jobs near {{location}} · {{categories}} · {{budget}}"
+      "sub": "Open jobs near {{location}} Â· {{categories}} Â· {{budget}}"
     },
     "stats": {
       "openJobs": "Open jobs",
@@ -449,7 +456,7 @@
     "error": {
       "couldNotLoad": "Could not load jobs",
       "retry": "Try Again",
-      "mapsNotReady": "Maps not ready — please try again.",
+      "mapsNotReady": "Maps not ready â€” please try again.",
       "couldNotResolve": "Could not resolve that place. Please try again.",
       "noResults": "No results found for that area."
     },
@@ -457,7 +464,7 @@
       "map": "Map",
       "list": "List",
       "budgetAny": "Budget: Any",
-      "budgetRange": "Budget: ₪{{min}}–₪{{max}}",
+      "budgetRange": "Budget: â‚ª{{min}}â€“â‚ª{{max}}",
       "clearFilters": "Clear filters",
       "currentLocation": "Current location"
     }
@@ -470,11 +477,11 @@
       "subtitle": "Say hello!"
     },
     "input": {
-      "placeholder": "Type a message…"
+      "placeholder": "Type a messageâ€¦"
     }
   },
   "conversations": {
-    "loading": "Loading messages…",
+    "loading": "Loading messagesâ€¦",
     "empty": {
       "title": "No conversations yet",
       "message": "Start a chat from a task once a bid is accepted."
@@ -554,7 +561,7 @@
       "title": "Edit Task",
       "titleLabel": "Title",
       "descriptionLabel": "Description",
-      "budgetLabel": "Budget (₪)",
+      "budgetLabel": "Budget (â‚ª)",
       "locationLabel": "General location",
       "addressLabel": "Exact address",
       "saveChanges": "Save Changes"
@@ -596,8 +603,8 @@
     "notFound": "Task not found.",
     "noPhotos": "No photos attached",
     "requester": "Task Requester",
-    "yourBid": "Your Bid: ₪{{amount}}",
-    "suggestedBudget": "Suggested budget: ₪{{amount}}",
+    "yourBid": "Your Bid: â‚ª{{amount}}",
+    "suggestedBudget": "Suggested budget: â‚ª{{amount}}",
     "openToQuotes": "The requester is open to quotes.",
     "error": {
       "title": "Something went wrong",
@@ -621,7 +628,7 @@
       "chatWithRequester": "Chat with Requester"
     },
     "bidStatus": {
-      "submitted": "Bid Submitted ✓",
+      "submitted": "Bid Submitted âœ“",
       "accepted": "Bid Accepted",
       "noLongerAccepting": "No longer accepting bids"
     },
@@ -634,7 +641,7 @@
     "bidModal": {
       "title": "Submit Your Bid",
       "editTitle": "Edit Your Bid",
-      "price": "Your price (₪)",
+      "price": "Your price (â‚ª)",
       "pricePlaceholder": "e.g. 250",
       "pitchLabel": "Your pitch",
       "pitchPlaceholder": "Tell the requester why you're the right person...",
@@ -642,7 +649,7 @@
       "submit": "Send Offer",
       "updateOffer": "Update Offer",
       "cancel": "Cancel",
-      "errorPrice": "Enter a valid price greater than ₪0.",
+      "errorPrice": "Enter a valid price greater than â‚ª0.",
       "errorPitch": "Write a short pitch to the requester.",
       "maxBids": "This task has reached the maximum number of bids (15).",
       "errorSubmit": "Failed to submit bid. Please try again."
@@ -678,7 +685,7 @@
       "subtitle": "Choose a fixed price or let fixers quote",
       "fixedPrice": "Fixed Price",
       "quoteRequired": "Quote Required",
-      "budgetLabel": "Budget (₪)",
+      "budgetLabel": "Budget (â‚ª)",
       "enterBudget": "Enter your budget",
       "quoteNote": "Fixers will propose their own price when bidding on your task.",
       "urgency": {
@@ -693,7 +700,7 @@
       "subtitle": "Enter the address and verify the pin on the map",
       "taskLocation": "Task location",
       "locationPlaceholder": "e.g., Dizengoff 120, Tel Aviv",
-      "pinPlaced": "Pin placed — drag it or tap the map to adjust",
+      "pinPlaced": "Pin placed â€” drag it or tap the map to adjust",
       "enterAddress": "Enter an address above to place the pin",
       "locationDenied": "Location access was denied. Enter the address above and we'll find it on the map.",
       "privacyNote": "Fixers see only an approximate location. The exact address is shared only after you accept a bid."
@@ -725,7 +732,7 @@
       "budget": {
         "fixed": "Fixed Price",
         "quote": "Quote Required",
-        "amount": "Amount (₪)"
+        "amount": "Amount (â‚ª)"
       },
       "location": {
         "generalArea": "General Area",
@@ -745,7 +752,7 @@
       "locationRequired": "Location is required",
       "failedCreate": "Failed to create task. Please try again.",
       "noResults": "No results found. Try a more specific address.",
-      "mapsNotReady": "Maps not ready — please try again.",
+      "mapsNotReady": "Maps not ready â€” please try again.",
       "couldNotFind": "Could not find this location. Please try again.",
       "photoPermissionTitle": "Permission required",
       "photoPermission": "Please allow access to your photo library to add images."
@@ -872,7 +879,7 @@
   "landing": {
     "hero": {
       "title": "Local fixes, trusted Fixers.",
-      "subtitle": "Post a task, compare bids from verified local pros, and get the job done — on your terms.",
+      "subtitle": "Post a task, compare bids from verified local pros, and get the job done â€” on your terms.",
       "postTask": "Post a Task",
       "becomeFixer": "Become a Fixer",
       "available": "Available across Israel",
@@ -921,7 +928,8 @@
       "signInToPost": "Sign in to Post Task",
       "openFixerWorkspace": "Open Fixer Workspace",
       "joinAsFixer": "Join as a Fixer",
-      "signInToFind": "Sign in to Find Jobs"
+      "signInToFind": "Sign in to Find Jobs",
+      "getStarted": "Get Started"
     },
     "stats": {
       "tasksPosted": "Tasks posted",
@@ -974,7 +982,7 @@
     },
     "footer": {
       "tagline": "Your neighborhood. Fixed.",
-      "copyright": "© 2026 FixIt · Tel Aviv, Israel",
+      "copyright": "Â© 2026 FixIt Â· Tel Aviv, Israel",
       "footerTagline": "Your neighborhood. Fixed. A task marketplace for homeowners and skilled local pros.",
       "madeby": "Made for neighbors who get things done.",
       "product": "Product",
@@ -994,7 +1002,7 @@
       "termsLink": "Terms"
     },
     "language": {
-      "toggle": "EN | עב"
+      "toggle": "EN | ×¢×‘"
     },
     "hero2": {
       "eyebrowDefault": "Trusted by 12,000+ neighbors in Israel",
@@ -1099,7 +1107,7 @@
     "fixerSection": {
       "eyebrow": "For Fixers",
       "title": "Turn your skills into local work.",
-      "body": "Build a steady book of local jobs. Set your own rates, work where you want, get paid in cash, Bit, or Paybox. No subscription, no lead fees — we take a small cut only when you're hired.",
+      "body": "Build a steady book of local jobs. Set your own rates, work where you want, get paid in cash, Bit, or Paybox. No subscription, no lead fees â€” we take a small cut only when you're hired.",
       "learnMore": "Learn more",
       "tiles": {
         "rate": {
@@ -1108,7 +1116,7 @@
         },
         "nearby": {
           "title": "Work nearby",
-          "desc": "Filter by distance — keep your commute short."
+          "desc": "Filter by distance â€” keep your commute short."
         },
         "trust": {
           "title": "Build trust",
@@ -1148,5 +1156,72 @@
     "leaveReview": "Leave review",
     "reopen": "Reopen",
     "markComplete": "Mark complete"
+  },
+  "becomeFixer": {
+    "hero": {
+      "title": "Become a Fixer",
+      "subtitle": "Earn money on your own terms by helping people with tasks in your area."
+    },
+    "benefits": {
+      "flexibleHours": {
+        "title": "Flexible Hours",
+        "body": "Work when you want — accept jobs that fit your schedule."
+      },
+      "findWork": {
+        "title": "Find Work Nearby",
+        "body": "Browse tasks posted in your area with a live map."
+      },
+      "earnMore": {
+        "title": "Earn More",
+        "body": "Set your own price on every bid. No middleman cut."
+      },
+      "reputation": {
+        "title": "Build Your Reputation",
+        "body": "Collect reviews and grow a profile clients trust."
+      }
+    },
+    "steps": {
+      "heading": "How to get started",
+      "profile": {
+        "label": "Complete your profile",
+        "detail": "Add a bio and your specialisations so requesters know who you are."
+      },
+      "browse": {
+        "label": "Browse open tasks",
+        "detail": "Find jobs near you on the map or list view."
+      },
+      "bid": {
+        "label": "Place a bid",
+        "detail": "Name your price and send a short note. The requester picks their favourite."
+      }
+    },
+    "cta": {
+      "setupProfile": "Set Up My Profile",
+      "browseFirst": "Browse jobs first"
+    }
+  },
+  "menu": {
+    "fixerWorkspace": "Fixer Workspace",
+    "openRequester": "Open Requester",
+    "backToRequester": "Switch to your requester dashboard",
+    "requesterSection": "My Workspace",
+    "requesterHome": "Home",
+    "requesterHomeDesc": "Dashboard and task shortcuts",
+    "requesterTasks": "My Tasks",
+    "requesterTasksDesc": "Review bids and manage posted tasks",
+    "postTask": "Post a Task",
+    "postTaskDesc": "Create a new task",
+    "fixerSection": "Fixer Workspace",
+    "findJobs": "Find Jobs",
+    "findJobsDesc": "Browse and bid on tasks near you",
+    "myBids": "My Bids",
+    "myBidsDesc": "Track pending and accepted offers",
+    "fixerProfile": "Fixer Profile",
+    "fixerProfileDesc": "Skills, portfolio, and payment details",
+    "openFixerWorkspace": "Open Fixer Workspace",
+    "becomeFixer": "Become a Fixer",
+    "fixerWorkspaceDesc": "Find jobs and earn money",
+    "becomeFixerDesc": "Set up your profile and start earning",
+    "footer": "Your workspace, payments, and alerts stay tied to this account."
   }
 }

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -11,6 +11,13 @@
     "mode": {
       "requester": "מזמין",
       "fixer": "מתקן"
+    },
+    "workspace": {
+      "requesterBadge": "מזמין",
+      "fixerBadge": "סביבת מתקן",
+      "openFixer": "פתח סביבת מתקן",
+      "openRequester": "פתח סביבת מזמין",
+      "becomeFixer": "הפוך למתקן"
     }
   },
   "categories": {
@@ -921,7 +928,8 @@
       "signInToPost": "התחבר לפרסום משימה",
       "openFixerWorkspace": "פתח סביבת עבודה",
       "joinAsFixer": "הצטרף כמתקן",
-      "signInToFind": "התחבר למציאת עבודות"
+      "signInToFind": "התחבר למציאת עבודות",
+      "getStarted": "התחל עכשיו"
     },
     "stats": {
       "tasksPosted": "משימות שפורסמו",
@@ -1148,5 +1156,72 @@
     "leaveReview": "השאר ביקורת",
     "reopen": "פתח מחדש",
     "markComplete": "סמן כהושלם"
+  },
+  "becomeFixer": {
+    "hero": {
+      "title": "הפוך למתקן",
+      "subtitle": "הרוויח כסף בתנאים שלך על ידי עזרה לאנשים עם משימות באזורך."
+    },
+    "benefits": {
+      "flexibleHours": {
+        "title": "שעות גמישות",
+        "body": "עבוד מתי שנוח לך — קבל עבודות שמתאימות ללוח הזמנים שלך."
+      },
+      "findWork": {
+        "title": "מצא עבודה קרוב",
+        "body": "עיין במשימות שפורסמו באזורך עם מפה חיה."
+      },
+      "earnMore": {
+        "title": "הרוויח יותר",
+        "body": "קבע את המחיר שלך בכל הצעה. ללא עמלת ביניים."
+      },
+      "reputation": {
+        "title": "בנה מוניטין",
+        "body": "אסוף ביקורות וצור פרופיל שלקוחות סומכים עליו."
+      }
+    },
+    "steps": {
+      "heading": "איך מתחילים",
+      "profile": {
+        "label": "השלם את הפרופיל",
+        "detail": "הוסף ביו והתמחויות שלך כדי שמזמינים יידעו מי אתה."
+      },
+      "browse": {
+        "label": "עיין במשימות פתוחות",
+        "detail": "מצא עבודות קרוב אליך במפה או בתצוגת רשימה."
+      },
+      "bid": {
+        "label": "הגש הצעה",
+        "detail": "קבע את המחיר ושלח הערה קצרה. המזמין בוחר את המועדף עליו."
+      }
+    },
+    "cta": {
+      "setupProfile": "הגדר את הפרופיל שלי",
+      "browseFirst": "עיין בעבודות קודם"
+    }
+  },
+  "menu": {
+    "fixerWorkspace": "סביבת מתקן",
+    "openRequester": "פתח סביבת מזמין",
+    "backToRequester": "עבור ללוח המחוונים שלך כמזמין",
+    "requesterSection": "סביבת העבודה שלי",
+    "requesterHome": "בית",
+    "requesterHomeDesc": "לוח מחוונים וקיצורי דרך למשימות",
+    "requesterTasks": "המשימות שלי",
+    "requesterTasksDesc": "בחן הצעות ונהל משימות שפורסמו",
+    "postTask": "פרסם משימה",
+    "postTaskDesc": "צור משימה חדשה",
+    "fixerSection": "סביבת מתקן",
+    "findJobs": "מצא עבודות",
+    "findJobsDesc": "עיין והגש הצעות על משימות קרובות",
+    "myBids": "ההצעות שלי",
+    "myBidsDesc": "עקוב אחר הצעות ממתינות ומקובלות",
+    "fixerProfile": "פרופיל מתקן",
+    "fixerProfileDesc": "כישורים, תיק עבודות ופרטי תשלום",
+    "openFixerWorkspace": "פתח סביבת מתקן",
+    "becomeFixer": "הפוך למתקן",
+    "fixerWorkspaceDesc": "מצא עבודות והרוויח כסף",
+    "becomeFixerDesc": "הגדר את הפרופיל שלך והתחל להרוויח",
+    "footer": "סביבת העבודה, התשלומות וההתראות שלך קשורות לחשבון זה."
   }
 }

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -172,6 +172,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
     <View
       style={[
         styles.desktopBar,
+        mode === 'fixer' && styles.desktopBarFixer,
         {
           height: topInset + 64,
           paddingTop: topInset,
@@ -190,7 +191,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
 
         {mode === 'fixer' && (
           <View style={styles.fixerWorkspaceLabel}>
-            <MaterialCommunityIcons name="wrench-outline" size={14} color={brandColors.secondary} />
+            <MaterialCommunityIcons name="wrench-outline" size={14} color="#fff" />
             <Text style={styles.fixerWorkspaceLabelText}>Fixer Workspace</Text>
           </View>
         )}
@@ -209,16 +210,19 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
                   onPress={() => openWorkspaceScreen(item.screen)}
                   style={({ pressed }) => [
                     styles.desktopPageTab,
-                    selected && styles.desktopPageTabActive,
+                    selected && (mode === 'fixer' ? styles.desktopPageTabActiveFixer : styles.desktopPageTabActive),
                     pressed && styles.desktopActionPressed,
                   ]}
                 >
                   <MaterialCommunityIcons
                     name={item.icon as never}
                     size={18}
-                    color={selected ? brandColors.primary : brandColors.textMuted}
+                    color={selected ? (mode === 'fixer' ? brandColors.secondaryDark : brandColors.primary) : brandColors.textMuted}
                   />
-                  <Text style={[styles.desktopPageTabText, selected && styles.desktopPageTabTextActive]}>
+                  <Text style={[
+                    styles.desktopPageTabText,
+                    selected && (mode === 'fixer' ? styles.desktopPageTabTextActiveFixer : styles.desktopPageTabTextActive),
+                  ]}>
                     {item.label}
                   </Text>
                   {showMsgBadge && <NotifBadge count={unreadMsgCount} />}
@@ -304,11 +308,11 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
                     ? `Open notifications, ${notificationCount} unread`
                     : 'Open notifications'
                 }
-                style={({ pressed }) => [styles.desktopIconBtn, pressed && styles.desktopActionPressed]}
+                style={({ pressed }) => [styles.desktopIconBtn, styles.desktopIconBtnFixer, pressed && styles.desktopActionPressed]}
                 hitSlop={8}
                 onPress={openNotifications}
               >
-                <MaterialCommunityIcons name="bell-outline" size={20} color={brandColors.primary} />
+                <MaterialCommunityIcons name="bell-outline" size={20} color={brandColors.secondaryDark} />
                 <NotifBadge count={notificationCount} />
               </Pressable>
 
@@ -722,14 +726,14 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.xs,
     borderRadius: radii.pill,
-    backgroundColor: brandColors.warningSoft,
+    backgroundColor: brandColors.secondaryDark,
     borderWidth: 1,
-    borderColor: brandColors.secondary,
+    borderColor: brandColors.secondaryDark,
   },
   fixerWorkspaceLabelText: {
     fontSize: 11,
     fontWeight: '700',
-    color: brandColors.secondaryDark,
+    color: '#fff',
   },
   // Fixer workspace entry button (requester mode, right actions)
   desktopFixerWorkspaceBtn: {
@@ -758,11 +762,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     borderRadius: radii.pill,
     borderWidth: 1,
-    borderColor: brandColors.outlineLight,
-    backgroundColor: brandColors.surfaceAlt,
+    borderColor: brandColors.secondaryDark,
+    backgroundColor: 'rgba(255,255,255,0.55)',
   },
   desktopBackHomeBtnText: {
-    color: brandColors.textMuted,
+    color: brandColors.secondaryDark,
     fontSize: 12,
     fontWeight: '700',
     lineHeight: 16,
@@ -798,6 +802,22 @@ const styles = StyleSheet.create({
   },
   desktopPageTabTextActive: {
     color: brandColors.primary,
+  },
+  // Fixer-mode tab variants
+  desktopBarFixer: {
+    backgroundColor: '#FDF3E0',
+    borderBottomColor: brandColors.secondary,
+  },
+  desktopPageTabActiveFixer: {
+    backgroundColor: brandColors.warningSoft,
+    borderColor: brandColors.secondary,
+  },
+  desktopPageTabTextActiveFixer: {
+    color: brandColors.secondaryDark,
+  },
+  desktopIconBtnFixer: {
+    backgroundColor: brandColors.warningSoft,
+    borderColor: brandColors.secondary,
   },
 
   // Language switcher chips

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -132,10 +132,6 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
     openStackScreen('NotificationCenter');
   };
 
-  const openSettings = () => {
-    openStackScreen('Settings');
-  };
-
   const openCreateTask = () => {
     openStackScreen('CreateTask');
   };
@@ -192,52 +188,14 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
           <AppLogo compact />
         </Pressable>
 
-        <View style={styles.desktopCenter}>
-          <View style={styles.modeToggleWrap}>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Switch to requester workspace"
-              accessibilityState={{ selected: mode === 'requester' }}
-              style={[styles.modeToggleBtn, mode === 'requester' && styles.modeToggleBtnActive]}
-              onPress={() => handleModeChange('requester')}
-            >
-              <MaterialCommunityIcons
-                name="home-outline"
-                size={15}
-                color={mode === 'requester' ? brandColors.textOnDark : brandColors.primaryMuted}
-              />
-              <Text
-                style={[
-                  styles.modeToggleLabel,
-                  mode === 'requester' && styles.modeToggleLabelActive,
-                ]}
-              >
-                {t('nav.mode.requester')}
-              </Text>
-            </Pressable>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Switch to fixer workspace"
-              accessibilityState={{ selected: mode === 'fixer' }}
-              style={[styles.modeToggleBtn, mode === 'fixer' && styles.modeToggleBtnActive]}
-              onPress={() => handleModeChange('fixer')}
-            >
-              <MaterialCommunityIcons
-                name="wrench-outline"
-                size={15}
-                color={mode === 'fixer' ? brandColors.textOnDark : brandColors.primaryMuted}
-              />
-              <Text
-                style={[
-                  styles.modeToggleLabel,
-                  mode === 'fixer' && styles.modeToggleLabelActive,
-                ]}
-              >
-                {t('nav.mode.fixer')}
-              </Text>
-            </Pressable>
+        {mode === 'fixer' && (
+          <View style={styles.fixerWorkspaceLabel}>
+            <MaterialCommunityIcons name="wrench-outline" size={14} color={brandColors.secondary} />
+            <Text style={styles.fixerWorkspaceLabelText}>Fixer Workspace</Text>
           </View>
+        )}
 
+        <View style={styles.desktopCenter}>
           <View style={styles.desktopPageTabs}>
             {workspaceTabs.map((item) => {
               const selected = activeScreen === item.screen;
@@ -271,57 +229,100 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
         </View>
 
         <View style={styles.desktopActions}>
-          {mode === 'requester' && (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Post a task"
-              style={({ pressed }) => [styles.desktopPrimaryAction, pressed && styles.desktopActionPressed]}
-              onPress={openCreateTask}
-            >
-              <MaterialCommunityIcons name="plus" size={17} color={brandColors.primaryDark} />
-              <Text style={styles.desktopPrimaryActionText}>{t('nav.postTask')}</Text>
-            </Pressable>
-          )}
-
-          <View style={styles.langSwitcher}>
-            {(['en', 'he'] as const).map((lang) => (
+          {mode === 'requester' ? (
+            <>
               <Pressable
-                key={lang}
-                onPress={() => void changeLanguage(lang)}
-                style={[styles.langChip, language === lang && styles.langChipActive]}
+                accessibilityRole="button"
+                accessibilityLabel="Post a task"
+                style={({ pressed }) => [styles.desktopPrimaryAction, pressed && styles.desktopActionPressed]}
+                onPress={openCreateTask}
               >
-                <Text style={[styles.langChipText, language === lang && styles.langChipTextActive]}>
-                  {lang === 'en' ? 'EN' : 'עב'}
-                </Text>
+                <MaterialCommunityIcons name="plus" size={17} color={brandColors.primaryDark} />
+                <Text style={styles.desktopPrimaryActionText}>{t('nav.postTask')}</Text>
               </Pressable>
-            ))}
-          </View>
 
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={
-              notificationCount > 0
-                ? `Open notifications, ${notificationCount} unread`
-                : 'Open notifications'
-            }
-            style={({ pressed }) => [styles.desktopIconBtn, pressed && styles.desktopActionPressed]}
-            hitSlop={8}
-            onPress={openNotifications}
-          >
-            <MaterialCommunityIcons name="bell-outline" size={20} color={brandColors.primary} />
-            <NotifBadge count={notificationCount} />
-          </Pressable>
+              <View style={styles.langSwitcher}>
+                {(['en', 'he'] as const).map((lang) => (
+                  <Pressable
+                    key={lang}
+                    onPress={() => void changeLanguage(lang)}
+                    style={[styles.langChip, language === lang && styles.langChipActive]}
+                  >
+                    <Text style={[styles.langChipText, language === lang && styles.langChipTextActive]}>
+                      {lang === 'en' ? 'EN' : 'עב'}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
 
-          {mode === 'fixer' && (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Open settings"
-              style={({ pressed }) => [styles.desktopIconBtn, pressed && styles.desktopActionPressed]}
-              hitSlop={8}
-              onPress={openSettings}
-            >
-              <MaterialCommunityIcons name="cog-outline" size={20} color={brandColors.primary} />
-            </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={
+                  notificationCount > 0
+                    ? `Open notifications, ${notificationCount} unread`
+                    : 'Open notifications'
+                }
+                style={({ pressed }) => [styles.desktopIconBtn, pressed && styles.desktopActionPressed]}
+                hitSlop={8}
+                onPress={openNotifications}
+              >
+                <MaterialCommunityIcons name="bell-outline" size={20} color={brandColors.primary} />
+                <NotifBadge count={notificationCount} />
+              </Pressable>
+
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Open Fixer Workspace"
+                style={({ pressed }) => [styles.desktopFixerWorkspaceBtn, pressed && styles.desktopActionPressed]}
+                hitSlop={8}
+                onPress={() => handleModeChange('fixer')}
+              >
+                <MaterialCommunityIcons name="wrench-outline" size={15} color={brandColors.secondaryDark} />
+                <Text style={styles.desktopFixerWorkspaceBtnText}>Fixer Workspace</Text>
+              </Pressable>
+            </>
+          ) : (
+            <>
+              <View style={styles.langSwitcher}>
+                {(['en', 'he'] as const).map((lang) => (
+                  <Pressable
+                    key={lang}
+                    onPress={() => void changeLanguage(lang)}
+                    style={[styles.langChip, language === lang && styles.langChipActive]}
+                  >
+                    <Text style={[styles.langChipText, language === lang && styles.langChipTextActive]}>
+                      {lang === 'en' ? 'EN' : 'עב'}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={
+                  notificationCount > 0
+                    ? `Open notifications, ${notificationCount} unread`
+                    : 'Open notifications'
+                }
+                style={({ pressed }) => [styles.desktopIconBtn, pressed && styles.desktopActionPressed]}
+                hitSlop={8}
+                onPress={openNotifications}
+              >
+                <MaterialCommunityIcons name="bell-outline" size={20} color={brandColors.primary} />
+                <NotifBadge count={notificationCount} />
+              </Pressable>
+
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Back to Home"
+                style={({ pressed }) => [styles.desktopBackHomeBtn, pressed && styles.desktopActionPressed]}
+                hitSlop={8}
+                onPress={() => handleModeChange('requester')}
+              >
+                <MaterialCommunityIcons name="arrow-left" size={15} color={brandColors.primaryMuted} />
+                <Text style={styles.desktopBackHomeBtnText}>Back to Home</Text>
+              </Pressable>
+            </>
           )}
         </View>
       </View>
@@ -713,35 +714,58 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     lineHeight: 16,
   },
-  // Mode toggle (desktop)
-  modeToggleWrap: {
-    flexDirection: 'row',
-    backgroundColor: brandColors.surfaceAlt,
-    borderRadius: radii.pill,
-    padding: 3,
-    gap: 2,
-    borderWidth: 1,
-    borderColor: brandColors.outlineLight,
-  },
-  modeToggleBtn: {
+  // Fixer workspace label (shown next to logo in fixer mode)
+  fixerWorkspaceLabel: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs,
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.xs + 2,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.xs,
     borderRadius: radii.pill,
+    backgroundColor: brandColors.warningSoft,
+    borderWidth: 1,
+    borderColor: brandColors.secondary,
   },
-  modeToggleBtnActive: {
-    backgroundColor: brandColors.primary,
+  fixerWorkspaceLabelText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: brandColors.secondaryDark,
   },
-  modeToggleLabel: {
+  // Fixer workspace entry button (requester mode, right actions)
+  desktopFixerWorkspaceBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    height: 38,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+    borderColor: brandColors.outlineLight,
+    backgroundColor: brandColors.surfaceAlt,
+  },
+  desktopFixerWorkspaceBtnText: {
+    color: brandColors.secondaryDark,
     fontSize: 12,
     fontWeight: '700',
     lineHeight: 16,
-    color: brandColors.textMuted,
   },
-  modeToggleLabelActive: {
-    color: brandColors.textOnDark,
+  // Back to home button (fixer mode, right actions)
+  desktopBackHomeBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    height: 38,
+    paddingHorizontal: spacing.md,
+    borderRadius: radii.pill,
+    borderWidth: 1,
+    borderColor: brandColors.outlineLight,
+    backgroundColor: brandColors.surfaceAlt,
+  },
+  desktopBackHomeBtnText: {
+    color: brandColors.textMuted,
+    fontSize: 12,
+    fontWeight: '700',
+    lineHeight: 16,
   },
   desktopPageTabs: {
     flexDirection: 'row',

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -335,13 +335,13 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
 
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel="Back to home"
+                accessibilityLabel="Open Requester Workspace"
                 style={({ pressed }) => [styles.desktopBackHomeBtn, pressed && styles.desktopActionPressed]}
                 hitSlop={8}
                 onPress={() => handleModeChange('requester')}
               >
-                <MaterialCommunityIcons name="arrow-left" size={14} color={brandColors.secondaryDark} />
-                <Text style={styles.desktopBackHomeBtnText}>Home</Text>
+                <MaterialCommunityIcons name="chevron-left" size={14} color={brandColors.secondaryDark} />
+                <Text style={styles.desktopBackHomeBtnText}>Open Requester</Text>
               </Pressable>
             </>
           )}

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -194,10 +194,15 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
           <AppLogo compact />
         </Pressable>
 
-        {mode === 'fixer' && (
-          <View style={styles.fixerWorkspaceLabel}>
-            <MaterialCommunityIcons name="wrench-outline" size={14} color="#fff" />
-            <Text style={styles.fixerWorkspaceLabelText}>Fixer Workspace</Text>
+        {mode === 'fixer' ? (
+          <View style={styles.modeLabel}>
+            <MaterialCommunityIcons name="wrench-outline" size={13} color="#fff" />
+            <Text style={styles.modeLabelText}>Fixer Workspace</Text>
+          </View>
+        ) : (
+          <View style={[styles.modeLabel, styles.modeLabelRequester]}>
+            <MaterialCommunityIcons name="home-outline" size={13} color={brandColors.primary} />
+            <Text style={[styles.modeLabelText, styles.modeLabelRequesterText]}>Requester</Text>
           </View>
         )}
 
@@ -290,10 +295,11 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
                 hitSlop={8}
                 onPress={openFixerOnboarding}
               >
-                <MaterialCommunityIcons name="wrench-outline" size={15} color={fixerActivated ? brandColors.secondaryDark : '#fff'} />
+                <MaterialCommunityIcons name="wrench-outline" size={14} color={fixerActivated ? brandColors.secondaryDark : '#fff'} />
                 <Text style={[styles.desktopFixerWorkspaceBtnText, !fixerActivated && styles.desktopBecomeFixerBtnText]}>
-                  {fixerActivated ? 'Fixer Workspace' : 'Become a Fixer'}
+                  {fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
                 </Text>
+                {fixerActivated && <MaterialCommunityIcons name="chevron-right" size={13} color={brandColors.secondaryDark} />}
               </Pressable>
             </>
           ) : (
@@ -329,13 +335,13 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
 
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel="Exit Fixer Workspace"
+                accessibilityLabel="Back to home"
                 style={({ pressed }) => [styles.desktopBackHomeBtn, pressed && styles.desktopActionPressed]}
                 hitSlop={8}
                 onPress={() => handleModeChange('requester')}
               >
-                <MaterialCommunityIcons name="close" size={15} color={brandColors.secondaryDark} />
-                <Text style={styles.desktopBackHomeBtnText}>Exit Fixer Workspace</Text>
+                <MaterialCommunityIcons name="arrow-left" size={14} color={brandColors.secondaryDark} />
+                <Text style={styles.desktopBackHomeBtnText}>Home</Text>
               </Pressable>
             </>
           )}
@@ -666,8 +672,8 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     lineHeight: 16,
   },
-  // Fixer workspace label (shown next to logo in fixer mode)
-  fixerWorkspaceLabel: {
+  // "You are here" badge — next to logo, shared base style
+  modeLabel: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.xs,
@@ -678,10 +684,17 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: brandColors.secondaryDark,
   },
-  fixerWorkspaceLabelText: {
+  modeLabelText: {
     fontSize: 11,
     fontWeight: '700',
     color: '#fff',
+  },
+  modeLabelRequester: {
+    backgroundColor: brandColors.infoSoft,
+    borderColor: brandColors.primary,
+  },
+  modeLabelRequesterText: {
+    color: brandColors.primary,
   },
   // "Become a Fixer" CTA variant (first-time, filled amber)
   desktopBecomeFixerBtn: {

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -128,8 +128,8 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
     openStackScreen('NotificationCenter');
   };
 
-  const openCreateTask = () => {
-    openStackScreen('CreateTask');
+  const openSettings = () => {
+    openStackScreen('Settings');
   };
 
   const openFixerOnboarding = () => {
@@ -243,107 +243,80 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
         </View>
 
         <View style={styles.desktopActions}>
-          {mode === 'requester' ? (
-            <>
+          {/* Shared: lang switcher, notifications, settings */}
+          <View style={styles.langSwitcher}>
+            {(['en', 'he'] as const).map((lang) => (
               <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Post a task"
-                style={({ pressed }) => [styles.desktopPrimaryAction, pressed && styles.desktopActionPressed]}
-                onPress={openCreateTask}
+                key={lang}
+                onPress={() => void changeLanguage(lang)}
+                style={[styles.langChip, language === lang && styles.langChipActive]}
               >
-                <MaterialCommunityIcons name="plus" size={17} color={brandColors.primaryDark} />
-                <Text style={styles.desktopPrimaryActionText}>{t('nav.postTask')}</Text>
-              </Pressable>
-
-              <View style={styles.langSwitcher}>
-                {(['en', 'he'] as const).map((lang) => (
-                  <Pressable
-                    key={lang}
-                    onPress={() => void changeLanguage(lang)}
-                    style={[styles.langChip, language === lang && styles.langChipActive]}
-                  >
-                    <Text style={[styles.langChipText, language === lang && styles.langChipTextActive]}>
-                      {lang === 'en' ? 'EN' : 'עב'}
-                    </Text>
-                  </Pressable>
-                ))}
-              </View>
-
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={
-                  notificationCount > 0
-                    ? `Open notifications, ${notificationCount} unread`
-                    : 'Open notifications'
-                }
-                style={({ pressed }) => [styles.desktopIconBtn, pressed && styles.desktopActionPressed]}
-                hitSlop={8}
-                onPress={openNotifications}
-              >
-                <MaterialCommunityIcons name="bell-outline" size={20} color={brandColors.primary} />
-                <NotifBadge count={notificationCount} />
-              </Pressable>
-
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
-                style={({ pressed }) => [
-                  styles.desktopFixerWorkspaceBtn,
-                  !fixerActivated && styles.desktopBecomeFixerBtn,
-                  pressed && styles.desktopActionPressed,
-                ]}
-                hitSlop={8}
-                onPress={openFixerOnboarding}
-              >
-                <MaterialCommunityIcons name="wrench-outline" size={14} color={fixerActivated ? brandColors.secondaryDark : '#fff'} />
-                <Text style={[styles.desktopFixerWorkspaceBtnText, !fixerActivated && styles.desktopBecomeFixerBtnText]}>
-                  {fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+                <Text style={[styles.langChipText, language === lang && styles.langChipTextActive]}>
+                  {lang === 'en' ? 'EN' : 'עב'}
                 </Text>
-                {fixerActivated && <MaterialCommunityIcons name="chevron-right" size={13} color={brandColors.secondaryDark} />}
               </Pressable>
-            </>
+            ))}
+          </View>
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={notificationCount > 0 ? `Open notifications, ${notificationCount} unread` : 'Open notifications'}
+            style={({ pressed }) => [
+              styles.desktopIconBtn,
+              mode === 'fixer' && styles.desktopIconBtnFixer,
+              pressed && styles.desktopActionPressed,
+            ]}
+            hitSlop={8}
+            onPress={openNotifications}
+          >
+            <MaterialCommunityIcons name="bell-outline" size={20} color={mode === 'fixer' ? brandColors.secondaryDark : brandColors.primary} />
+            <NotifBadge count={notificationCount} />
+          </Pressable>
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Open settings"
+            style={({ pressed }) => [
+              styles.desktopIconBtn,
+              mode === 'fixer' && styles.desktopIconBtnFixer,
+              pressed && styles.desktopActionPressed,
+            ]}
+            hitSlop={8}
+            onPress={openSettings}
+          >
+            <MaterialCommunityIcons name="cog-outline" size={20} color={mode === 'fixer' ? brandColors.secondaryDark : brandColors.primary} />
+          </Pressable>
+
+          {/* Workspace switcher */}
+          {mode === 'requester' ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+              style={({ pressed }) => [
+                styles.desktopFixerWorkspaceBtn,
+                !fixerActivated && styles.desktopBecomeFixerBtn,
+                pressed && styles.desktopActionPressed,
+              ]}
+              hitSlop={8}
+              onPress={openFixerOnboarding}
+            >
+              <MaterialCommunityIcons name="wrench-outline" size={14} color={fixerActivated ? brandColors.secondaryDark : '#fff'} />
+              <Text style={[styles.desktopFixerWorkspaceBtnText, !fixerActivated && styles.desktopBecomeFixerBtnText]}>
+                {fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+              </Text>
+              {fixerActivated && <MaterialCommunityIcons name="chevron-right" size={13} color={brandColors.secondaryDark} />}
+            </Pressable>
           ) : (
-            <>
-              <View style={styles.langSwitcher}>
-                {(['en', 'he'] as const).map((lang) => (
-                  <Pressable
-                    key={lang}
-                    onPress={() => void changeLanguage(lang)}
-                    style={[styles.langChip, language === lang && styles.langChipActive]}
-                  >
-                    <Text style={[styles.langChipText, language === lang && styles.langChipTextActive]}>
-                      {lang === 'en' ? 'EN' : 'עב'}
-                    </Text>
-                  </Pressable>
-                ))}
-              </View>
-
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={
-                  notificationCount > 0
-                    ? `Open notifications, ${notificationCount} unread`
-                    : 'Open notifications'
-                }
-                style={({ pressed }) => [styles.desktopIconBtn, styles.desktopIconBtnFixer, pressed && styles.desktopActionPressed]}
-                hitSlop={8}
-                onPress={openNotifications}
-              >
-                <MaterialCommunityIcons name="bell-outline" size={20} color={brandColors.secondaryDark} />
-                <NotifBadge count={notificationCount} />
-              </Pressable>
-
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Open Requester Workspace"
-                style={({ pressed }) => [styles.desktopBackHomeBtn, pressed && styles.desktopActionPressed]}
-                hitSlop={8}
-                onPress={() => handleModeChange('requester')}
-              >
-                <MaterialCommunityIcons name="chevron-left" size={14} color={brandColors.secondaryDark} />
-                <Text style={styles.desktopBackHomeBtnText}>Open Requester</Text>
-              </Pressable>
-            </>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Open Requester Workspace"
+              style={({ pressed }) => [styles.desktopBackHomeBtn, pressed && styles.desktopActionPressed]}
+              hitSlop={8}
+              onPress={() => handleModeChange('requester')}
+            >
+              <MaterialCommunityIcons name="chevron-left" size={14} color={brandColors.secondaryDark} />
+              <Text style={styles.desktopBackHomeBtnText}>Open Requester Workspace</Text>
+            </Pressable>
           )}
         </View>
       </View>

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 import { Platform, Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
-import { CommonActions } from '@react-navigation/native';
 import {
   BottomTabHeaderProps,
   createBottomTabNavigator,
@@ -20,7 +19,6 @@ import TaskDetailsFixer from '../screens/TaskDetailsFixer';
 import SettingsScreen from '../screens/SettingsScreen';
 import PublicProfileScreen from '../screens/PublicProfileScreen';
 import NotificationCenterScreen from '../screens/NotificationCenterScreen';
-import LandingScreen from '../screens/LandingScreen';
 import BecomeFixerScreen from '../screens/BecomeFixerScreen';
 import ChatScreen from '../screens/ChatScreen';
 import AppLogo from '../components/AppLogo';
@@ -29,9 +27,7 @@ import { useNotificationContext, FIXER_NOTIF_TYPES, REQUESTER_NOTIF_TYPES } from
 import { useUnreadMessages } from '../hooks/useUnreadMessages';
 import { useLanguage } from '../context/LanguageContext';
 import { brandColors, spacing, radii, shadows, typography } from '../theme';
-import type { Category } from '../constants/categories';
 import {
-  asLandingScreenWithNavigationProps,
   type RootStackParamList,
 } from './landingIntent';
 
@@ -41,8 +37,6 @@ const DESKTOP_BREAKPOINT = 900;
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const ModeTabs = createBottomTabNavigator();
-const LandingScreenWithNavigationProps = asLandingScreenWithNavigationProps(LandingScreen);
-
 type NestedRouteSnapshot = {
   name?: string;
   params?: { screen?: unknown };
@@ -60,21 +54,6 @@ function getActiveWorkspaceScreen(route: NestedRouteSnapshot): string | undefine
   }
 
   return typeof route.params?.screen === 'string' ? route.params.screen : undefined;
-}
-
-function resetToLanding(navigation: BottomTabHeaderProps['navigation']) {
-  const parentNavigation = navigation.getParent();
-  if (parentNavigation) {
-    parentNavigation.dispatch(
-      CommonActions.reset({
-        index: 0,
-        routes: [{ name: 'Landing' }],
-      }),
-    );
-    return;
-  }
-
-  navigation.navigate('Landing' as never);
 }
 
 // ─── Shared notification badge ───────────────────────────────────────────────
@@ -125,8 +104,10 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
     navigation.navigate(screen as never);
   };
 
-  const openLanding = () => {
-    resetToLanding(navigation);
+  const openDashboard = () => {
+    navigation.navigate(mode === 'fixer' ? 'FixerMode' : 'RequesterMode', {
+      screen: mode === 'fixer' ? 'FindJobs' : 'Dashboard',
+    });
   };
 
   const openNotifications = () => {
@@ -188,7 +169,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Go to FixIt home"
-          onPress={openLanding}
+          onPress={openDashboard}
           style={({ pressed }) => [styles.logoPressable, { opacity: pressed ? 0.78 : 1 }]}
         >
           <AppLogo compact />
@@ -364,7 +345,7 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
     navigation.navigate(screen as never);
   };
 
-  const openLanding = () => {
+  const openHome = () => {
     navigation.navigate(mode === 'fixer' ? 'FixerMode' : 'RequesterMode', {
       screen: mode === 'fixer' ? 'FindJobs' : 'Dashboard',
     });
@@ -442,7 +423,7 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Go to workspace home"
-            onPress={openLanding}
+            onPress={openHome}
             hitSlop={8}
             style={({ pressed }) => ({ opacity: pressed ? 0.78 : 1 })}
           >
@@ -530,84 +511,11 @@ function MainNavigator() {
 function SignedInLanding({
   navigation,
 }: NativeStackScreenProps<RootStackParamList, 'Landing'>) {
-  const { width } = useWindowDimensions();
-
   useEffect(() => {
-    if (Platform.OS !== 'web' || width < DESKTOP_BREAKPOINT) {
-      navigation.replace('Main');
-    }
-  }, [navigation, width]);
+    navigation.replace('Main');
+  }, [navigation]);
 
-  const openRequesterDashboard = () => {
-    navigation.navigate('Main', {
-      screen: 'RequesterMode',
-      params: { screen: 'Dashboard' },
-    });
-  };
-
-  const openRequesterTasks = () => {
-    navigation.navigate('Main', {
-      screen: 'RequesterMode',
-      params: { screen: 'MyTasks' },
-    });
-  };
-
-  const openFixerWorkspace = () => {
-    navigation.navigate('Main', {
-      screen: 'FixerMode',
-      params: { screen: 'FindJobs' },
-    });
-  };
-
-  const openFixerBids = () => {
-    navigation.navigate('Main', {
-      screen: 'FixerMode',
-      params: { screen: 'MyBids' },
-    });
-  };
-
-  const openFixerProfile = () => {
-    navigation.navigate('Main', {
-      screen: 'FixerMode',
-      params: { screen: 'FixerProfile' },
-    });
-  };
-
-  const openPostTask = (category?: Category) => {
-    navigation.navigate('CreateTask', category ? { category } : undefined);
-  };
-
-  const openSettings = () => {
-    navigation.navigate('Settings');
-  };
-
-  const openNotifications = () => {
-    navigation.navigate('NotificationCenter');
-  };
-
-  if (Platform.OS !== 'web' || width < DESKTOP_BREAKPOINT) {
-    return null;
-  }
-
-  return (
-    <LandingScreenWithNavigationProps
-      isSignedIn
-      onLogin={openRequesterDashboard}
-      onDashboard={openRequesterDashboard}
-      onRequesterHome={openRequesterDashboard}
-      onRequesterTasks={openRequesterTasks}
-      onPostTask={openPostTask}
-      onCategoryPress={openPostTask}
-      onCategorySelect={openPostTask}
-      onBecomeFixer={openFixerWorkspace}
-      onFixerHome={openFixerWorkspace}
-      onFixerBids={openFixerBids}
-      onFixerProfile={openFixerProfile}
-      onNotifications={openNotifications}
-      onProfile={openSettings}
-      onSettings={openSettings}
-    />
-  );
+  return null;
 }
 
 export default function AppNavigator() {

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -21,6 +21,7 @@ import SettingsScreen from '../screens/SettingsScreen';
 import PublicProfileScreen from '../screens/PublicProfileScreen';
 import NotificationCenterScreen from '../screens/NotificationCenterScreen';
 import LandingScreen from '../screens/LandingScreen';
+import BecomeFixerScreen from '../screens/BecomeFixerScreen';
 import ChatScreen from '../screens/ChatScreen';
 import AppLogo from '../components/AppLogo';
 import HamburgerMenu from '../components/HamburgerMenu';
@@ -134,6 +135,10 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
 
   const openCreateTask = () => {
     openStackScreen('CreateTask');
+  };
+
+  const openFixerOnboarding = () => {
+    openStackScreen('BecomeFixerOnboarding');
   };
 
   const openWorkspaceScreen = (screen: string) => {
@@ -279,7 +284,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
                 accessibilityLabel="Open Fixer Workspace"
                 style={({ pressed }) => [styles.desktopFixerWorkspaceBtn, pressed && styles.desktopActionPressed]}
                 hitSlop={8}
-                onPress={() => handleModeChange('fixer')}
+                onPress={openFixerOnboarding}
               >
                 <MaterialCommunityIcons name="wrench-outline" size={15} color={brandColors.secondaryDark} />
                 <Text style={styles.desktopFixerWorkspaceBtnText}>Fixer Workspace</Text>
@@ -389,6 +394,15 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
     navigation.navigate('FixerMode', { screen: 'FindJobs' });
   };
 
+  const openFixerOnboarding = () => {
+    const parentNavigation = navigation.getParent();
+    if (parentNavigation) {
+      parentNavigation.navigate('BecomeFixerOnboarding' as never);
+    } else {
+      navigation.navigate('BecomeFixerOnboarding' as never);
+    }
+  };
+
   const openFixerBids = () => {
     navigation.navigate('FixerMode', { screen: 'MyBids' });
   };
@@ -476,6 +490,7 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
         onRequesterHomePress={openRequesterHome}
         onRequesterTasksPress={openRequesterTasks}
         onPostTaskPress={openCreateTask}
+        onFixerWorkspacePress={openFixerOnboarding}
         onFixerHomePress={openFixerHome}
         onFixerBidsPress={openFixerBids}
         onFixerProfilePress={openFixerProfile}
@@ -617,6 +632,7 @@ export default function AppNavigator() {
       <Stack.Screen name="Settings" component={SettingsScreen} options={{ title: 'Settings' }} />
       <Stack.Screen name="PublicProfile" component={PublicProfileScreen} options={{ title: 'Profile' }} />
       <Stack.Screen name="NotificationCenter" component={NotificationCenterScreen} options={{ title: 'Notifications' }} />
+      <Stack.Screen name="BecomeFixerOnboarding" component={BecomeFixerScreen} options={{ title: 'Become a Fixer', headerShown: false }} />
       <Stack.Screen name="Chat" component={ChatScreen} options={{ title: 'Chat' }} />
     </Stack.Navigator>
   );

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { auth } from '../config/firebase';
 import { Platform, Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
 import {
   BottomTabHeaderProps,
@@ -68,7 +69,7 @@ function NotifBadge({ count }: { count: number }) {
 }
 
 // ─── Desktop header (wide screens / web) ─────────────────────────────────────
-const FIXER_ONBOARDING_KEY = 'fixerOnboardingSeen';
+const getFixerOnboardingKey = () => `fixerOnboardingSeen_${auth.currentUser?.uid ?? 'anon'}`;
 
 function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
   const insets = useSafeAreaInsets();
@@ -95,7 +96,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
   }, [route.name]);
 
   const checkFixerActivated = () => {
-    AsyncStorage.getItem(FIXER_ONBOARDING_KEY).then((v) => setFixerActivated(v === 'true'));
+    AsyncStorage.getItem(getFixerOnboardingKey()).then((v) => setFixerActivated(v === 'true'));
   };
 
   const isMountedRef = useRef(true);
@@ -337,7 +338,7 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
   const { language, changeLanguage } = useLanguage();
 
   useEffect(() => {
-    AsyncStorage.getItem(FIXER_ONBOARDING_KEY).then((v) => setFixerActivated(v === 'true'));
+    AsyncStorage.getItem(getFixerOnboardingKey()).then((v) => setFixerActivated(v === 'true'));
   }, []);
 
   const handleModeChange = (value: Mode) => {
@@ -392,7 +393,7 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
       navigation.navigate('BecomeFixerOnboarding' as never);
     }
     const unsubscribe = navigation.addListener('focus' as never, () => {
-      AsyncStorage.getItem(FIXER_ONBOARDING_KEY).then((v) => setFixerActivated(v === 'true'));
+      AsyncStorage.getItem(getFixerOnboardingKey()).then((v) => setFixerActivated(v === 'true'));
       unsubscribe();
     });
   };

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -82,7 +82,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
   const { unreadCount } = useNotificationContext();
   const notificationCount = unreadCount(typeFilter);
   const { unreadCount: unreadMsgCount } = useUnreadMessages();
-  const { language, changeLanguage } = useLanguage();
+  const { language, changeLanguage, isRTL } = useLanguage();
   const { t } = useTranslation();
 
   useEffect(() => {
@@ -196,14 +196,14 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
         </Pressable>
 
         {mode === 'fixer' ? (
-          <View style={styles.modeLabel}>
+          <View style={[styles.modeLabel, { flexDirection: isRTL ? 'row-reverse' : 'row' }]}>
             <MaterialCommunityIcons name="wrench-outline" size={13} color="#fff" />
-            <Text style={styles.modeLabelText}>Fixer Workspace</Text>
+            <Text style={styles.modeLabelText}>{t('nav.workspace.fixerBadge')}</Text>
           </View>
         ) : (
-          <View style={[styles.modeLabel, styles.modeLabelRequester]}>
+          <View style={[styles.modeLabel, styles.modeLabelRequester, { flexDirection: isRTL ? 'row-reverse' : 'row' }]}>
             <MaterialCommunityIcons name="home-outline" size={13} color={brandColors.primary} />
-            <Text style={[styles.modeLabelText, styles.modeLabelRequesterText]}>Requester</Text>
+            <Text style={[styles.modeLabelText, styles.modeLabelRequesterText]}>{t('nav.workspace.requesterBadge')}</Text>
           </View>
         )}
 
@@ -292,7 +292,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
           {mode === 'requester' ? (
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel={fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+              accessibilityLabel={fixerActivated ? t('nav.workspace.openFixer') : t('nav.workspace.becomeFixer')}
               style={({ pressed }) => [
                 styles.desktopFixerWorkspaceBtn,
                 !fixerActivated && styles.desktopBecomeFixerBtn,
@@ -301,22 +301,23 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
               hitSlop={8}
               onPress={openFixerOnboarding}
             >
+              {isRTL && fixerActivated && <MaterialCommunityIcons name="chevron-left" size={13} color={brandColors.secondaryDark} />}
               <MaterialCommunityIcons name="wrench-outline" size={14} color={fixerActivated ? brandColors.secondaryDark : '#fff'} />
               <Text style={[styles.desktopFixerWorkspaceBtnText, !fixerActivated && styles.desktopBecomeFixerBtnText]}>
-                {fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+                {fixerActivated ? t('nav.workspace.openFixer') : t('nav.workspace.becomeFixer')}
               </Text>
-              {fixerActivated && <MaterialCommunityIcons name="chevron-right" size={13} color={brandColors.secondaryDark} />}
+              {!isRTL && fixerActivated && <MaterialCommunityIcons name="chevron-right" size={13} color={brandColors.secondaryDark} />}
             </Pressable>
           ) : (
             <Pressable
               accessibilityRole="button"
-              accessibilityLabel="Open Requester Workspace"
+              accessibilityLabel={t('nav.workspace.openRequester')}
               style={({ pressed }) => [styles.desktopBackHomeBtn, pressed && styles.desktopActionPressed]}
               hitSlop={8}
               onPress={() => handleModeChange('requester')}
             >
-              <MaterialCommunityIcons name="chevron-left" size={14} color={brandColors.secondaryDark} />
-              <Text style={styles.desktopBackHomeBtnText}>Open Requester Workspace</Text>
+              <MaterialCommunityIcons name={isRTL ? 'chevron-right' : 'chevron-left'} size={14} color={brandColors.secondaryDark} />
+              <Text style={styles.desktopBackHomeBtnText}>{t('nav.workspace.openRequester')}</Text>
             </Pressable>
           )}
         </View>

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform, Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
 import {
   BottomTabHeaderProps,
   createBottomTabNavigator,
 } from '@react-navigation/bottom-tabs';
-import { createNativeStackNavigator, type NativeStackScreenProps } from '@react-navigation/native-stack';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { useTheme } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -67,11 +68,14 @@ function NotifBadge({ count }: { count: number }) {
 }
 
 // ─── Desktop header (wide screens / web) ─────────────────────────────────────
+const FIXER_ONBOARDING_KEY = 'fixerOnboardingSeen';
+
 function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
   const insets = useSafeAreaInsets();
   const topInset = insets.top > 0 ? insets.top : spacing.sm;
   const [navStateVersion, setNavStateVersion] = useState(0);
   const [activeScreenOverride, setActiveScreenOverride] = useState<string | null>(null);
+  const [fixerActivated, setFixerActivated] = useState(true); // default true avoids flicker
   const mode: Mode = route.name === 'FixerMode' ? 'fixer' : 'requester';
   const typeFilter = mode === 'fixer' ? FIXER_NOTIF_TYPES : REQUESTER_NOTIF_TYPES;
   const { unreadCount } = useNotificationContext();
@@ -90,6 +94,17 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
     setActiveScreenOverride(null);
   }, [route.name]);
 
+  const checkFixerActivated = () => {
+    AsyncStorage.getItem(FIXER_ONBOARDING_KEY).then((v) => setFixerActivated(v === 'true'));
+  };
+
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    checkFixerActivated();
+    return () => { isMountedRef.current = false; };
+  }, []); // intentionally empty — run once on mount
+
   const handleModeChange = (value: Mode) => {
     const nextRoute = value === 'fixer' ? 'FixerMode' : 'RequesterMode';
     if (route.name !== nextRoute) navigation.navigate(nextRoute);
@@ -105,9 +120,8 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
   };
 
   const openDashboard = () => {
-    navigation.navigate(mode === 'fixer' ? 'FixerMode' : 'RequesterMode', {
-      screen: mode === 'fixer' ? 'FindJobs' : 'Dashboard',
-    });
+    // Logo always means "go home" — the requester dashboard is home regardless of current mode
+    navigation.navigate('RequesterMode', { screen: 'Dashboard' });
   };
 
   const openNotifications = () => {
@@ -120,6 +134,11 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
 
   const openFixerOnboarding = () => {
     openStackScreen('BecomeFixerOnboarding');
+    // Re-check after returning (onboarding screen sets the flag)
+    const unsubscribe = navigation.addListener('focus' as never, () => {
+      checkFixerActivated();
+      unsubscribe();
+    });
   };
 
   const openWorkspaceScreen = (screen: string) => {
@@ -202,7 +221,7 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
                 >
                   <MaterialCommunityIcons
                     name={item.icon as never}
-                    size={18}
+                    size={16}
                     color={selected ? (mode === 'fixer' ? brandColors.secondaryDark : brandColors.primary) : brandColors.textMuted}
                   />
                   <Text style={[
@@ -262,13 +281,19 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
 
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel="Open Fixer Workspace"
-                style={({ pressed }) => [styles.desktopFixerWorkspaceBtn, pressed && styles.desktopActionPressed]}
+                accessibilityLabel={fixerActivated ? 'Open Fixer Workspace' : 'Become a Fixer'}
+                style={({ pressed }) => [
+                  styles.desktopFixerWorkspaceBtn,
+                  !fixerActivated && styles.desktopBecomeFixerBtn,
+                  pressed && styles.desktopActionPressed,
+                ]}
                 hitSlop={8}
                 onPress={openFixerOnboarding}
               >
-                <MaterialCommunityIcons name="wrench-outline" size={15} color={brandColors.secondaryDark} />
-                <Text style={styles.desktopFixerWorkspaceBtnText}>Fixer Workspace</Text>
+                <MaterialCommunityIcons name="wrench-outline" size={15} color={fixerActivated ? brandColors.secondaryDark : '#fff'} />
+                <Text style={[styles.desktopFixerWorkspaceBtnText, !fixerActivated && styles.desktopBecomeFixerBtnText]}>
+                  {fixerActivated ? 'Fixer Workspace' : 'Become a Fixer'}
+                </Text>
               </Pressable>
             </>
           ) : (
@@ -304,13 +329,13 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
 
               <Pressable
                 accessibilityRole="button"
-                accessibilityLabel="Back to Home"
+                accessibilityLabel="Exit Fixer Workspace"
                 style={({ pressed }) => [styles.desktopBackHomeBtn, pressed && styles.desktopActionPressed]}
                 hitSlop={8}
                 onPress={() => handleModeChange('requester')}
               >
-                <MaterialCommunityIcons name="arrow-left" size={15} color={brandColors.primaryMuted} />
-                <Text style={styles.desktopBackHomeBtnText}>Back to Home</Text>
+                <MaterialCommunityIcons name="close" size={15} color={brandColors.secondaryDark} />
+                <Text style={styles.desktopBackHomeBtnText}>Exit Fixer Workspace</Text>
               </Pressable>
             </>
           )}
@@ -325,11 +350,16 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
   const insets = useSafeAreaInsets();
   const topInset = insets.top + spacing.sm;
   const [menuOpen, setMenuOpen] = useState(false);
+  const [fixerActivated, setFixerActivated] = useState(true);
   const mode: Mode = route.name === 'FixerMode' ? 'fixer' : 'requester';
   const typeFilter = mode === 'fixer' ? FIXER_NOTIF_TYPES : REQUESTER_NOTIF_TYPES;
   const { unreadCount } = useNotificationContext();
   const notificationCount = unreadCount(typeFilter);
   const { language, changeLanguage } = useLanguage();
+
+  useEffect(() => {
+    AsyncStorage.getItem(FIXER_ONBOARDING_KEY).then((v) => setFixerActivated(v === 'true'));
+  }, []);
 
   const handleModeChange = (value: Mode) => {
     const nextRoute = value === 'fixer' ? 'FixerMode' : 'RequesterMode';
@@ -382,6 +412,10 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
     } else {
       navigation.navigate('BecomeFixerOnboarding' as never);
     }
+    const unsubscribe = navigation.addListener('focus' as never, () => {
+      AsyncStorage.getItem(FIXER_ONBOARDING_KEY).then((v) => setFixerActivated(v === 'true'));
+      unsubscribe();
+    });
   };
 
   const openFixerBids = () => {
@@ -471,6 +505,7 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
         onRequesterHomePress={openRequesterHome}
         onRequesterTasksPress={openRequesterTasks}
         onPostTaskPress={openCreateTask}
+        fixerActivated={fixerActivated}
         onFixerWorkspacePress={openFixerOnboarding}
         onFixerHomePress={openFixerHome}
         onFixerBidsPress={openFixerBids}
@@ -508,22 +543,12 @@ function MainNavigator() {
   );
 }
 
-function SignedInLanding({
-  navigation,
-}: NativeStackScreenProps<RootStackParamList, 'Landing'>) {
-  useEffect(() => {
-    navigation.replace('Main');
-  }, [navigation]);
-
-  return null;
-}
-
 export default function AppNavigator() {
   const theme = useTheme();
 
   return (
     <Stack.Navigator
-      initialRouteName={Platform.OS === 'web' ? 'Landing' : 'Main'}
+      initialRouteName="Main"
       screenOptions={{
         headerTintColor: theme.colors.primary,
         headerStyle: { backgroundColor: theme.colors.surface },
@@ -532,7 +557,6 @@ export default function AppNavigator() {
         contentStyle: { backgroundColor: theme.colors.background },
       }}
     >
-      <Stack.Screen name="Landing" component={SignedInLanding} options={{ headerShown: false }} />
       <Stack.Screen name="Main" component={MainNavigator} options={{ headerShown: false }} />
       <Stack.Screen name="CreateTask" component={CreateTask} options={{ title: 'Create Task' }} />
       <Stack.Screen name="TaskDetails" component={TaskDetails} options={{ title: 'Task Details' }} />
@@ -659,6 +683,14 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: '#fff',
   },
+  // "Become a Fixer" CTA variant (first-time, filled amber)
+  desktopBecomeFixerBtn: {
+    backgroundColor: brandColors.secondaryDark,
+    borderColor: brandColors.secondaryDark,
+  },
+  desktopBecomeFixerBtnText: {
+    color: '#fff',
+  },
   // Fixer workspace entry button (requester mode, right actions)
   desktopFixerWorkspaceBtn: {
     flexDirection: 'row',
@@ -703,29 +735,28 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   desktopPageTab: {
-    minHeight: 38,
-    flexDirection: 'column',
+    minHeight: 48,
+    flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 2,
+    gap: spacing.xs,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.xs,
-    borderRadius: radii.md,
-    borderWidth: 1,
-    borderColor: 'transparent',
+    borderBottomWidth: 3,
+    borderBottomColor: 'transparent',
   },
   desktopPageTabActive: {
-    backgroundColor: brandColors.infoSoft,
-    borderColor: brandColors.outlineLight,
+    borderBottomColor: brandColors.primary,
   },
   desktopPageTabText: {
-    fontSize: 10,
-    fontWeight: '700',
-    lineHeight: 13,
+    fontSize: 13,
+    fontWeight: '500',
+    lineHeight: 18,
     color: brandColors.textMuted,
   },
   desktopPageTabTextActive: {
     color: brandColors.primary,
+    fontWeight: '700',
   },
   // Fixer-mode tab variants
   desktopBarFixer: {
@@ -733,11 +764,11 @@ const styles = StyleSheet.create({
     borderBottomColor: brandColors.secondary,
   },
   desktopPageTabActiveFixer: {
-    backgroundColor: brandColors.warningSoft,
-    borderColor: brandColors.secondary,
+    borderBottomColor: brandColors.secondaryDark,
   },
   desktopPageTabTextActiveFixer: {
     color: brandColors.secondaryDark,
+    fontWeight: '700',
   },
   desktopIconBtnFixer: {
     backgroundColor: brandColors.warningSoft,

--- a/frontend/src/navigation/landingIntent.ts
+++ b/frontend/src/navigation/landingIntent.ts
@@ -36,7 +36,6 @@ export interface LandingScreenNavigationProps {
 }
 
 export type RootStackParamList = {
-  Landing: undefined;
   Main:
     | {
         screen?: 'RequesterMode' | 'FixerMode';

--- a/frontend/src/navigation/landingIntent.ts
+++ b/frontend/src/navigation/landingIntent.ts
@@ -52,6 +52,7 @@ export type RootStackParamList = {
   Settings: undefined;
   PublicProfile: { userId?: string } | undefined;
   NotificationCenter: undefined;
+  BecomeFixerOnboarding: undefined;
   Chat: {
     taskId: string;
     myDbId?: string;

--- a/frontend/src/screens/BecomeFixerScreen.tsx
+++ b/frontend/src/screens/BecomeFixerScreen.tsx
@@ -1,0 +1,312 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+import { Text } from 'react-native-paper';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { type NativeStackScreenProps } from '@react-navigation/native-stack';
+import { type RootStackParamList } from '../navigation/landingIntent';
+import { FButton } from '../components/ui';
+import { brandColors, radii, shadows, spacing, typography } from '../theme';
+
+const STORAGE_KEY = 'fixerOnboardingSeen';
+
+const BENEFITS = [
+  {
+    icon: 'clock-fast' as const,
+    title: 'Flexible Hours',
+    body: 'Work when you want — accept jobs that fit your schedule.',
+  },
+  {
+    icon: 'map-marker-radius-outline' as const,
+    title: 'Find Work Nearby',
+    body: 'Browse tasks posted in your area with a live map.',
+  },
+  {
+    icon: 'cash-multiple' as const,
+    title: 'Earn More',
+    body: 'Set your own price on every bid. No middleman cut.',
+  },
+  {
+    icon: 'star-circle-outline' as const,
+    title: 'Build Your Reputation',
+    body: 'Collect reviews and grow a profile clients trust.',
+  },
+];
+
+type Props = NativeStackScreenProps<RootStackParamList, 'BecomeFixerOnboarding'>;
+
+export default function BecomeFixerScreen({ navigation }: Props) {
+  const { width } = useWindowDimensions();
+  const wide = width >= 900 && Platform.OS === 'web';
+  const fadeAnim = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(24)).current;
+
+  const navigationRef = React.useRef(navigation);
+  navigationRef.current = navigation;
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY).then((seen) => {
+      if (seen === 'true') {
+        navigationRef.current.replace('Main', { screen: 'FixerMode', params: { screen: 'FindJobs' } });
+      } else {
+        Animated.parallel([
+          Animated.timing(fadeAnim, { toValue: 1, duration: 320, useNativeDriver: true }),
+          Animated.timing(slideAnim, { toValue: 0, duration: 320, useNativeDriver: true }),
+        ]).start();
+      }
+    });
+  }, [fadeAnim, slideAnim]);
+
+  const markSeenAndNavigate = async (dest: 'profile' | 'jobs') => {
+    await AsyncStorage.setItem(STORAGE_KEY, 'true');
+    if (dest === 'profile') {
+      navigation.replace('Main', { screen: 'FixerMode', params: { screen: 'FixerProfile' } });
+    } else {
+      goToFixerHome();
+    }
+  };
+
+  const goToFixerHome = () => {
+    navigation.replace('Main', { screen: 'FixerMode', params: { screen: 'FindJobs' } });
+  };
+
+  return (
+    <Animated.View style={[styles.root, { opacity: fadeAnim, transform: [{ translateY: slideAnim }] }]}>
+      <ScrollView
+        contentContainerStyle={[styles.scroll, wide && styles.scrollWide]}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Hero */}
+        <LinearGradient
+          colors={['#D49A2A', '#F1B545']}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={[styles.hero, wide && styles.heroWide]}
+        >
+          <View style={styles.heroIcon}>
+            <MaterialCommunityIcons name="wrench" size={40} color="#fff" />
+          </View>
+          <Text style={[typography.h1, styles.heroTitle]}>Become a Fixer</Text>
+          <Text style={[typography.body, styles.heroSubtitle]}>
+            Earn money on your own terms by helping people with tasks in your area.
+          </Text>
+        </LinearGradient>
+
+        {/* Benefits grid */}
+        <View style={[styles.benefitsGrid, wide && styles.benefitsGridWide]}>
+          {BENEFITS.map((b) => (
+            <View key={b.icon} style={[styles.benefitCard, wide && styles.benefitCardWide]}>
+              <View style={styles.benefitIcon}>
+                <MaterialCommunityIcons name={b.icon} size={24} color={brandColors.secondaryDark} />
+              </View>
+              <View style={styles.benefitText}>
+                <Text style={[typography.bodyMedium, styles.benefitTitle]}>{b.title}</Text>
+                <Text style={[typography.bodySm, styles.benefitBody]}>{b.body}</Text>
+              </View>
+            </View>
+          ))}
+        </View>
+
+        {/* Steps */}
+        <View style={[styles.stepsSection, wide && styles.stepsSectionWide]}>
+          <Text style={[typography.h3, styles.stepsHeading]}>How to get started</Text>
+          <View style={styles.steps}>
+            {[
+              { n: '1', label: 'Complete your profile', detail: 'Add a bio and your specialisations so requesters know who you are.' },
+              { n: '2', label: 'Browse open tasks', detail: 'Find jobs near you on the map or list view.' },
+              { n: '3', label: 'Place a bid', detail: 'Name your price and send a short note. The requester picks their favourite.' },
+            ].map((step) => (
+              <View key={step.n} style={styles.step}>
+                <View style={styles.stepBadge}>
+                  <Text style={styles.stepBadgeText}>{step.n}</Text>
+                </View>
+                <View style={styles.stepText}>
+                  <Text style={[typography.bodyMedium, styles.stepLabel]}>{step.label}</Text>
+                  <Text style={[typography.bodySm, { color: brandColors.textMuted }]}>{step.detail}</Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        {/* CTAs */}
+        <View style={[styles.ctaSection, wide && styles.ctaSectionWide]}>
+          <FButton
+            variant="primary"
+            size="lg"
+            onPress={() => void markSeenAndNavigate('profile')}
+          >
+            Set Up My Profile
+          </FButton>
+          <Pressable
+            accessibilityRole="button"
+            style={({ pressed }) => [styles.skipBtn, pressed && { opacity: 0.7 }]}
+            onPress={() => void markSeenAndNavigate('jobs')}
+          >
+            <Text style={styles.skipText}>Browse jobs first →</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: brandColors.background,
+  },
+  scroll: {
+    paddingBottom: spacing.xxxl,
+  },
+  scrollWide: {
+    alignItems: 'center',
+  },
+  hero: {
+    alignItems: 'center',
+    paddingHorizontal: spacing.xxl,
+    paddingTop: spacing.xxxl,
+    paddingBottom: spacing.xxl,
+    gap: spacing.md,
+  },
+  heroWide: {
+    width: '100%',
+    maxWidth: 720,
+    alignSelf: 'center',
+    marginTop: spacing.xxl,
+    borderRadius: radii.xl,
+    ...shadows.md,
+  },
+  heroIcon: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: 'rgba(255,255,255,0.22)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: spacing.sm,
+  },
+  heroTitle: {
+    color: '#fff',
+    textAlign: 'center',
+  },
+  heroSubtitle: {
+    color: 'rgba(255,255,255,0.88)',
+    textAlign: 'center',
+    maxWidth: 420,
+  },
+  benefitsGrid: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.xxl,
+    gap: spacing.md,
+  },
+  benefitsGridWide: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    maxWidth: 720,
+    width: '100%',
+  },
+  benefitCard: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.md,
+    backgroundColor: brandColors.surface,
+    borderRadius: radii.lg,
+    padding: spacing.lg,
+    borderWidth: 1,
+    borderColor: brandColors.outlineLight,
+    ...shadows.sm,
+  },
+  benefitCardWide: {
+    flexBasis: '47%',
+    flexGrow: 1,
+  },
+  benefitIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: radii.md,
+    backgroundColor: brandColors.warningSoft,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  benefitText: {
+    flex: 1,
+    gap: 3,
+  },
+  benefitTitle: {
+    color: brandColors.textPrimary,
+  },
+  benefitBody: {
+    color: brandColors.textMuted,
+  },
+  stepsSection: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.xxl,
+    gap: spacing.lg,
+  },
+  stepsSectionWide: {
+    maxWidth: 720,
+    width: '100%',
+  },
+  stepsHeading: {
+    color: brandColors.textPrimary,
+  },
+  steps: {
+    gap: spacing.md,
+  },
+  step: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.md,
+  },
+  stepBadge: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: brandColors.secondaryDark,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 2,
+  },
+  stepBadgeText: {
+    color: '#fff',
+    fontSize: 14,
+    fontWeight: '800',
+  },
+  stepText: {
+    flex: 1,
+    gap: 2,
+  },
+  stepLabel: {
+    color: brandColors.textPrimary,
+  },
+  ctaSection: {
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.xxl,
+    gap: spacing.md,
+    alignItems: 'stretch',
+  },
+  ctaSectionWide: {
+    maxWidth: 400,
+    width: '100%',
+  },
+  skipBtn: {
+    alignSelf: 'center',
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+  },
+  skipText: {
+    color: brandColors.primaryMuted,
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/frontend/src/screens/BecomeFixerScreen.tsx
+++ b/frontend/src/screens/BecomeFixerScreen.tsx
@@ -12,41 +12,33 @@ import { Text } from 'react-native-paper';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { LinearGradient } from 'expo-linear-gradient';
+import { useTranslation } from 'react-i18next';
 import { type NativeStackScreenProps } from '@react-navigation/native-stack';
 import { type RootStackParamList } from '../navigation/landingIntent';
 import { FButton } from '../components/ui';
+import { useLanguage } from '../context/LanguageContext';
 import { brandColors, radii, shadows, spacing, typography } from '../theme';
 import { auth } from '../config/firebase';
 
 const getOnboardingKey = () => `fixerOnboardingSeen_${auth.currentUser?.uid ?? 'anon'}`;
 
-const BENEFITS = [
-  {
-    icon: 'clock-fast' as const,
-    title: 'Flexible Hours',
-    body: 'Work when you want — accept jobs that fit your schedule.',
-  },
-  {
-    icon: 'map-marker-radius-outline' as const,
-    title: 'Find Work Nearby',
-    body: 'Browse tasks posted in your area with a live map.',
-  },
-  {
-    icon: 'cash-multiple' as const,
-    title: 'Earn More',
-    body: 'Set your own price on every bid. No middleman cut.',
-  },
-  {
-    icon: 'star-circle-outline' as const,
-    title: 'Build Your Reputation',
-    body: 'Collect reviews and grow a profile clients trust.',
-  },
-];
+type BenefitKey = 'flexibleHours' | 'findWork' | 'earnMore' | 'reputation';
+
+const BENEFIT_ICONS: Record<BenefitKey, string> = {
+  flexibleHours: 'clock-fast',
+  findWork: 'map-marker-radius-outline',
+  earnMore: 'cash-multiple',
+  reputation: 'star-circle-outline',
+};
+
+const STEP_KEYS = ['profile', 'browse', 'bid'] as const;
 
 type Props = NativeStackScreenProps<RootStackParamList, 'BecomeFixerOnboarding'>;
 
 export default function BecomeFixerScreen({ navigation }: Props) {
   const { width } = useWindowDimensions();
+  const { t } = useTranslation();
+  const { isRTL } = useLanguage();
   const wide = width >= 900 && Platform.OS === 'web';
   const fadeAnim = useRef(new Animated.Value(0)).current;
   const slideAnim = useRef(new Animated.Value(24)).current;
@@ -72,13 +64,11 @@ export default function BecomeFixerScreen({ navigation }: Props) {
     if (dest === 'profile') {
       navigation.replace('Main', { screen: 'FixerMode', params: { screen: 'FixerProfile' } });
     } else {
-      goToFixerHome();
+      navigation.replace('Main', { screen: 'FixerMode', params: { screen: 'FindJobs' } });
     }
   };
 
-  const goToFixerHome = () => {
-    navigation.replace('Main', { screen: 'FixerMode', params: { screen: 'FindJobs' } });
-  };
+  const rowDirection = isRTL ? 'row-reverse' : 'row';
 
   return (
     <Animated.View style={[styles.root, { opacity: fadeAnim, transform: [{ translateY: slideAnim }] }]}>
@@ -96,22 +86,24 @@ export default function BecomeFixerScreen({ navigation }: Props) {
           <View style={styles.heroIcon}>
             <MaterialCommunityIcons name="wrench" size={40} color="#fff" />
           </View>
-          <Text style={[typography.h1, styles.heroTitle]}>Become a Fixer</Text>
-          <Text style={[typography.body, styles.heroSubtitle]}>
-            Earn money on your own terms by helping people with tasks in your area.
-          </Text>
+          <Text style={[typography.h1, styles.heroTitle]}>{t('becomeFixer.hero.title')}</Text>
+          <Text style={[typography.body, styles.heroSubtitle]}>{t('becomeFixer.hero.subtitle')}</Text>
         </LinearGradient>
 
         {/* Benefits grid */}
         <View style={[styles.benefitsGrid, wide && styles.benefitsGridWide]}>
-          {BENEFITS.map((b) => (
-            <View key={b.icon} style={[styles.benefitCard, wide && styles.benefitCardWide]}>
+          {(Object.keys(BENEFIT_ICONS) as BenefitKey[]).map((key) => (
+            <View key={key} style={[styles.benefitCard, { flexDirection: rowDirection }, wide && styles.benefitCardWide]}>
               <View style={styles.benefitIcon}>
-                <MaterialCommunityIcons name={b.icon} size={24} color={brandColors.secondaryDark} />
+                <MaterialCommunityIcons name={BENEFIT_ICONS[key] as never} size={24} color={brandColors.secondaryDark} />
               </View>
               <View style={styles.benefitText}>
-                <Text style={[typography.bodyMedium, styles.benefitTitle]}>{b.title}</Text>
-                <Text style={[typography.bodySm, styles.benefitBody]}>{b.body}</Text>
+                <Text style={[typography.bodyMedium, styles.benefitTitle, { textAlign: isRTL ? 'right' : 'left' }]}>
+                  {t(`becomeFixer.benefits.${key}.title`)}
+                </Text>
+                <Text style={[typography.bodySm, styles.benefitBody, { textAlign: isRTL ? 'right' : 'left' }]}>
+                  {t(`becomeFixer.benefits.${key}.body`)}
+                </Text>
               </View>
             </View>
           ))}
@@ -119,20 +111,22 @@ export default function BecomeFixerScreen({ navigation }: Props) {
 
         {/* Steps */}
         <View style={[styles.stepsSection, wide && styles.stepsSectionWide]}>
-          <Text style={[typography.h3, styles.stepsHeading]}>How to get started</Text>
+          <Text style={[typography.h3, styles.stepsHeading, { textAlign: isRTL ? 'right' : 'left' }]}>
+            {t('becomeFixer.steps.heading')}
+          </Text>
           <View style={styles.steps}>
-            {[
-              { n: '1', label: 'Complete your profile', detail: 'Add a bio and your specialisations so requesters know who you are.' },
-              { n: '2', label: 'Browse open tasks', detail: 'Find jobs near you on the map or list view.' },
-              { n: '3', label: 'Place a bid', detail: 'Name your price and send a short note. The requester picks their favourite.' },
-            ].map((step) => (
-              <View key={step.n} style={styles.step}>
+            {STEP_KEYS.map((key, idx) => (
+              <View key={key} style={[styles.step, { flexDirection: rowDirection }]}>
                 <View style={styles.stepBadge}>
-                  <Text style={styles.stepBadgeText}>{step.n}</Text>
+                  <Text style={styles.stepBadgeText}>{idx + 1}</Text>
                 </View>
                 <View style={styles.stepText}>
-                  <Text style={[typography.bodyMedium, styles.stepLabel]}>{step.label}</Text>
-                  <Text style={[typography.bodySm, { color: brandColors.textMuted }]}>{step.detail}</Text>
+                  <Text style={[typography.bodyMedium, styles.stepLabel, { textAlign: isRTL ? 'right' : 'left' }]}>
+                    {t(`becomeFixer.steps.${key}.label`)}
+                  </Text>
+                  <Text style={[typography.bodySm, { color: brandColors.textMuted, textAlign: isRTL ? 'right' : 'left' }]}>
+                    {t(`becomeFixer.steps.${key}.detail`)}
+                  </Text>
                 </View>
               </View>
             ))}
@@ -146,14 +140,16 @@ export default function BecomeFixerScreen({ navigation }: Props) {
             size="lg"
             onPress={() => void markSeenAndNavigate('profile')}
           >
-            Set Up My Profile
+            {t('becomeFixer.cta.setupProfile')}
           </FButton>
           <Pressable
             accessibilityRole="button"
             style={({ pressed }) => [styles.skipBtn, pressed && { opacity: 0.7 }]}
             onPress={() => void markSeenAndNavigate('jobs')}
           >
-            <Text style={styles.skipText}>Browse jobs first →</Text>
+            <Text style={styles.skipText}>
+              {isRTL ? `← ${t('becomeFixer.cta.browseFirst')}` : `${t('becomeFixer.cta.browseFirst')} →`}
+            </Text>
           </Pressable>
         </View>
       </ScrollView>
@@ -217,7 +213,6 @@ const styles = StyleSheet.create({
     width: '100%',
   },
   benefitCard: {
-    flexDirection: 'row',
     alignItems: 'flex-start',
     gap: spacing.md,
     backgroundColor: brandColors.surface,
@@ -265,7 +260,6 @@ const styles = StyleSheet.create({
     gap: spacing.md,
   },
   step: {
-    flexDirection: 'row',
     alignItems: 'flex-start',
     gap: spacing.md,
   },

--- a/frontend/src/screens/BecomeFixerScreen.tsx
+++ b/frontend/src/screens/BecomeFixerScreen.tsx
@@ -16,8 +16,9 @@ import { type NativeStackScreenProps } from '@react-navigation/native-stack';
 import { type RootStackParamList } from '../navigation/landingIntent';
 import { FButton } from '../components/ui';
 import { brandColors, radii, shadows, spacing, typography } from '../theme';
+import { auth } from '../config/firebase';
 
-const STORAGE_KEY = 'fixerOnboardingSeen';
+const getOnboardingKey = () => `fixerOnboardingSeen_${auth.currentUser?.uid ?? 'anon'}`;
 
 const BENEFITS = [
   {
@@ -54,7 +55,7 @@ export default function BecomeFixerScreen({ navigation }: Props) {
   navigationRef.current = navigation;
 
   useEffect(() => {
-    AsyncStorage.getItem(STORAGE_KEY).then((seen) => {
+    AsyncStorage.getItem(getOnboardingKey()).then((seen) => {
       if (seen === 'true') {
         navigationRef.current.replace('Main', { screen: 'FixerMode', params: { screen: 'FindJobs' } });
       } else {
@@ -67,7 +68,7 @@ export default function BecomeFixerScreen({ navigation }: Props) {
   }, [fadeAnim, slideAnim]);
 
   const markSeenAndNavigate = async (dest: 'profile' | 'jobs') => {
-    await AsyncStorage.setItem(STORAGE_KEY, 'true');
+    await AsyncStorage.setItem(getOnboardingKey(), 'true');
     if (dest === 'profile') {
       navigation.replace('Main', { screen: 'FixerMode', params: { screen: 'FixerProfile' } });
     } else {

--- a/frontend/src/screens/LandingScreen.tsx
+++ b/frontend/src/screens/LandingScreen.tsx
@@ -396,11 +396,7 @@ export default function LandingScreen({
     setSelectedCategory((current) => (current === category ? null : category));
   };
 
-  const handleLogin = () => {
-    runAndClose(onLogin ?? (() => onPostTask()));
-  };
-
-  const handleCreateAccount = () => {
+  const handleGetStarted = () => {
     runAndClose(onCreateAccount ?? onLogin ?? (() => onPostTask()));
   };
 
@@ -441,7 +437,7 @@ export default function LandingScreen({
     { label: t('landing.nav.findJobs'), shortLabel: t('landing.nav.fixer'), icon: 'account-hard-hat-outline', onPress: handleFixerCta },
   ];
   const compactDashboardLabels = wide && width < 1040;
-  const postTaskCtaLabel = isSignedIn ? t('landing.nav.postTask') : t('landing.nav.signInToPost');
+  const postTaskCtaLabel = isSignedIn ? t('landing.nav.postTask') : 'Get Started';
   const fixerCtaLabel = isSignedIn ? t('landing.nav.openFixerWorkspace') : hasDedicatedFixerOnboarding ? t('landing.nav.joinAsFixer') : t('landing.nav.signInToFind');
 
   return (
@@ -537,27 +533,17 @@ export default function LandingScreen({
               </View>
             ) : (
               <>
-                {!isSignedIn && wide && (
-                  <Pressable
-                    onPress={handleLogin}
-                    style={styles.navLogin}
-                    accessibilityRole="button"
-                    accessibilityLabel={t('landing.nav.login')}
-                  >
-                    <Text style={styles.navLoginText}>{t('landing.nav.login')}</Text>
-                  </Pressable>
-                )}
                 <Pressable
-                  onPress={isSignedIn ? handleRequesterHome : () => handlePostTaskCta()}
+                  onPress={isSignedIn ? handleRequesterHome : handleGetStarted}
                   accessibilityRole="button"
-                  accessibilityLabel={isSignedIn ? 'Requester Dashboard' : postTaskCtaLabel}
+                  accessibilityLabel={isSignedIn ? 'Requester Dashboard' : 'Get Started'}
                   style={({ pressed }) => [
                     styles.navCta,
                     { opacity: pressed ? 0.85 : 1, transform: [{ scale: pressed ? 0.96 : 1 }] },
                   ]}
                 >
                   <Text style={styles.navCtaText} numberOfLines={1}>
-                    {isSignedIn ? 'Requester Dashboard' : postTaskCtaLabel}
+                    {isSignedIn ? 'Requester Dashboard' : 'Get Started'}
                   </Text>
                 </Pressable>
               </>
@@ -608,24 +594,13 @@ export default function LandingScreen({
             ))}
             {!isSignedIn && (
               <Pressable
-                onPress={handleLogin}
+                onPress={handleGetStarted}
                 accessibilityRole="button"
-                accessibilityLabel={t('landing.nav.login')}
-                style={({ pressed }) => [styles.mobileMenuItem, pressed && styles.mobileMenuItemPressed]}
-              >
-                <MaterialCommunityIcons name="login" size={18} color={brandColors.textOnDark} />
-                <Text style={styles.mobileMenuText}>{t('landing.nav.login')}</Text>
-              </Pressable>
-            )}
-            {!isSignedIn && onCreateAccount && (
-              <Pressable
-                onPress={handleCreateAccount}
-                accessibilityRole="button"
-                accessibilityLabel={t('landing.nav.createAccount')}
+                accessibilityLabel="Get Started"
                 style={({ pressed }) => [styles.mobileMenuItem, pressed && styles.mobileMenuItemPressed]}
               >
                 <MaterialCommunityIcons name="account-plus-outline" size={18} color={brandColors.textOnDark} />
-                <Text style={styles.mobileMenuText}>{t('landing.nav.createAccount')}</Text>
+                <Text style={styles.mobileMenuText}>Get Started</Text>
               </Pressable>
             )}
             {!isSignedIn && (
@@ -664,7 +639,7 @@ export default function LandingScreen({
               {t('landing.hero.body')}
             </Text>
             <View style={styles.heroActions}>
-              <FButton onPress={() => handlePostTaskCta()} variant="secondary" size="lg" icon={isSignedIn ? 'plus' : 'login'}>
+              <FButton onPress={() => handlePostTaskCta()} variant="secondary" size="lg" icon={isSignedIn ? 'plus' : 'arrow-right'}>
                 {postTaskCtaLabel}
               </FButton>
               <Pressable
@@ -811,7 +786,7 @@ export default function LandingScreen({
                       <Text style={styles.catInlinePrompt} numberOfLines={3}>
                         {cat.starterPrompt}
                       </Text>
-                      <FButton onPress={() => handleCategoryTask(cat.value)} icon={isSignedIn ? 'plus' : 'login'} fullWidth>
+                      <FButton onPress={() => handleCategoryTask(cat.value)} icon={isSignedIn ? 'plus' : 'arrow-right'} fullWidth>
                         {isSignedIn ? t('landing.categories.postIn', { label: cat.label }) : postTaskCtaLabel}
                       </FButton>
                     </View>

--- a/frontend/src/screens/LandingScreen.tsx
+++ b/frontend/src/screens/LandingScreen.tsx
@@ -437,7 +437,7 @@ export default function LandingScreen({
     { label: t('landing.nav.findJobs'), shortLabel: t('landing.nav.fixer'), icon: 'account-hard-hat-outline', onPress: handleFixerCta },
   ];
   const compactDashboardLabels = wide && width < 1040;
-  const postTaskCtaLabel = isSignedIn ? t('landing.nav.postTask') : 'Get Started';
+  const postTaskCtaLabel = isSignedIn ? t('landing.nav.postTask') : t('landing.nav.getStarted');
   const fixerCtaLabel = isSignedIn ? t('landing.nav.openFixerWorkspace') : hasDedicatedFixerOnboarding ? t('landing.nav.joinAsFixer') : t('landing.nav.signInToFind');
 
   return (
@@ -536,14 +536,14 @@ export default function LandingScreen({
                 <Pressable
                   onPress={isSignedIn ? handleRequesterHome : handleGetStarted}
                   accessibilityRole="button"
-                  accessibilityLabel={isSignedIn ? 'Requester Dashboard' : 'Get Started'}
+                  accessibilityLabel={isSignedIn ? t('landing.nav.requesterDashboard') : 'Get Started'}
                   style={({ pressed }) => [
                     styles.navCta,
                     { opacity: pressed ? 0.85 : 1, transform: [{ scale: pressed ? 0.96 : 1 }] },
                   ]}
                 >
                   <Text style={styles.navCtaText} numberOfLines={1}>
-                    {isSignedIn ? 'Requester Dashboard' : 'Get Started'}
+                    {isSignedIn ? t('landing.nav.requesterDashboard') : 'Get Started'}
                   </Text>
                 </Pressable>
               </>
@@ -596,7 +596,7 @@ export default function LandingScreen({
               <Pressable
                 onPress={handleGetStarted}
                 accessibilityRole="button"
-                accessibilityLabel="Get Started"
+                accessibilityLabel={t('landing.nav.getStarted')}
                 style={({ pressed }) => [styles.mobileMenuItem, pressed && styles.mobileMenuItemPressed]}
               >
                 <MaterialCommunityIcons name="account-plus-outline" size={18} color={brandColors.textOnDark} />

--- a/frontend/src/screens/LandingScreen.web.tsx
+++ b/frontend/src/screens/LandingScreen.web.tsx
@@ -1033,11 +1033,9 @@ export default function LandingScreen({
                 </button>
               )}
             </>
-          ) : (
-            <button type="button" className="login" onClick={handleLogin}>{t('landing.nav.login')}</button>
-          )}
-          <button type="button" className="cta" onClick={() => handlePostTaskCta()}>
-            {postTaskCtaLabel} <span className="arr">→</span>
+          ) : null}
+          <button type="button" className="cta" onClick={isSignedIn ? () => handlePostTaskCta() : () => runAndClose(onCreateAccount ?? onLogin ?? (() => onPostTask()))}>
+            {isSignedIn ? postTaskCtaLabel : 'Get Started'} <span className="arr">→</span>
           </button>
           <button
             type="button"
@@ -1064,9 +1062,7 @@ export default function LandingScreen({
               <a href="#how" onClick={closeMenus}>{t('landing.nav.howItWorks')}</a>
               <a href="#categories" onClick={closeMenus}>{t('landing.nav.categories')}</a>
               <a href="#fixers" onClick={closeMenus}>{t('landing.nav.forFixers')}</a>
-              <button type="button" onClick={handleLogin}><LandingIcon name="login" size={18} />{t('landing.nav.login')}</button>
-              {onCreateAccount && <button type="button" onClick={() => runAndClose(onCreateAccount)}><LandingIcon name="account-plus-outline" size={18} />{t('landing.nav.createAccount')}</button>}
-              <button type="button" onClick={() => handlePostTaskCta()}><LandingIcon name={isSignedIn ? 'plus-circle-outline' : 'login'} size={18} />{postTaskCtaLabel}</button>
+              <button type="button" onClick={() => runAndClose(onCreateAccount ?? onLogin ?? (() => onPostTask()))}><LandingIcon name="account-plus-outline" size={18} />Get Started</button>
               <button type="button" onClick={handleFixerCta}><LandingIcon name="account-hard-hat-outline" size={18} />{fixerCtaLabel}</button>
             </>
           )}

--- a/frontend/src/screens/LandingScreen.web.tsx
+++ b/frontend/src/screens/LandingScreen.web.tsx
@@ -1035,7 +1035,7 @@ export default function LandingScreen({
             </>
           ) : null}
           <button type="button" className="cta" onClick={isSignedIn ? () => handlePostTaskCta() : () => runAndClose(onCreateAccount ?? onLogin ?? (() => onPostTask()))}>
-            {isSignedIn ? postTaskCtaLabel : 'Get Started'} <span className="arr">→</span>
+            {isSignedIn ? postTaskCtaLabel : t('landing.nav.getStarted')} <span className="arr">→</span>
           </button>
           <button
             type="button"
@@ -1062,7 +1062,7 @@ export default function LandingScreen({
               <a href="#how" onClick={closeMenus}>{t('landing.nav.howItWorks')}</a>
               <a href="#categories" onClick={closeMenus}>{t('landing.nav.categories')}</a>
               <a href="#fixers" onClick={closeMenus}>{t('landing.nav.forFixers')}</a>
-              <button type="button" onClick={() => runAndClose(onCreateAccount ?? onLogin ?? (() => onPostTask()))}><LandingIcon name="account-plus-outline" size={18} />Get Started</button>
+              <button type="button" onClick={() => runAndClose(onCreateAccount ?? onLogin ?? (() => onPostTask()))}><LandingIcon name="account-plus-outline" size={18} />{t('landing.nav.getStarted')}</button>
               <button type="button" onClick={handleFixerCta}><LandingIcon name="account-hard-hat-outline" size={18} />{fixerCtaLabel}</button>
             </>
           )}


### PR DESCRIPTION
## Summary

- **Remove mode toggle** — the Requester/Fixer pill toggle is gone. Requester is the default app experience; Fixer is an explicit opt-in
- **Location badges** — "Requester" (blue) and "Fixer Workspace" (amber) badges sit next to the logo so current location is always clear
- **Amber fixer header** — the desktop header turns gold/amber in fixer mode, making it unmistakably a different environment
- **Become a Fixer onboarding screen** — first-time users see a benefits/steps screen before entering the fixer workspace. Returning users auto-forward. Flag is scoped per Firebase UID so new accounts always see the onboarding
- **Signed-in users skip the landing page** — `Landing` stack screen removed; signed-in users go straight to the app on every load
- **Symmetric workspace switchers** — "Open Fixer Workspace ›" in requester mode, "‹ Open Requester Workspace" in fixer mode. Neither implies one side is "home"
- **Active tab underline** — replaced the soft box highlight with a 3px bottom border (standard web pattern), tabs are horizontal icon+label rows
- **Settings icon on both workspaces** — cog icon visible in both headers; Post Task button removed from nav (redundant with dashboard)

## Test plan

- [ ] New account: "Become a Fixer" button shown (amber, filled), clicking it shows onboarding screen
- [ ] After completing onboarding: button changes to "Open Fixer Workspace ›"
- [ ] Different account on same device: each sees their own onboarding state
- [ ] Logo click always navigates to Requester dashboard regardless of current workspace
- [ ] Fixer workspace header is amber; requester header is white/blue
- [ ] Active tab has visible underline indicator in both workspaces
- [ ] Settings icon visible in both workspaces
- [ ] No landing page shown after sign-in on page load or logo click

🤖 Generated with [Claude Code](https://claude.com/claude-code)