### PR TITLE
feat: Shick updates — completion flow, UX improvements, web navigation

### DIFF
--- a/backend/prisma/migrations/20260605122054_add_dual_completion_flags/migration.sql
+++ b/backend/prisma/migrations/20260605122054_add_dual_completion_flags/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "fixer_completed" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "requester_completed" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -126,6 +126,8 @@ model Task {
   assigned_fixer_id     String?
   completion_photos     String[]
   is_payment_confirmed  Boolean    @default(false)
+  requester_completed   Boolean    @default(false)
+  fixer_completed       Boolean    @default(false)
   completed_at          DateTime?
   created_at            DateTime   @default(now())
   updated_at            DateTime   @updatedAt

--- a/backend/src/__tests__/routes/admin.test.ts
+++ b/backend/src/__tests__/routes/admin.test.ts
@@ -52,7 +52,12 @@ async function setupFlaggedReview() {
   // Accept bid, complete task
   __setUid('requester-uid');
   await request(app).put(`/api/bids/${bidRes.body.bid.id}/accept`).set('Authorization', REQUESTER_AUTH);
-  await request(app).put(`/api/tasks/${taskId}/status`).set('Authorization', REQUESTER_AUTH).send({ status: 'COMPLETED' });
+  // Dual-confirm completion
+  await request(app).put(`/api/tasks/${taskId}/confirm-payment`).set('Authorization', REQUESTER_AUTH);
+  await request(app).put(`/api/tasks/${taskId}/confirm-completion`).set('Authorization', REQUESTER_AUTH);
+  __setUid('fixer-uid');
+  await request(app).put(`/api/tasks/${taskId}/confirm-completion`).set('Authorization', FIXER_AUTH);
+  __setUid('requester-uid');
 
   // Write review
   const reviewRes = await request(app)

--- a/backend/src/__tests__/routes/messages.test.ts
+++ b/backend/src/__tests__/routes/messages.test.ts
@@ -518,6 +518,90 @@ describe('GET /api/conversations', () => {
   });
 });
 
+// ── DELETE /api/tasks/:id/messages ───────────────────────────────────────────
+
+async function completeTask(taskId: string) {
+  __setUid('requester-uid');
+  await request(app).put(`/api/tasks/${taskId}/confirm-payment`).set('Authorization', REQUESTER_AUTH);
+  await request(app).put(`/api/tasks/${taskId}/confirm-completion`).set('Authorization', REQUESTER_AUTH);
+  __setUid('fixer-uid');
+  await request(app).put(`/api/tasks/${taskId}/confirm-completion`).set('Authorization', FIXER_AUTH);
+  __setUid('requester-uid');
+}
+
+describe('DELETE /api/tasks/:id/messages', () => {
+  it('deletes all messages for a completed task', async () => {
+    const task = await createTaskInProgress();
+    await seedMessages(task.id);
+    await completeTask(task.id);
+
+    __setUid('requester-uid');
+    const res = await request(app)
+      .delete(`/api/tasks/${task.id}/messages`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    const count = await prisma.message.count({ where: { task_id: task.id } });
+    expect(count).toBe(0);
+  });
+
+  it('allows the fixer to delete messages for a completed task', async () => {
+    const task = await createTaskInProgress();
+    await seedMessages(task.id);
+    await completeTask(task.id);
+
+    __setUid('fixer-uid');
+    const res = await request(app)
+      .delete(`/api/tasks/${task.id}/messages`)
+      .set('Authorization', FIXER_AUTH);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('returns 403 for an in-progress task', async () => {
+    const task = await createTaskInProgress();
+    await seedMessages(task.id);
+
+    __setUid('requester-uid');
+    const res = await request(app)
+      .delete(`/api/tasks/${task.id}/messages`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 for a non-participant', async () => {
+    const task = await createTaskInProgress();
+    await seedMessages(task.id);
+    await completeTask(task.id);
+
+    __setUid('other-uid');
+    const res = await request(app)
+      .delete(`/api/tasks/${task.id}/messages`)
+      .set('Authorization', OTHER_AUTH);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for a non-existent task', async () => {
+    __setUid('requester-uid');
+    const res = await request(app)
+      .delete('/api/tasks/non-existent-id/messages')
+      .set('Authorization', REQUESTER_AUTH);
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 401 without auth header', async () => {
+    const task = await createTaskInProgress();
+    const res = await request(app).delete(`/api/tasks/${task.id}/messages`);
+    expect(res.status).toBe(401);
+  });
+});
+
 // ── Messages deleted on task completion ──────────────────────────────────────
 
 describe('Task completion preserves messages', () => {

--- a/backend/src/__tests__/routes/messages.test.ts
+++ b/backend/src/__tests__/routes/messages.test.ts
@@ -520,8 +520,8 @@ describe('GET /api/conversations', () => {
 
 // ── Messages deleted on task completion ──────────────────────────────────────
 
-describe('Task completion deletes messages', () => {
-  it('deletes all messages when requester marks task as COMPLETED', async () => {
+describe('Task completion preserves messages', () => {
+  it('keeps messages when task is completed via dual-confirm', async () => {
     const task = await createTaskInProgress();
     await seedMessages(task.id);
 
@@ -529,16 +529,21 @@ describe('Task completion deletes messages', () => {
     const before = await prisma.message.count({ where: { task_id: task.id } });
     expect(before).toBe(3);
 
-    // Complete the task
+    // Complete the task via dual-confirm flow
     __setUid('requester-uid');
-    const res = await request(app)
-      .put(`/api/tasks/${task.id}/status`)
-      .set('Authorization', REQUESTER_AUTH)
-      .send({ status: 'COMPLETED' });
-    expect(res.status).toBe(200);
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-payment`)
+      .set('Authorization', REQUESTER_AUTH);
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', REQUESTER_AUTH);
+    __setUid('fixer-uid');
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', FIXER_AUTH);
 
-    // Messages should be gone
+    // Messages should be preserved for past conversations
     const after = await prisma.message.count({ where: { task_id: task.id } });
-    expect(after).toBe(0);
+    expect(after).toBe(3);
   });
 });

--- a/backend/src/__tests__/routes/reviews.test.ts
+++ b/backend/src/__tests__/routes/reviews.test.ts
@@ -54,11 +54,18 @@ async function createTaskAndReview() {
   __setUid('requester-uid');
   await request(app).put(`/api/bids/${bidId}/accept`).set('Authorization', REQUESTER_AUTH);
 
-  // Mark completed
+  // Dual-confirm completion: payment → requester → fixer
   await request(app)
-    .put(`/api/tasks/${taskId}/status`)
-    .set('Authorization', REQUESTER_AUTH)
-    .send({ status: 'COMPLETED' });
+    .put(`/api/tasks/${taskId}/confirm-payment`)
+    .set('Authorization', REQUESTER_AUTH);
+  await request(app)
+    .put(`/api/tasks/${taskId}/confirm-completion`)
+    .set('Authorization', REQUESTER_AUTH);
+  __setUid('fixer-uid');
+  await request(app)
+    .put(`/api/tasks/${taskId}/confirm-completion`)
+    .set('Authorization', FIXER_AUTH);
+  __setUid('requester-uid');
 
   // Requester writes review about fixer
   const reviewRes = await request(app)

--- a/backend/src/__tests__/routes/tasks.test.ts
+++ b/backend/src/__tests__/routes/tasks.test.ts
@@ -68,6 +68,22 @@ async function acceptBid(taskId: string) {
   return bidId;
 }
 
+// Full dual-confirm completion: confirm payment → requester confirms → fixer confirms
+async function completeTaskFull(taskId: string) {
+  __setUid('test-uid');
+  await request(app)
+    .put(`/api/tasks/${taskId}/confirm-payment`)
+    .set('Authorization', REQUESTER_AUTH);
+  await request(app)
+    .put(`/api/tasks/${taskId}/confirm-completion`)
+    .set('Authorization', REQUESTER_AUTH);
+  __setUid('fixer-uid');
+  await request(app)
+    .put(`/api/tasks/${taskId}/confirm-completion`)
+    .set('Authorization', FIXER_AUTH);
+  __setUid('test-uid');
+}
+
 // ── POST /api/tasks ───────────────────────────────────────────────────────────
 
 describe('POST /api/tasks', () => {
@@ -295,15 +311,22 @@ describe('PUT /api/tasks/:id/status', () => {
     expect(bids.every((b) => b.status === 'REJECTED')).toBe(true);
   });
 
-  it('requester can mark an IN_PROGRESS task as COMPLETED', async () => {
+  it('dual-confirm completes an IN_PROGRESS task', async () => {
+    const task = await createTask();
+    await acceptBid(task.id);
+    await completeTaskFull(task.id);
+    const updated = await prisma.task.findUnique({ where: { id: task.id } });
+    expect(updated!.status).toBe('COMPLETED');
+  });
+
+  it('rejects direct IN_PROGRESS → COMPLETED transition', async () => {
     const task = await createTask();
     await acceptBid(task.id);
     const res = await request(app)
       .put(`/api/tasks/${task.id}/status`)
       .set('Authorization', REQUESTER_AUTH)
       .send({ status: 'COMPLETED' });
-    expect(res.status).toBe(200);
-    expect(res.body.task.status).toBe('COMPLETED');
+    expect(res.status).toBe(400);
   });
 
   it('requester can cancel an IN_PROGRESS task', async () => {
@@ -340,14 +363,9 @@ describe('PUT /api/tasks/:id/status', () => {
 // ── PUT /api/tasks/:id/confirm-payment ────────────────────────────────────────
 
 describe('PUT /api/tasks/:id/confirm-payment', () => {
-  it('requester can confirm payment on a COMPLETED task', async () => {
+  it('requester can confirm payment on an IN_PROGRESS task', async () => {
     const task = await createTask();
     await acceptBid(task.id);
-    await request(app)
-      .put(`/api/tasks/${task.id}/status`)
-      .set('Authorization', REQUESTER_AUTH)
-      .send({ status: 'COMPLETED' });
-
     const res = await request(app)
       .put(`/api/tasks/${task.id}/confirm-payment`)
       .set('Authorization', REQUESTER_AUTH);
@@ -370,10 +388,7 @@ describe('POST /api/tasks/:id/reviews', () => {
   async function completeTask() {
     const task = await createTask();
     await acceptBid(task.id);
-    await request(app)
-      .put(`/api/tasks/${task.id}/status`)
-      .set('Authorization', REQUESTER_AUTH)
-      .send({ status: 'COMPLETED' });
+    await completeTaskFull(task.id);
     return task;
   }
 
@@ -588,10 +603,7 @@ describe('POST /api/tasks/:id/reviews (forbidden)', () => {
   it('returns 403 when a non-requester tries to submit a review', async () => {
     const task = await createTask();
     await acceptBid(task.id);
-    await request(app)
-      .put(`/api/tasks/${task.id}/status`)
-      .set('Authorization', REQUESTER_AUTH)
-      .send({ status: 'COMPLETED' });
+    await completeTaskFull(task.id);
 
     __setUid('fixer-uid');
     const res = await request(app)
@@ -718,10 +730,7 @@ describe('POST /api/tasks/:id/reviews (edge cases)', () => {
   async function completeTask() {
     const task = await createTask();
     await acceptBid(task.id);
-    await request(app)
-      .put(`/api/tasks/${task.id}/status`)
-      .set('Authorization', REQUESTER_AUTH)
-      .send({ status: 'COMPLETED' });
+    await completeTaskFull(task.id);
     return task;
   }
 

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -141,6 +141,31 @@ router.get('/conversations', async (req: Request, res: Response, next: NextFunct
   }
 });
 
+// DELETE /api/tasks/:id/messages — delete all messages for a completed/canceled task (participant only)
+router.delete('/tasks/:id/messages', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const taskId = req.params.id;
+    const userId = req.user!.id;
+
+    const task = await prisma.task.findUnique({ where: { id: taskId } });
+    if (!task) throw new NotFoundError('Task not found');
+
+    const isMember =
+      task.requester_id === userId || task.assigned_fixer_id === userId;
+    if (!isMember) throw new ForbiddenError('Not a participant in this task');
+
+    if (task.status !== 'COMPLETED' && task.status !== 'CANCELED') {
+      throw new ForbiddenError('Can only delete messages for completed or canceled tasks');
+    }
+
+    await prisma.message.deleteMany({ where: { task_id: taskId } });
+
+    res.json({ ok: true });
+  } catch (err) {
+    next(err);
+  }
+});
+
 // PUT /api/tasks/:id/messages/read — mark all unread messages received by the caller in this task as read
 router.put('/tasks/:id/messages/read', async (req: Request, res: Response, next: NextFunction) => {
   try {

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -428,7 +428,7 @@ router.put('/:id/status', validate(updateTaskStatusSchema), async (req: Request,
     // transition here.
     const validTransitions: Partial<Record<TaskStatus, TaskStatus[]>> = {
       OPEN: ['CANCELED'],
-      IN_PROGRESS: ['COMPLETED', 'CANCELED'],
+      IN_PROGRESS: ['CANCELED'],
     };
 
     if (!validTransitions[task.status]?.includes(newStatus)) {
@@ -464,34 +464,10 @@ router.put('/:id/status', validate(updateTaskStatusSchema), async (req: Request,
           'Task',
         );
       }
-    } else if (task.status === 'IN_PROGRESS' && newStatus === 'COMPLETED') {
-      await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
-        await tx.task.update({
-          where: { id: task.id },
-          data: { status: 'COMPLETED', completed_at: new Date() },
-        });
-        // Delete chat messages once the task is completed
-        await tx.message.deleteMany({ where: { task_id: task.id } });
-        // Increment fixer's completed task count
-        if (task.assigned_fixer_id) {
-          await tx.user.update({
-            where: { id: task.assigned_fixer_id },
-            data: { completed_tasks_as_fixer: { increment: 1 } },
-          });
-        }
-      });
-
-      if (task.assigned_fixer_id) {
-        await sendNotification(
-          task.assigned_fixer_id,
-          'Task Completed',
-          `The task "${task.title}" has been marked as completed.`,
-          'TASK_COMPLETED',
-          task.id,
-          'Task',
-        );
-      }
     } else if (task.status === 'IN_PROGRESS' && newStatus === 'CANCELED') {
+      if (task.is_payment_confirmed) {
+        throw new ValidationError('Cannot cancel a task after payment has been confirmed');
+      }
       await prisma.task.update({
         where: { id: task.id },
         data: { status: 'CANCELED' },
@@ -554,13 +530,108 @@ router.put('/:id/confirm-payment', async (req: Request, res: Response, next: Nex
 
     if (!task) throw new NotFoundError('Task not found');
     if (req.user.id !== task.requester_id) throw new ForbiddenError('Only the requester can confirm payment');
-    if (task.status !== 'COMPLETED') throw new ValidationError('Payment can only be confirmed on a completed task');
+    if (task.status !== 'IN_PROGRESS' && task.status !== 'COMPLETED') {
+      throw new ValidationError('Payment can only be confirmed on an in-progress or completed task');
+    }
 
     const updated = await prisma.task.update({
       where: { id: task.id },
       data: { is_payment_confirmed: true },
     });
 
+    // Notify fixer that payment was confirmed
+    if (task.assigned_fixer_id) {
+      await sendNotification(
+        task.assigned_fixer_id,
+        'Payment Confirmed',
+        `The requester confirmed payment for "${task.title}". You can now mark the task as completed.`,
+        'TASK_COMPLETED',
+        task.id,
+        'Task',
+      );
+    }
+
+    res.json({ task: updated });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// PUT /api/tasks/:id/confirm-completion — both sides must confirm after payment
+router.put('/:id/confirm-completion', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const task = await prisma.task.findUnique({ where: { id: req.params.id } });
+
+    if (!task) throw new NotFoundError('Task not found');
+    if (task.status !== 'IN_PROGRESS') throw new ValidationError('Task must be in progress');
+    if (!task.is_payment_confirmed) throw new ValidationError('Payment must be confirmed before marking as completed');
+
+    const isRequester = req.user.id === task.requester_id;
+    const isFixer = req.user.id === task.assigned_fixer_id;
+    if (!isRequester && !isFixer) throw new ForbiddenError('Only the requester or assigned fixer can confirm completion');
+
+    const updateData: Record<string, boolean> = {};
+    if (isRequester) updateData.requester_completed = true;
+    if (isFixer) updateData.fixer_completed = true;
+
+    const newRequesterCompleted = isRequester ? true : task.requester_completed;
+    const newFixerCompleted = isFixer ? true : task.fixer_completed;
+    const bothCompleted = newRequesterCompleted && newFixerCompleted;
+
+    if (bothCompleted) {
+      await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        await tx.task.update({
+          where: { id: task.id },
+          data: { ...updateData, status: 'COMPLETED', completed_at: new Date() },
+        });
+        if (task.assigned_fixer_id) {
+          await tx.user.update({
+            where: { id: task.assigned_fixer_id },
+            data: { completed_tasks_as_fixer: { increment: 1 } },
+          });
+        }
+      });
+
+      // Notify both sides
+      await sendNotification(
+        task.requester_id,
+        'Task Completed',
+        `The task "${task.title}" has been marked as completed by both sides.`,
+        'TASK_COMPLETED',
+        task.id,
+        'Task',
+      );
+      if (task.assigned_fixer_id) {
+        await sendNotification(
+          task.assigned_fixer_id,
+          'Task Completed',
+          `The task "${task.title}" has been marked as completed by both sides.`,
+          'TASK_COMPLETED',
+          task.id,
+          'Task',
+        );
+      }
+    } else {
+      await prisma.task.update({
+        where: { id: task.id },
+        data: updateData,
+      });
+
+      // Notify the other side
+      const otherUserId = isRequester ? task.assigned_fixer_id : task.requester_id;
+      if (otherUserId) {
+        await sendNotification(
+          otherUserId,
+          'Completion Confirmed',
+          `One side has confirmed completion of "${task.title}". Please confirm on your end.`,
+          'TASK_COMPLETED',
+          task.id,
+          'Task',
+        );
+      }
+    }
+
+    const updated = await prisma.task.findUnique({ where: { id: task.id } });
     res.json({ task: updated });
   } catch (err) {
     next(err);

--- a/backend/src/utils/ratingCalculator.ts
+++ b/backend/src/utils/ratingCalculator.ts
@@ -23,8 +23,10 @@ const DECAY_LAMBDA = Math.LN2 / 180;
 
 // Bayesian confidence parameter — number of "virtual" reviews pulling toward
 // the platform average. With m=3, a fixer needs ~3 real reviews before their
-// personal average starts to dominate.
-const BAYESIAN_M = 3;
+// personal average starts to dominate. With m=1, a fixer needs just
+// ~1 real review before their personal average starts to dominate.
+// Can be increased as the platform scales.
+const BAYESIAN_M = 1;
 
 export async function recalculateFixerRating(fixerId: string): Promise<void> {
   const reviews = await prisma.review.findMany({

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,6 +1,6 @@
 import './src/i18n';
 import { StatusBar } from 'expo-status-bar';
-import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';
+import { NavigationContainer, useNavigationContainerRef, type LinkingOptions } from '@react-navigation/native';
 import { PaperProvider } from 'react-native-paper';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -29,6 +29,55 @@ type SignedOutSurface = 'landing' | 'auth';
 
 const USE_SIGNED_OUT_LANDING = Platform.OS === 'web';
 const DEFAULT_SIGNED_OUT_SURFACE: SignedOutSurface = USE_SIGNED_OUT_LANDING ? 'landing' : 'auth';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const linking: LinkingOptions<any> = {
+  prefixes: [typeof window !== 'undefined' ? window.location.origin : ''],
+  config: {
+    screens: {
+      Main: {
+        path: '',
+        screens: {
+          RequesterMode: {
+            path: 'requester',
+            screens: {
+              Dashboard: 'dashboard',
+              MyTasks: 'my-tasks',
+              Messages: 'messages',
+              Profile: 'profile',
+            },
+          },
+          FixerMode: {
+            path: 'fixer',
+            screens: {
+              FindJobs: 'find-jobs',
+              MyBids: 'my-bids',
+              Messages: 'messages',
+              FixerProfile: 'profile',
+            },
+          },
+        },
+      },
+      CreateTask: 'create-task',
+      TaskDetails: {
+        path: 'task/:taskId',
+      },
+      TaskDetailsFixer: {
+        path: 'job/:taskId',
+      },
+      Settings: 'settings',
+      PublicProfile: {
+        path: 'user/:userId',
+      },
+      NotificationCenter: 'notifications',
+      BecomeFixerOnboarding: 'become-fixer',
+      PastConversations: 'past-conversations',
+      Chat: {
+        path: 'chat/:taskId',
+      },
+    },
+  },
+};
 
 const LandingScreenWithNavigationProps = asLandingScreenWithNavigationProps(LandingScreen);
 
@@ -129,6 +178,7 @@ function RootContent() {
     <NotificationProvider>
       <NavigationContainer
         ref={navigationRef}
+        linking={Platform.OS === 'web' ? linking : undefined}
         theme={navigationTheme}
         onReady={() => setNavigationReady(true)}
       >

--- a/frontend/src/components/DiscoveryListCard.tsx
+++ b/frontend/src/components/DiscoveryListCard.tsx
@@ -8,21 +8,21 @@ import { getCategoryMetadata } from '../constants/categories';
 import { getCategoryLabel } from '../utils/categoryMetadata';
 import { brandColors, spacing, radii, shadows, typography } from '../theme';
 
-function formatTimeAgo(dateString: string): string {
+function formatTimeAgo(dateString: string, t: (key: string, opts?: Record<string, unknown>) => string): string {
   const diffMs = Date.now() - new Date(dateString).getTime();
   const minutes = Math.floor(diffMs / 60000);
-  if (minutes < 1) return 'Just now';
-  if (minutes === 1) return '1 minute ago';
-  if (minutes < 60) return `${minutes} minutes ago`;
+  if (minutes < 1) return t('timeAgo.justNow');
+  if (minutes === 1) return t('timeAgo.minuteAgo');
+  if (minutes < 60) return t('timeAgo.minutesAgo', { count: minutes });
   const hours = Math.floor(minutes / 60);
-  if (hours === 1) return '1 hour ago';
-  if (hours < 24) return `${hours} hours ago`;
+  if (hours === 1) return t('timeAgo.hourAgo');
+  if (hours < 24) return t('timeAgo.hoursAgo', { count: hours });
   const days = Math.floor(hours / 24);
-  if (days === 1) return 'Yesterday';
-  if (days < 7) return `${days} days ago`;
+  if (days === 1) return t('timeAgo.yesterday');
+  if (days < 7) return t('timeAgo.daysAgo', { count: days });
   const weeks = Math.floor(days / 7);
-  if (weeks === 1) return '1 week ago';
-  return `${weeks} weeks ago`;
+  if (weeks === 1) return t('timeAgo.weekAgo');
+  return t('timeAgo.weeksAgo', { count: weeks });
 }
 
 interface DiscoveryListCardProps {
@@ -33,7 +33,7 @@ interface DiscoveryListCardProps {
 
 export default function DiscoveryListCard({ task, hasBid = false, onPress }: DiscoveryListCardProps) {
   const { t } = useTranslation();
-  const budgetLabel = task.suggestedPrice != null ? `₪${task.suggestedPrice}` : 'No price specified';
+  const budgetLabel = task.suggestedPrice != null ? `₪${task.suggestedPrice}` : t('discoveryCard.noPrice');
   const catMeta = getCategoryMetadata(task.category);
 
   return (
@@ -59,13 +59,13 @@ export default function DiscoveryListCard({ task, hasBid = false, onPress }: Dis
           <View style={styles.categoryLine}>
             <Text style={[typography.caption, { color: catMeta.color }]}>{getCategoryLabel(task.category, t)}</Text>
             <View style={styles.metaDot} />
-            <Text style={[typography.caption, styles.metaText]}>{formatTimeAgo(task.createdAt)}</Text>
+            <Text style={[typography.caption, styles.metaText]}>{formatTimeAgo(task.createdAt, t)}</Text>
           </View>
           <View style={{ flexDirection: 'row', gap: spacing.xs }}>
             {hasBid && (
               <View style={styles.bidStatusPill}>
                 <MaterialCommunityIcons name="check-circle-outline" size={12} color={brandColors.success} />
-                <Text style={[typography.caption, styles.bidStatusText]}>Bid sent</Text>
+                <Text style={[typography.caption, styles.bidStatusText]}>{t('discoveryCard.bidSent')}</Text>
               </View>
             )}
             {task.urgency === 'TODAY' && (
@@ -108,7 +108,7 @@ export default function DiscoveryListCard({ task, hasBid = false, onPress }: Dis
         </View>
         <View style={[styles.detailsCue, hasBid && styles.bidDetailsCue]}>
           <Text style={[typography.caption, hasBid ? styles.bidDetailsText : styles.detailsText]}>
-            {hasBid ? 'View bid' : 'Details'}
+            {hasBid ? t('discoveryCard.viewBid') : t('discoveryCard.details')}
           </Text>
           <MaterialCommunityIcons
             name={hasBid ? 'check-circle-outline' : 'arrow-right'}

--- a/frontend/src/components/DiscoveryPreviewCard.tsx
+++ b/frontend/src/components/DiscoveryPreviewCard.tsx
@@ -21,7 +21,7 @@ export default function DiscoveryPreviewCard({
   onViewDetails,
 }: DiscoveryPreviewCardProps) {
   const { t } = useTranslation();
-  const budgetLabel = task.suggestedPrice != null ? `₪${task.suggestedPrice}` : 'No price specified';
+  const budgetLabel = task.suggestedPrice != null ? `₪${task.suggestedPrice}` : t('discoveryCard.noPrice');
   const catMeta = getCategoryMetadata(task.category);
 
   return (
@@ -32,7 +32,7 @@ export default function DiscoveryPreviewCard({
             <MaterialCommunityIcons name={catMeta.icon} size={18} color={catMeta.color} />
           </View>
           <View>
-            <Text style={[typography.caption, { color: brandColors.textMuted }]}>Selected job</Text>
+            <Text style={[typography.caption, { color: brandColors.textMuted }]}>{t('discoveryCard.selectedJob')}</Text>
             <Text style={[typography.label, { color: catMeta.color }]}>{getCategoryLabel(task.category, t)}</Text>
           </View>
         </View>
@@ -45,19 +45,19 @@ export default function DiscoveryPreviewCard({
         {hasBid && (
           <View style={styles.bidNotice}>
             <MaterialCommunityIcons name="check-circle-outline" size={15} color={brandColors.success} />
-            <Text style={[typography.caption, styles.bidNoticeText]}>Bid already sent</Text>
+            <Text style={[typography.caption, styles.bidNoticeText]}>{t('discoveryCard.bidAlreadySent')}</Text>
           </View>
         )}
         {task.urgency === 'TODAY' && (
           <View style={[styles.bidNotice, { backgroundColor: brandColors.dangerSoft, borderColor: 'rgba(168,91,91,0.22)' }]}>
             <MaterialCommunityIcons name="clock-alert-outline" size={15} color={brandColors.danger} />
-            <Text style={[typography.caption, { color: brandColors.danger, fontWeight: '700' }]}>Today</Text>
+            <Text style={[typography.caption, { color: brandColors.danger, fontWeight: '700' }]}>{t('createTask.step4.urgency.today')}</Text>
           </View>
         )}
         {task.urgency === 'THIS_WEEK' && (
           <View style={[styles.bidNotice, { backgroundColor: brandColors.warningSoft, borderColor: 'rgba(155,109,42,0.22)' }]}>
             <MaterialCommunityIcons name="calendar-week" size={15} color={brandColors.warning} />
-            <Text style={[typography.caption, { color: brandColors.warning, fontWeight: '700' }]}>This week</Text>
+            <Text style={[typography.caption, { color: brandColors.warning, fontWeight: '700' }]}>{t('createTask.step4.urgency.thisWeek')}</Text>
           </View>
         )}
       </View>
@@ -94,7 +94,7 @@ export default function DiscoveryPreviewCard({
         size="md"
         variant={hasBid ? 'secondary' : 'primary'}
       >
-        {hasBid ? 'View Your Bid' : 'View Details'}
+        {hasBid ? t('discoveryCard.viewYourBid') : t('discoveryCard.viewDetails')}
       </FButton>
     </View>
   );

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -326,7 +326,7 @@
     "header": {
       "kicker": "Fixer Workspace",
       "title": "Bid pipeline",
-      "sub": "{{tab}} bids Â· {{pending}} pending Â· {{active}} active jobs"
+      "sub": "{{tab}} bids · {{pending}} pending · {{active}} active jobs"
     },
     "tabs": {
       "active": "Active",
@@ -356,7 +356,7 @@
     },
     "editModal": {
       "title": "Edit Bid",
-      "offer": "Offer (â‚ª)",
+      "offer": "Offer (₪)",
       "description": "Description",
       "save": "Save Changes",
       "cancel": "Cancel"
@@ -408,7 +408,7 @@
     "header": {
       "kicker": "Fixer Workspace",
       "title": "Find jobs",
-      "sub": "Open jobs near {{location}} Â· {{categories}} Â· {{budget}}"
+      "sub": "Open jobs near {{location}} · {{categories}} · {{budget}}"
     },
     "stats": {
       "openJobs": "Open jobs",
@@ -464,7 +464,7 @@
       "map": "Map",
       "list": "List",
       "budgetAny": "Budget: Any",
-      "budgetRange": "Budget: â‚ª{{min}}â€“â‚ª{{max}}",
+      "budgetRange": "Budget: ₪{{min}}–₪{{max}}",
       "clearFilters": "Clear filters",
       "currentLocation": "Current location"
     }
@@ -477,18 +477,29 @@
       "subtitle": "Say hello!"
     },
     "input": {
-      "placeholder": "Type a messageâ€¦"
+      "placeholder": "Type a message…"
     }
   },
   "conversations": {
-    "loading": "Loading messagesâ€¦",
+    "loading": "Loading messages…",
     "empty": {
       "title": "No conversations yet",
       "message": "Start a chat from a task once a bid is accepted."
     },
     "yesterday": "Yesterday",
     "unread": "unread",
-    "noMessages": "No messages yet"
+    "noMessages": "No messages yet",
+    "active": "Active",
+    "past": "Past Conversations"
+  },
+  "pastConversations": {
+    "empty": {
+      "title": "No past conversations",
+      "message": "Completed and canceled task conversations will appear here."
+    },
+    "deleteConfirmTitle": "Delete conversation?",
+    "deleteConfirmMessage": "Delete the conversation for \"{{title}}\"? This removes all messages permanently.",
+    "deleteFailed": "Failed to delete conversation."
   },
   "notifications": {
     "loading": "Loading notifications...",
@@ -553,6 +564,32 @@
         "confirm": "Reject bid"
       }
     },
+    "decline": {
+      "title": "Decline Bid",
+      "description": "Select a reason so the fixer can improve future bids.",
+      "reasons": {
+        "PRICE_TOO_HIGH": "Price too high",
+        "BAD_TIMING": "Bad timing",
+        "CHOSE_ANOTHER": "Chose another fixer",
+        "NOT_QUALIFIED": "Not the right fit",
+        "OTHER": "Other"
+      },
+      "note": "Note (optional)",
+      "notePlaceholder": "Add details if you'd like...",
+      "confirm": "Confirm Decline"
+    },
+    "completion": {
+      "photos": "Completion Photos",
+      "payStep": "Step 1: Pay the fixer",
+      "paymentConfirmed": "Payment confirmed",
+      "waitingFixer": "Waiting for the fixer to confirm completion",
+      "canceled": "Canceled",
+      "canceledMessage": "This task was canceled. Reopen it to re-post it to the discovery feed for fixers to bid on again.",
+      "reopenTask": "Reopen Task",
+      "reopenError": "Failed to reopen task.",
+      "reopenConfirmTitle": "Reopen task?",
+      "reopenConfirmMessage": "This will re-post the task to the discovery feed for fixers to bid on."
+    },
     "fixerReviews": {
       "title": "Fixer Reviews",
       "noReviews": "No reviews yet."
@@ -561,7 +598,7 @@
       "title": "Edit Task",
       "titleLabel": "Title",
       "descriptionLabel": "Description",
-      "budgetLabel": "Budget (â‚ª)",
+      "budgetLabel": "Budget (₪)",
       "locationLabel": "General location",
       "addressLabel": "Exact address",
       "saveChanges": "Save Changes"
@@ -603,8 +640,8 @@
     "notFound": "Task not found.",
     "noPhotos": "No photos attached",
     "requester": "Task Requester",
-    "yourBid": "Your Bid: â‚ª{{amount}}",
-    "suggestedBudget": "Suggested budget: â‚ª{{amount}}",
+    "yourBid": "Your Bid: ₪{{amount}}",
+    "suggestedBudget": "Suggested budget: ₪{{amount}}",
     "openToQuotes": "The requester is open to quotes.",
     "error": {
       "title": "Something went wrong",
@@ -628,7 +665,7 @@
       "chatWithRequester": "Chat with Requester"
     },
     "bidStatus": {
-      "submitted": "Bid Submitted âœ“",
+      "submitted": "Bid Submitted ✓",
       "accepted": "Bid Accepted",
       "noLongerAccepting": "No longer accepting bids"
     },
@@ -641,7 +678,7 @@
     "bidModal": {
       "title": "Submit Your Bid",
       "editTitle": "Edit Your Bid",
-      "price": "Your price (â‚ª)",
+      "price": "Your price (₪)",
       "pricePlaceholder": "e.g. 250",
       "pitchLabel": "Your pitch",
       "pitchPlaceholder": "Tell the requester why you're the right person...",
@@ -649,10 +686,29 @@
       "submit": "Send Offer",
       "updateOffer": "Update Offer",
       "cancel": "Cancel",
-      "errorPrice": "Enter a valid price greater than â‚ª0.",
+      "errorPrice": "Enter a valid price greater than ₪0.",
       "errorPitch": "Write a short pitch to the requester.",
       "maxBids": "This task has reached the maximum number of bids (15).",
       "errorSubmit": "Failed to submit bid. Please try again."
+    },
+    "rejectionReasons": {
+      "PRICE_TOO_HIGH": "Price too high",
+      "BAD_TIMING": "Bad timing",
+      "CHOSE_ANOTHER": "Chose another fixer",
+      "NOT_QUALIFIED": "Not the right fit",
+      "OTHER": "Other"
+    },
+    "completion": {
+      "photos": "Completion Photos",
+      "addPhotos": "Add Completion Photos",
+      "uploaded": "Uploaded",
+      "uploadedMessage": "Completion photos added and saved to your portfolio.",
+      "uploadError": "Failed to upload completion photos.",
+      "waitingPayment": "Waiting for the requester to confirm payment before you can mark as completed",
+      "paymentConfirmed": "Payment confirmed",
+      "markCompleted": "Mark as Completed",
+      "waitingRequester": "Waiting for the requester to confirm completion",
+      "reason": "Reason"
     }
   },
   "createTask": {
@@ -685,7 +741,7 @@
       "subtitle": "Choose a fixed price or let fixers quote",
       "fixedPrice": "Fixed Price",
       "quoteRequired": "Quote Required",
-      "budgetLabel": "Budget (â‚ª)",
+      "budgetLabel": "Budget (₪)",
       "enterBudget": "Enter your budget",
       "quoteNote": "Fixers will propose their own price when bidding on your task.",
       "urgency": {
@@ -732,7 +788,7 @@
       "budget": {
         "fixed": "Fixed Price",
         "quote": "Quote Required",
-        "amount": "Amount (â‚ª)"
+        "amount": "Amount (₪)"
       },
       "location": {
         "generalArea": "General Area",
@@ -874,7 +930,25 @@
     "portfolioTitle": "Portfolio ({{count}})",
     "reviewsTitle": "Reviews ({{count}})",
     "review": "review",
-    "reviews": "reviews"
+    "reviews": "reviews",
+    "respondsIn": "Responds in ~{{value}} {{unit}}",
+    "report": {
+      "title": "Report Review",
+      "prompt": "Why are you reporting this review?",
+      "webPrompt": "Report reason:\n1. Spam\n2. Offensive\n3. Misleading\n4. Other\n\nEnter number (1-4):",
+      "submitted": "Report submitted",
+      "thankYou": "Thank you",
+      "alreadyReported": "You have already reported this review",
+      "failedSubmit": "Failed to submit report",
+      "reasons": {
+        "SPAM": "Spam",
+        "OFFENSIVE": "Offensive",
+        "MISLEADING": "Misleading",
+        "OTHER": "Other"
+      },
+      "detailsPlaceholder": "Please describe the issue...",
+      "detailsRequired": "Details are required when selecting Other."
+    }
   },
   "landing": {
     "hero": {
@@ -982,7 +1056,7 @@
     },
     "footer": {
       "tagline": "Your neighborhood. Fixed.",
-      "copyright": "Â© 2026 FixIt Â· Tel Aviv, Israel",
+      "copyright": "© 2026 FixIt · Tel Aviv, Israel",
       "footerTagline": "Your neighborhood. Fixed. A task marketplace for homeowners and skilled local pros.",
       "madeby": "Made for neighbors who get things done.",
       "product": "Product",
@@ -1132,6 +1206,27 @@
   "placeholder": {
     "title": "Coming Soon",
     "message": "This feature is under construction."
+  },
+  "timeAgo": {
+    "justNow": "Just now",
+    "minuteAgo": "1 minute ago",
+    "minutesAgo": "{{count}} minutes ago",
+    "hourAgo": "1 hour ago",
+    "hoursAgo": "{{count}} hours ago",
+    "yesterday": "Yesterday",
+    "daysAgo": "{{count}} days ago",
+    "weekAgo": "1 week ago",
+    "weeksAgo": "{{count}} weeks ago"
+  },
+  "discoveryCard": {
+    "noPrice": "No price specified",
+    "bidSent": "Bid sent",
+    "viewBid": "View bid",
+    "details": "Details",
+    "selectedJob": "Selected job",
+    "bidAlreadySent": "Bid already sent",
+    "viewYourBid": "View Your Bid",
+    "viewDetails": "View Details"
   },
   "status": {
     "open": "Open",

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -488,7 +488,18 @@
     },
     "yesterday": "אתמול",
     "unread": "לא נקרא",
-    "noMessages": "אין הודעות עדיין"
+    "noMessages": "אין הודעות עדיין",
+    "active": "פעיל",
+    "past": "שיחות קודמות"
+  },
+  "pastConversations": {
+    "empty": {
+      "title": "אין שיחות קודמות",
+      "message": "שיחות ממשימות שהושלמו או בוטלו יופיעו כאן."
+    },
+    "deleteConfirmTitle": "למחוק שיחה?",
+    "deleteConfirmMessage": "למחוק את השיחה של \"{{title}}\"? פעולה זו מסירה את כל ההודעות לצמיתות.",
+    "deleteFailed": "מחיקת השיחה נכשלה."
   },
   "notifications": {
     "loading": "טוען התראות...",
@@ -552,6 +563,32 @@
         "title": "לדחות את ההצעה הזו?",
         "confirm": "דחה הצעה"
       }
+    },
+    "decline": {
+      "title": "דחיית הצעה",
+      "description": "בחר סיבה כדי שהמתקן יוכל לשפר הצעות עתידיות.",
+      "reasons": {
+        "PRICE_TOO_HIGH": "מחיר גבוה מדי",
+        "BAD_TIMING": "תזמון לא מתאים",
+        "CHOSE_ANOTHER": "בחרתי מתקן אחר",
+        "NOT_QUALIFIED": "לא מתאים",
+        "OTHER": "אחר"
+      },
+      "note": "הערה (אופציונלי)",
+      "notePlaceholder": "הוסף פרטים אם תרצה...",
+      "confirm": "אשר דחייה"
+    },
+    "completion": {
+      "photos": "תמונות השלמה",
+      "payStep": "שלב 1: שלם למתקן",
+      "paymentConfirmed": "התשלום אושר",
+      "waitingFixer": "ממתין לאישור השלמה מהמתקן",
+      "canceled": "בוטל",
+      "canceledMessage": "משימה זו בוטלה. פתח אותה מחדש כדי לפרסם אותה שוב בפיד הגילוי.",
+      "reopenTask": "פתח מחדש",
+      "reopenError": "פתיחת המשימה מחדש נכשלה.",
+      "reopenConfirmTitle": "לפתוח מחדש?",
+      "reopenConfirmMessage": "זה יפרסם את המשימה מחדש בפיד הגילוי."
     },
     "fixerReviews": {
       "title": "ביקורות על המתקן",
@@ -635,6 +672,25 @@
       "errorPitch": "כתוב תיאור קצר למזמין.",
       "maxBids": "המשימה הגיעה למספר המקסימלי של הצעות (15).",
       "errorSubmit": "הגשת ההצעה נכשלה. נסה שוב."
+    },
+    "rejectionReasons": {
+      "PRICE_TOO_HIGH": "מחיר גבוה מדי",
+      "BAD_TIMING": "תזמון לא מתאים",
+      "CHOSE_ANOTHER": "נבחר מתקן אחר",
+      "NOT_QUALIFIED": "לא מתאים",
+      "OTHER": "אחר"
+    },
+    "completion": {
+      "photos": "תמונות השלמה",
+      "addPhotos": "הוסף תמונות השלמה",
+      "uploaded": "הועלה",
+      "uploadedMessage": "תמונות ההשלמה נוספו ונשמרו בתיק העבודות שלך.",
+      "uploadError": "העלאת תמונות ההשלמה נכשלה.",
+      "waitingPayment": "ממתין לאישור תשלום מהמזמין לפני שתוכל לסמן כהושלם",
+      "paymentConfirmed": "התשלום אושר",
+      "markCompleted": "סמן כהושלם",
+      "waitingRequester": "ממתין לאישור השלמה מהמזמין",
+      "reason": "סיבה"
     },
     "actions": {
       "submitBid": "הגש הצעה",
@@ -874,7 +930,25 @@
     "portfolioTitle": "תיק עבודות ({{count}})",
     "reviewsTitle": "ביקורות ({{count}})",
     "review": "ביקורת",
-    "reviews": "ביקורות"
+    "reviews": "ביקורות",
+    "respondsIn": "מגיב תוך ~{{value}} {{unit}}",
+    "report": {
+      "title": "דיווח על ביקורת",
+      "prompt": "למה את/ה מדווח/ת על ביקורת זו?",
+      "webPrompt": "סיבת הדיווח:\n1. ספאם\n2. פוגעני\n3. מטעה\n4. אחר\n\nהכנס מספר (1-4):",
+      "submitted": "הדיווח נשלח",
+      "thankYou": "תודה",
+      "alreadyReported": "כבר דיווחת על ביקורת זו",
+      "failedSubmit": "שליחת הדיווח נכשלה",
+      "reasons": {
+        "SPAM": "ספאם",
+        "OFFENSIVE": "פוגעני",
+        "MISLEADING": "מטעה",
+        "OTHER": "אחר"
+      },
+      "detailsPlaceholder": "אנא תאר/י את הבעיה...",
+      "detailsRequired": "נדרש פירוט כשבוחרים אחר."
+    }
   },
   "landing": {
     "hero": {
@@ -1132,6 +1206,27 @@
   "placeholder": {
     "title": "בקרוב",
     "message": "תכונה זו נמצאת בפיתוח."
+  },
+  "timeAgo": {
+    "justNow": "עכשיו",
+    "minuteAgo": "לפני דקה",
+    "minutesAgo": "לפני {{count}} דקות",
+    "hourAgo": "לפני שעה",
+    "hoursAgo": "לפני {{count}} שעות",
+    "yesterday": "אתמול",
+    "daysAgo": "לפני {{count}} ימים",
+    "weekAgo": "לפני שבוע",
+    "weeksAgo": "לפני {{count}} שבועות"
+  },
+  "discoveryCard": {
+    "noPrice": "ללא מחיר מצוין",
+    "bidSent": "הצעה נשלחה",
+    "viewBid": "ראה הצעה",
+    "details": "פרטים",
+    "selectedJob": "עבודה נבחרת",
+    "bidAlreadySent": "הצעה כבר נשלחה",
+    "viewYourBid": "ראה את ההצעה שלך",
+    "viewDetails": "ראה פרטים"
   },
   "status": {
     "open": "פתוח",

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -23,6 +23,7 @@ import PublicProfileScreen from '../screens/PublicProfileScreen';
 import NotificationCenterScreen from '../screens/NotificationCenterScreen';
 import BecomeFixerScreen from '../screens/BecomeFixerScreen';
 import ChatScreen from '../screens/ChatScreen';
+import PastConversationsScreen from '../screens/PastConversationsScreen';
 import AppLogo from '../components/AppLogo';
 import HamburgerMenu from '../components/HamburgerMenu';
 import { useNotificationContext, FIXER_NOTIF_TYPES, REQUESTER_NOTIF_TYPES } from '../context/NotificationContext';
@@ -244,20 +245,22 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
         </View>
 
         <View style={styles.desktopActions}>
-          {/* Shared: lang switcher, notifications, settings */}
-          <View style={styles.langSwitcher}>
-            {(['en', 'he'] as const).map((lang) => (
-              <Pressable
-                key={lang}
-                onPress={() => void changeLanguage(lang)}
-                style={[styles.langChip, language === lang && styles.langChipActive]}
-              >
-                <Text style={[styles.langChipText, language === lang && styles.langChipTextActive]}>
-                  {lang === 'en' ? 'EN' : 'עב'}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
+          {/* Shared: globe lang toggle, notifications, settings */}
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={language === 'en' ? 'Switch to Hebrew' : 'Switch to English'}
+            style={({ pressed }) => [
+              styles.desktopIconBtn,
+              mode === 'fixer' && styles.desktopIconBtnFixer,
+              pressed && styles.desktopActionPressed,
+            ]}
+            onPress={() => void changeLanguage(language === 'en' ? 'he' : 'en')}
+          >
+            <MaterialCommunityIcons name="web" size={20} color={brandColors.textSecondary} />
+            <Text style={{ fontSize: 10, fontWeight: '700', color: brandColors.textSecondary, marginLeft: 2 }}>
+              {language === 'en' ? 'EN' : 'עב'}
+            </Text>
+          </Pressable>
 
           <Pressable
             accessibilityRole="button"
@@ -446,21 +449,20 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
           </Pressable>
         </View>
 
-        {/* lang + bell — right */}
+        {/* globe + bell — right */}
         <View style={styles.mobileRightActions}>
-          <View style={styles.langSwitcher}>
-            {(['en', 'he'] as const).map((lang) => (
-              <Pressable
-                key={lang}
-                onPress={() => void changeLanguage(lang)}
-                style={[styles.langChipDark, language === lang && styles.langChipDarkActive]}
-              >
-                <Text style={[styles.langChipText, language === lang && styles.langChipTextActive]}>
-                  {lang === 'en' ? 'EN' : 'עב'}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={language === 'en' ? 'Switch to Hebrew' : 'Switch to English'}
+            style={styles.iconBtn}
+            hitSlop={8}
+            onPress={() => void changeLanguage(language === 'en' ? 'he' : 'en')}
+          >
+            <MaterialCommunityIcons name="web" size={22} color={brandColors.textOnDark} />
+            <View style={styles.globeLangBadge}>
+              <Text style={styles.globeLangText}>{language === 'en' ? 'EN' : 'עב'}</Text>
+            </View>
+          </Pressable>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel={
@@ -546,6 +548,7 @@ export default function AppNavigator() {
       <Stack.Screen name="PublicProfile" component={PublicProfileScreen} options={{ title: 'Profile' }} />
       <Stack.Screen name="NotificationCenter" component={NotificationCenterScreen} options={{ title: 'Notifications' }} />
       <Stack.Screen name="BecomeFixerOnboarding" component={BecomeFixerScreen} options={{ title: 'Become a Fixer', headerShown: false }} />
+      <Stack.Screen name="PastConversations" component={PastConversationsScreen} options={{ title: 'Past Conversations' }} />
       <Stack.Screen name="Chat" component={ChatScreen} options={{ title: 'Chat' }} />
     </Stack.Navigator>
   );
@@ -802,6 +805,22 @@ const styles = StyleSheet.create({
   },
   langChipTextActive: {
     color: brandColors.white,
+  },
+  globeLangBadge: {
+    position: 'absolute',
+    bottom: -2,
+    right: -4,
+    backgroundColor: brandColors.primary,
+    borderRadius: 6,
+    paddingHorizontal: 3,
+    minWidth: 16,
+    alignItems: 'center',
+  },
+  globeLangText: {
+    fontSize: 8,
+    fontWeight: '800' as const,
+    color: brandColors.white,
+    lineHeight: 12,
   },
 
   // Notification badge

--- a/frontend/src/navigation/landingIntent.ts
+++ b/frontend/src/navigation/landingIntent.ts
@@ -52,6 +52,7 @@ export type RootStackParamList = {
   PublicProfile: { userId?: string } | undefined;
   NotificationCenter: undefined;
   BecomeFixerOnboarding: undefined;
+  PastConversations: { mode?: string } | undefined;
   Chat: {
     taskId: string;
     myDbId?: string;

--- a/frontend/src/screens/AdminScreen.tsx
+++ b/frontend/src/screens/AdminScreen.tsx
@@ -305,15 +305,22 @@ export default function AdminScreen() {
                 Reports ({item.reports.length}):
               </Text>
               {item.reports.map((report) => (
-                <View key={report.id} style={styles.reportRow}>
-                  <View style={[styles.reasonBadge, { backgroundColor: brandColors.dangerSoft }]}>
-                    <Text style={[typography.caption, { color: brandColors.danger }]}>
-                      {REASON_LABELS[report.reason] ?? report.reason}
+                <View key={report.id} style={{ marginBottom: spacing.xs }}>
+                  <View style={styles.reportRow}>
+                    <View style={[styles.reasonBadge, { backgroundColor: brandColors.dangerSoft }]}>
+                      <Text style={[typography.caption, { color: brandColors.danger }]}>
+                        {REASON_LABELS[report.reason] ?? report.reason}
+                      </Text>
+                    </View>
+                    <Text style={[typography.bodySm, { color: brandColors.textMuted, flex: 1 }]}>
+                      by {report.reporter.full_name}
                     </Text>
                   </View>
-                  <Text style={[typography.bodySm, { color: brandColors.textMuted, flex: 1 }]}>
-                    by {report.reporter.full_name}
-                  </Text>
+                  {report.details ? (
+                    <Text style={[typography.bodySm, { color: brandColors.textSecondary, marginLeft: spacing.sm, marginTop: 2 }]}>
+                      &ldquo;{report.details}&rdquo;
+                    </Text>
+                  ) : null}
                 </View>
               ))}
             </View>

--- a/frontend/src/screens/ChatScreen.tsx
+++ b/frontend/src/screens/ChatScreen.tsx
@@ -69,7 +69,7 @@ export default function ChatScreen({ route }: { route: any }) {
   const socketRef = useRef<Awaited<ReturnType<typeof getSocket>> | null>(null);
   const flatListRef = useRef<FlatList<Message>>(null);
 
-  const isReadOnly = taskStatus === 'COMPLETED';
+  const isReadOnly = taskStatus === 'COMPLETED' || taskStatus === 'CANCELED';
 
   // Set header dynamically — title tap opens task, avatar tap navigates to public profile
   useEffect(() => {

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -521,52 +521,46 @@ export default function FixerProfileScreen() {
               </View>
             </FCard>
 
-            {/* Verification section */}
-            <FCard style={styles.section} shadow="sm">
-              <View style={styles.sectionHeader}>
-                <View style={styles.sectionIcon}>
-                  <MaterialCommunityIcons name="shield-check-outline" size={18} color={brandColors.primary} />
+            {/* Verification section — hidden once approved */}
+            {profile?.verification_status !== 'APPROVED' && (
+              <FCard style={styles.section} shadow="sm">
+                <View style={styles.sectionHeader}>
+                  <View style={styles.sectionIcon}>
+                    <MaterialCommunityIcons name="shield-check-outline" size={18} color={brandColors.primary} />
+                  </View>
+                  <View>
+                    <Text style={styles.sectionKicker}>{t('fixerProfile.verification.kicker')}</Text>
+                    <Text style={[typography.h3, { color: brandColors.textPrimary }]}>{t('fixerProfile.verification.title')}</Text>
+                  </View>
                 </View>
-                <View>
-                  <Text style={styles.sectionKicker}>{t('fixerProfile.verification.kicker')}</Text>
-                  <Text style={[typography.h3, { color: brandColors.textPrimary }]}>{t('fixerProfile.verification.title')}</Text>
-                </View>
-              </View>
 
-              {profile?.verification_status === 'APPROVED' ? (
-                <View style={styles.verificationBanner}>
-                  <MaterialCommunityIcons name="check-decagram" size={20} color={brandColors.primary} />
-                  <Text style={[typography.bodyMedium, { color: brandColors.primary }]}>{t('fixerProfile.verification.verified')}</Text>
-                  <Text style={[typography.caption, { color: brandColors.textMuted, flex: 1 }]}>
-                    {t('fixerProfile.verification.verifiedMsg')}
-                  </Text>
-                </View>
-              ) : profile?.verification_status === 'PENDING' ? (
-                <View style={styles.verificationBanner}>
-                  <MaterialCommunityIcons name="clock-outline" size={20} color={brandColors.warning} />
-                  <Text style={[typography.bodyMedium, { color: brandColors.warning }]}>{t('fixerProfile.verification.pending')}</Text>
-                  <Text style={[typography.caption, { color: brandColors.textMuted, flex: 1 }]}>
-                    {t('fixerProfile.verification.pendingMsg')}
-                  </Text>
-                </View>
-              ) : (
-                <>
-                  <Text style={[typography.body, { color: brandColors.textMuted, marginBottom: spacing.md }]}>
-                    {t('fixerProfile.verification.uploadMsg')}
-                  </Text>
-                  <FButton
-                    variant="secondary"
-                    icon="camera-outline"
-                    onPress={() => void handleSubmitVerification()}
-                    loading={uploadingVerification}
-                    disabled={uploadingVerification}
-                    fullWidth
-                  >
-                    {t('fixerProfile.verification.uploadBtn')}
-                  </FButton>
-                </>
-              )}
-            </FCard>
+                {profile?.verification_status === 'PENDING' ? (
+                  <View style={styles.verificationBanner}>
+                    <MaterialCommunityIcons name="clock-outline" size={20} color={brandColors.warning} />
+                    <Text style={[typography.bodyMedium, { color: brandColors.warning }]}>{t('fixerProfile.verification.pending')}</Text>
+                    <Text style={[typography.caption, { color: brandColors.textMuted, flex: 1 }]}>
+                      {t('fixerProfile.verification.pendingMsg')}
+                    </Text>
+                  </View>
+                ) : (
+                  <>
+                    <Text style={[typography.body, { color: brandColors.textMuted, marginBottom: spacing.md }]}>
+                      {t('fixerProfile.verification.uploadMsg')}
+                    </Text>
+                    <FButton
+                      variant="secondary"
+                      icon="camera-outline"
+                      onPress={() => void handleSubmitVerification()}
+                      loading={uploadingVerification}
+                      disabled={uploadingVerification}
+                      fullWidth
+                    >
+                      {t('fixerProfile.verification.uploadBtn')}
+                    </FButton>
+                  </>
+                )}
+              </FCard>
+            )}
 
             <FCard style={styles.section} shadow="sm">
               <View style={styles.portfolioHeader}>

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   Alert,
   Image,
@@ -10,6 +10,7 @@ import {
   View,
   useWindowDimensions,
 } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Avatar, Divider, Switch, Text } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
@@ -83,6 +84,14 @@ export default function FixerProfileScreen() {
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushLoading, setPushLoading] = useState(false);
   const [uploadingVerification, setUploadingVerification] = useState(false);
+
+  useEffect(() => {
+    if (Platform.OS === 'web') {
+      AsyncStorage.getItem('pushEnabled').then((v) => setPushEnabled(v === 'true'));
+    } else {
+      Notifications.getPermissionsAsync().then(({ status }) => setPushEnabled(status === 'granted'));
+    }
+  }, []);
 
   const fetchProfile = React.useCallback(async () => {
     try {
@@ -492,8 +501,8 @@ export default function FixerProfileScreen() {
                   value={pushEnabled}
                   onValueChange={async (value) => {
                     if (Platform.OS === 'web') {
-                      // On web, toggle locally (push tokens only work on mobile)
                       setPushEnabled(value);
+                      void AsyncStorage.setItem('pushEnabled', String(value));
                       return;
                     }
                     if (!value) { setPushEnabled(false); return; }

--- a/frontend/src/screens/MyBidsScreen.tsx
+++ b/frontend/src/screens/MyBidsScreen.tsx
@@ -160,7 +160,7 @@ function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccep
               <View style={styles.rejectionHeader}>
                 <MaterialCommunityIcons name="information-outline" size={14} color={brandColors.danger} />
                 <Text style={[typography.caption, { color: brandColors.danger, fontWeight: '700' }]}>
-                  {REJECTION_LABELS[bid.rejection_reason] ?? 'Rejected'}
+                  {t(`taskDetailsFixer.rejectionReasons.${bid.rejection_reason}`, { defaultValue: bid.rejection_reason })}
                 </Text>
               </View>
               {bid.rejection_note ? (
@@ -241,14 +241,7 @@ function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccep
   );
 }
 
-const REJECTION_LABELS: Record<string, string> = {
-  PRICE_TOO_HIGH: 'Price too high',
-  BAD_TIMING: 'Bad timing',
-  CHOSE_ANOTHER: 'Another fixer was chosen',
-  NOT_QUALIFIED: 'Not the right fit',
-  TASK_CANCELED: 'Task was canceled',
-  OTHER: 'Other reason',
-};
+// Rejection labels now come from i18n: taskDetailsFixer.rejectionReasons.*
 
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 

--- a/frontend/src/screens/PastConversationsScreen.tsx
+++ b/frontend/src/screens/PastConversationsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { FlatList, Pressable, StyleSheet, View } from 'react-native';
+import { Alert, FlatList, Platform, Pressable, StyleSheet, View } from 'react-native';
 import { Avatar, Text } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
@@ -7,34 +7,10 @@ import { useTranslation } from 'react-i18next';
 import api from '../api/axiosInstance';
 import LoadingScreen from '../components/LoadingScreen';
 import EmptyState from '../components/EmptyState';
+import { Conversation, formatConversationTime } from './ConversationListScreen';
 import { brandColors, radii, spacing, typography } from '../theme';
 
-interface OtherParty {
-  id: string;
-  full_name: string;
-  avatar_url: string | null;
-}
-
-export interface Conversation {
-  taskId: string;
-  taskTitle: string;
-  taskStatus?: string;
-  otherParty: OtherParty | null;
-  lastMessage: { content: string; timestamp: string } | null;
-  unreadCount: number;
-}
-
-export function formatConversationTime(dateStr: string, t: (key: string) => string): string {
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
-  if (diffDays === 0) return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
-  if (diffDays === 1) return t('conversations.yesterday');
-  if (diffDays < 7) return date.toLocaleDateString(undefined, { weekday: 'short' });
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-}
-
-export default function ConversationListScreen({ route }: { route?: { params?: { mode?: string } } }) {
+export default function PastConversationsScreen({ route }: { route?: { params?: { mode?: string } } }) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const navigation = useNavigation<any>();
   const { t } = useTranslation();
@@ -46,7 +22,10 @@ export default function ConversationListScreen({ route }: { route?: { params?: {
     try {
       const params = mode ? { mode } : {};
       const res = await api.get('/api/conversations', { params });
-      setConversations(res.data.conversations ?? []);
+      const all: Conversation[] = res.data.conversations ?? [];
+      setConversations(
+        all.filter((c) => c.taskStatus === 'COMPLETED' || c.taskStatus === 'CANCELED'),
+      );
     } catch {
       // non-fatal
     } finally {
@@ -54,45 +33,58 @@ export default function ConversationListScreen({ route }: { route?: { params?: {
     }
   }, [mode]);
 
-  useFocusEffect(useCallback(() => {
-    setLoading(true);
-    void load();
-  }, [load]));
+  useFocusEffect(
+    useCallback(() => {
+      setLoading(true);
+      void load();
+    }, [load]),
+  );
+
+  const deleteConversation = (taskId: string, taskTitle: string) => {
+    const doDelete = async () => {
+      try {
+        await api.delete(`/api/tasks/${taskId}/messages`);
+        setConversations((prev) => prev.filter((c) => c.taskId !== taskId));
+      } catch {
+        if (Platform.OS === 'web') {
+          window.alert(t('pastConversations.deleteFailed'));
+        } else {
+          Alert.alert(t('common.error'), t('pastConversations.deleteFailed'));
+        }
+      }
+    };
+
+    if (Platform.OS === 'web') {
+      if (confirm(t('pastConversations.deleteConfirmMessage', { title: taskTitle }))) {
+        void doDelete();
+      }
+    } else {
+      Alert.alert(
+        t('pastConversations.deleteConfirmTitle'),
+        t('pastConversations.deleteConfirmMessage', { title: taskTitle }),
+        [
+          { text: t('common.cancel'), style: 'cancel' },
+          { text: t('common.delete'), style: 'destructive', onPress: () => void doDelete() },
+        ],
+      );
+    }
+  };
 
   if (loading) return <LoadingScreen label={t('conversations.loading')} />;
 
-  const activeConversations = conversations.filter(
-    (c) => c.taskStatus !== 'COMPLETED' && c.taskStatus !== 'CANCELED',
-  );
-  const pastCount = conversations.filter(
-    (c) => c.taskStatus === 'COMPLETED' || c.taskStatus === 'CANCELED',
-  ).length;
-
   return (
     <FlatList
-      data={activeConversations}
+      data={conversations}
       keyExtractor={(item) => item.taskId}
-      contentContainerStyle={activeConversations.length === 0 && pastCount === 0 ? styles.emptyContainer : styles.listContent}
+      contentContainerStyle={conversations.length === 0 ? styles.emptyContainer : styles.listContent}
       ItemSeparatorComponent={() => <View style={styles.separator} />}
       ListEmptyComponent={
         <EmptyState
-          icon="chat-outline"
-          title={t('conversations.empty.title')}
-          message={t('conversations.empty.message')}
+          icon="archive-outline"
+          title={t('pastConversations.empty.title')}
+          message={t('pastConversations.empty.message')}
         />
       }
-      ListFooterComponent={pastCount > 0 ? (
-        <Pressable
-          style={styles.pastButton}
-          onPress={() => navigation.navigate('PastConversations', { mode })}
-        >
-          <MaterialCommunityIcons name="archive-outline" size={20} color={brandColors.textMuted} />
-          <Text style={[typography.label, { color: brandColors.textMuted, flex: 1 }]}>
-            {t('conversations.past')} ({pastCount})
-          </Text>
-          <MaterialCommunityIcons name="chevron-right" size={20} color={brandColors.outlineLight} />
-        </Pressable>
-      ) : null}
       renderItem={({ item }) => {
         const other = item.otherParty;
         return (
@@ -140,25 +132,24 @@ export default function ConversationListScreen({ route }: { route?: { params?: {
               <Text style={[typography.caption, { color: brandColors.textMuted }]} numberOfLines={1}>
                 {item.taskTitle}
               </Text>
-              <View style={styles.bottomRow}>
-                <Text
-                  style={[
-                    typography.bodySm,
-                    { color: item.unreadCount > 0 ? brandColors.textPrimary : brandColors.textMuted, flex: 1 },
-                  ]}
-                  numberOfLines={1}
-                >
-                  {item.lastMessage?.content || t('conversations.noMessages')}
-                </Text>
-                {item.unreadCount > 0 && (
-                  <View style={styles.badge}>
-                    <Text style={styles.badgeText}>{item.unreadCount > 99 ? '99+' : item.unreadCount}</Text>
-                  </View>
-                )}
-              </View>
+              <Text
+                style={[typography.bodySm, { color: brandColors.textMuted, flex: 1 }]}
+                numberOfLines={1}
+              >
+                {item.lastMessage?.content || t('conversations.noMessages')}
+              </Text>
             </View>
 
-            <MaterialCommunityIcons name="chevron-right" size={20} color={brandColors.outlineLight} />
+            <Pressable
+              style={styles.deleteBtn}
+              hitSlop={8}
+              onPress={(e) => {
+                e.stopPropagation();
+                deleteConversation(item.taskId, item.taskTitle);
+              }}
+            >
+              <MaterialCommunityIcons name="trash-can-outline" size={20} color={brandColors.danger} />
+            </Pressable>
           </Pressable>
         );
       }}
@@ -203,34 +194,11 @@ const styles = StyleSheet.create({
     color: brandColors.textPrimary,
     marginRight: spacing.sm,
   },
-  bottomRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm,
-  },
-  badge: {
-    backgroundColor: brandColors.primary,
-    borderRadius: radii.pill,
-    minWidth: 20,
-    height: 20,
+  deleteBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: radii.md,
     alignItems: 'center',
     justifyContent: 'center',
-    paddingHorizontal: 5,
-  },
-  badgeText: {
-    color: brandColors.white,
-    fontSize: 11,
-    fontWeight: '700',
-    lineHeight: 14,
-  },
-  pastButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: spacing.sm,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.lg,
-    borderTopWidth: 1,
-    borderTopColor: brandColors.outlineLight,
-    marginTop: spacing.sm,
   },
 });

--- a/frontend/src/screens/PublicProfileScreen.tsx
+++ b/frontend/src/screens/PublicProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Alert,
   FlatList,
@@ -8,7 +8,7 @@ import {
   StyleSheet,
   View,
 } from 'react-native';
-import { Avatar, Divider, Text } from 'react-native-paper';
+import { Avatar, Divider, Modal, Portal, Text, TextInput } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useFocusEffect } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
@@ -57,78 +57,51 @@ function StarRating({ rating, size = 16 }: { rating: number; size?: number }) {
   );
 }
 
-function formatResponseTime(minutes: number): string {
-  if (minutes < 60) return `Responds in ~${Math.round(minutes)} min`;
-  if (minutes < 1440) return `Responds in ~${Math.round(minutes / 60)} hr`;
-  return `Responds in ~${Math.round(minutes / 1440)} days`;
-}
-
 const REPORT_REASONS = ['SPAM', 'OFFENSIVE', 'MISLEADING', 'OTHER'] as const;
-
-const REPORT_REASON_LABELS: Record<string, string> = {
-  SPAM: 'Spam / ספאם',
-  OFFENSIVE: 'Offensive / פוגעני',
-  MISLEADING: 'Misleading / מטעה',
-  OTHER: 'Other / אחר',
-};
 
 function ReviewCard({ review, currentUserId }: { review: Review; currentUserId: string | null }) {
   const canReport = currentUserId === review.reviewee_id;
   const { t } = useTranslation();
+  const [reportModalVisible, setReportModalVisible] = useState(false);
+  const [selectedReason, setSelectedReason] = useState<typeof REPORT_REASONS[number] | null>(null);
+  const [otherDetails, setOtherDetails] = useState('');
+  const [submitting, setSubmitting] = useState(false);
   const date = new Date(review.created_at).toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
   });
 
-  const handleReport = () => {
-    const buttons = REPORT_REASONS.map((reason) => ({
-      text: REPORT_REASON_LABELS[reason],
-      onPress: async () => {
-        try {
-          await reportReview(review.id, reason);
-          const msg = 'Report submitted / הדיווח נשלח';
-          if (Platform.OS === 'web') {
-            // eslint-disable-next-line no-alert
-            window.alert(msg);
-          } else {
-            Alert.alert('Thank you', msg);
-          }
-        } catch (err: unknown) {
-          const axiosErr = err as {
-            response?: { data?: { error?: { message?: string } }; status?: number };
-          };
-          const message =
-            axiosErr.response?.status === 409
-              ? 'You have already reported this review / כבר דיווחת על ביקורת זו'
-              : axiosErr.response?.data?.error?.message ?? 'Failed to submit report';
-          if (Platform.OS === 'web') {
-            // eslint-disable-next-line no-alert
-            window.alert(message);
-          } else {
-            Alert.alert('Error', message);
-          }
-        }
-      },
-    }));
-    buttons.push({ text: 'Cancel', onPress: async () => {} });
-
-    if (Platform.OS === 'web') {
-      // On web, Alert.alert doesn't support multiple buttons well — use a simple prompt
-      const choice = // eslint-disable-next-line no-alert
-        window.prompt(
-          'Report reason / סיבת הדיווח:\n1. Spam\n2. Offensive\n3. Misleading\n4. Other\n\nEnter number (1-4):',
-        );
-      const idx = parseInt(choice ?? '', 10) - 1;
-      if (idx >= 0 && idx < REPORT_REASONS.length) {
-        buttons[idx].onPress();
+  const submitReport = async () => {
+    if (!selectedReason) return;
+    setSubmitting(true);
+    try {
+      await reportReview(review.id, selectedReason, otherDetails.trim() || undefined);
+      setReportModalVisible(false);
+      setSelectedReason(null);
+      setOtherDetails('');
+      if (Platform.OS === 'web') {
+        // eslint-disable-next-line no-alert
+        window.alert(t('publicProfile.report.submitted'));
+      } else {
+        Alert.alert(t('publicProfile.report.thankYou'), t('publicProfile.report.submitted'));
       }
-    } else {
-      Alert.alert(
-        'Report Review / דיווח על ביקורת',
-        'Why are you reporting this review?\nלמה את/ה מדווח/ת על ביקורת זו?',
-        buttons,
-      );
+    } catch (err: unknown) {
+      const axiosErr = err as {
+        response?: { data?: { error?: { message?: string } }; status?: number };
+      };
+      const message =
+        axiosErr.response?.status === 409
+          ? t('publicProfile.report.alreadyReported')
+          : axiosErr.response?.data?.error?.message ?? t('publicProfile.report.failedSubmit');
+      if (Platform.OS === 'web') {
+        // eslint-disable-next-line no-alert
+        window.alert(message);
+      } else {
+        Alert.alert(t('common.error'), message);
+      }
+    } finally {
+      setSubmitting(false);
     }
   };
 
@@ -155,7 +128,7 @@ function ReviewCard({ review, currentUserId }: { review: Review; currentUserId: 
         <View style={styles.reviewHeaderRight}>
           <Text style={[typography.caption, { color: brandColors.textMuted }]}>{date}</Text>
           {canReport && (
-            <Pressable onPress={handleReport} hitSlop={8}>
+            <Pressable onPress={() => setReportModalVisible(true)} hitSlop={8}>
               <MaterialCommunityIcons name="flag-outline" size={16} color={brandColors.textMuted} />
             </Pressable>
           )}
@@ -169,6 +142,69 @@ function ReviewCard({ review, currentUserId }: { review: Review; currentUserId: 
           {review.comment}
         </Text>
       ) : null}
+
+      {/* Report Modal */}
+      <Portal>
+        <Modal
+          visible={reportModalVisible}
+          onDismiss={() => { setReportModalVisible(false); setSelectedReason(null); setOtherDetails(''); }}
+          contentContainerStyle={styles.reportModal}
+        >
+          <Text style={[typography.h3, { color: brandColors.textPrimary, marginBottom: spacing.xs }]}>
+            {t('publicProfile.report.title')}
+          </Text>
+          <Text style={[typography.bodySm, { color: brandColors.textMuted, marginBottom: spacing.md }]}>
+            {t('publicProfile.report.prompt')}
+          </Text>
+          {REPORT_REASONS.map((reason) => (
+            <Pressable
+              key={reason}
+              style={[styles.reportOption, selectedReason === reason && styles.reportOptionSelected]}
+              onPress={() => setSelectedReason(reason)}
+            >
+              <MaterialCommunityIcons
+                name={selectedReason === reason ? 'radiobox-marked' : 'radiobox-blank'}
+                size={20}
+                color={selectedReason === reason ? brandColors.primary : brandColors.textMuted}
+              />
+              <Text style={[typography.body, { color: selectedReason === reason ? brandColors.primary : brandColors.textPrimary }]}>
+                {t(`publicProfile.report.reasons.${reason}`)}
+              </Text>
+            </Pressable>
+          ))}
+          <TextInput
+            mode="outlined"
+            placeholder={t('publicProfile.report.detailsPlaceholder')}
+            value={otherDetails}
+            onChangeText={setOtherDetails}
+            multiline
+            numberOfLines={3}
+            style={{ marginTop: spacing.sm, backgroundColor: brandColors.surface }}
+          />
+          {selectedReason === 'OTHER' && !otherDetails.trim() && (
+            <Text style={[typography.caption, { color: brandColors.danger, marginTop: spacing.xs }]}>
+              {t('publicProfile.report.detailsRequired')}
+            </Text>
+          )}
+          <View style={{ flexDirection: 'row', gap: spacing.sm, marginTop: spacing.md }}>
+            <Pressable
+              style={[styles.reportBtn, styles.reportBtnCancel]}
+              onPress={() => { setReportModalVisible(false); setSelectedReason(null); setOtherDetails(''); }}
+            >
+              <Text style={[typography.label, { color: brandColors.textMuted }]}>{t('common.cancel')}</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.reportBtn, styles.reportBtnSubmit, (!selectedReason || (selectedReason === 'OTHER' && !otherDetails.trim())) && { opacity: 0.5 }]}
+              onPress={() => void submitReport()}
+              disabled={!selectedReason || (selectedReason === 'OTHER' && !otherDetails.trim()) || submitting}
+            >
+              <Text style={[typography.label, { color: brandColors.white }]}>
+                {submitting ? t('common.loading') : t('common.submit')}
+              </Text>
+            </Pressable>
+          </View>
+        </Modal>
+      </Portal>
     </FCard>
   );
 }
@@ -209,6 +245,12 @@ export default function PublicProfileScreen({ route }: { route: any }) {
   if (profileLoading || reviewsLoading) {
     return <LoadingScreen label={t('publicProfile.loading')} />;
   }
+
+  const formatResponseTime = (minutes: number): string => {
+    if (minutes < 60) return t('publicProfile.respondsIn', { value: Math.round(minutes), unit: 'min' });
+    if (minutes < 1440) return t('publicProfile.respondsIn', { value: Math.round(minutes / 60), unit: 'hr' });
+    return t('publicProfile.respondsIn', { value: Math.round(minutes / 1440), unit: 'days' });
+  };
 
   const avgRating = profile?.average_rating_as_fixer;
   const memberSince = profile?.created_at
@@ -441,5 +483,34 @@ const styles = StyleSheet.create({
   reviewHeaderRight: {
     alignItems: 'flex-end',
     gap: spacing.xs,
+  },
+  reportModal: {
+    backgroundColor: brandColors.surface,
+    margin: spacing.lg,
+    padding: spacing.lg,
+    borderRadius: radii.lg,
+  },
+  reportOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radii.md,
+  },
+  reportOptionSelected: {
+    backgroundColor: brandColors.primaryMuted + '20',
+  },
+  reportBtn: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: spacing.sm + 2,
+    borderRadius: radii.md,
+  },
+  reportBtnCancel: {
+    backgroundColor: brandColors.surfaceAlt,
+  },
+  reportBtnSubmit: {
+    backgroundColor: brandColors.primary,
   },
 });

--- a/frontend/src/screens/SettingsScreen.tsx
+++ b/frontend/src/screens/SettingsScreen.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ScrollView, StyleSheet, Alert, View, Pressable, Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Text, Switch, Divider } from 'react-native-paper';
 import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { sendPasswordResetEmail, signOut } from 'firebase/auth';
@@ -25,6 +26,14 @@ export default function SettingsScreen() {
   const verificationLabel = user?.emailVerified ? t('settings.hero.verifiedEmail') : t('settings.hero.emailNotVerified');
   const verificationColor = user?.emailVerified ? brandColors.success : brandColors.warning;
 
+  useEffect(() => {
+    if (Platform.OS === 'web') {
+      AsyncStorage.getItem('pushEnabled').then((v) => setPushEnabled(v === 'true'));
+    } else {
+      Notifications.getPermissionsAsync().then(({ status }) => setPushEnabled(status === 'granted'));
+    }
+  }, []);
+
   const handleChangePassword = async () => {
     if (!user?.email) return;
     try {
@@ -37,8 +46,8 @@ export default function SettingsScreen() {
 
   const handlePushToggle = async (value: boolean) => {
     if (Platform.OS === 'web') {
-      // On web, toggle locally (push tokens only work on mobile)
       setPushEnabled(value);
+      void AsyncStorage.setItem('pushEnabled', String(value));
       return;
     }
     if (!value) {

--- a/frontend/src/screens/TaskDetails.tsx
+++ b/frontend/src/screens/TaskDetails.tsx
@@ -57,6 +57,8 @@ interface Task {
   media_urls: string[];
   completion_photos: string[];
   is_payment_confirmed: boolean;
+  requester_completed: boolean;
+  fixer_completed: boolean;
   created_at: string;
   completed_at: string | null;
   my_review: MyReview | null;
@@ -208,7 +210,7 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
 
   const markCompleted = async () => {
     try {
-      await api.put(`/api/tasks/${taskId}/status`, { status: 'COMPLETED' });
+      await api.put(`/api/tasks/${taskId}/confirm-completion`);
       fetchData();
     } catch {
       Alert.alert(t('common.error'), t('taskDetails.alerts.failedComplete'));
@@ -221,22 +223,22 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
         await api.put(`/api/tasks/${taskId}/reopen`);
         fetchData();
       } catch {
-        Alert.alert('Error', 'Failed to reopen task.');
+        Alert.alert(t('common.error'), t('taskDetails.completion.reopenError'));
       }
     };
 
     if (Platform.OS === 'web') {
       // eslint-disable-next-line no-restricted-globals
-      if (confirm('Reopen this task and re-post it to the discovery feed?')) {
+      if (confirm(t('taskDetails.completion.reopenConfirmMessage'))) {
         doReopen();
       }
     } else {
       Alert.alert(
-        'Reopen Task',
-        'Reopen this task and re-post it to the discovery feed for fixers to bid on?',
+        t('taskDetails.completion.reopenConfirmTitle'),
+        t('taskDetails.completion.reopenConfirmMessage'),
         [
-          { text: 'Cancel' },
-          { text: 'Reopen', onPress: doReopen },
+          { text: t('common.cancel') },
+          { text: t('taskDetails.completion.reopenTask'), onPress: doReopen },
         ],
       );
     }
@@ -564,9 +566,58 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
           </FCard>
 
           <View style={styles.actionButtons}>
-            <FButton variant="primary" icon="check-circle-outline" onPress={markCompleted} fullWidth>
-              {t('taskDetails.actions.markCompleted')}
-            </FButton>
+            {/* Step 1: Pay the fixer */}
+            {!task.is_payment_confirmed && (
+              <FCard style={{ marginBottom: spacing.sm }}>
+                <Text style={[typography.bodyMedium, { color: brandColors.textPrimary, marginBottom: spacing.sm }]}>
+                  {t('taskDetails.completion.payStep')}
+                </Text>
+                {acceptedBid?.fixer?.payment_link ? (
+                  <>
+                    <FButton
+                      variant="primary"
+                      icon="open-in-new"
+                      onPress={() => Linking.openURL(acceptedBid.fixer!.payment_link!)}
+                      fullWidth
+                    >
+                      {t('taskDetails.actions.payFixer')}
+                    </FButton>
+                    <FButton variant="outline" onPress={confirmPayment} fullWidth style={{ marginTop: spacing.sm }}>
+                      {t('taskDetails.actions.confirmPayment')}
+                    </FButton>
+                  </>
+                ) : (
+                  <View style={styles.noPaymentLink}>
+                    <MaterialCommunityIcons name="information-outline" size={20} color={brandColors.textMuted} />
+                    <Text style={[typography.body, { color: brandColors.textMuted, flex: 1 }]}>
+                      {t('taskDetails.payment.noPaymentLink')}
+                    </Text>
+                  </View>
+                )}
+              </FCard>
+            )}
+            {/* Step 2: Mark completed (only after payment) */}
+            {task.is_payment_confirmed && !task.requester_completed && (
+              <FButton variant="primary" icon="check-circle-outline" onPress={markCompleted} fullWidth>
+                {t('taskDetails.actions.markCompleted')}
+              </FButton>
+            )}
+            {task.is_payment_confirmed && task.requester_completed && !task.fixer_completed && (
+              <FCard style={{ marginBottom: spacing.sm }}>
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+                  <MaterialCommunityIcons name="clock-outline" size={20} color={brandColors.warning} />
+                  <Text style={[typography.body, { color: brandColors.textMuted, flex: 1 }]}>
+                    {t('taskDetails.completion.waitingFixer')}
+                  </Text>
+                </View>
+              </FCard>
+            )}
+            {task.is_payment_confirmed && (
+              <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs, marginBottom: spacing.sm }}>
+                <MaterialCommunityIcons name="check-circle" size={16} color={brandColors.success} />
+                <Text style={[typography.caption, { color: brandColors.success }]}>{t('taskDetails.completion.paymentConfirmed')}</Text>
+              </View>
+            )}
             <FButton
               variant="outline"
               icon="chat-outline"
@@ -583,10 +634,12 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
             >
               {t('taskDetails.actions.chatWithFixer')}
             </FButton>
-            <Pressable onPress={cancelTask} style={styles.cancelRow}>
-              <MaterialCommunityIcons name="close-circle-outline" size={16} color={brandColors.danger} />
-              <Text style={[typography.label, { color: brandColors.danger }]}>{t('taskDetails.actions.cancelTask')}</Text>
-            </Pressable>
+            {!task.is_payment_confirmed && (
+              <Pressable onPress={cancelTask} style={styles.cancelRow}>
+                <MaterialCommunityIcons name="close-circle-outline" size={16} color={brandColors.danger} />
+                <Text style={[typography.label, { color: brandColors.danger }]}>{t('taskDetails.actions.cancelTask')}</Text>
+              </Pressable>
+            )}
           </View>
         </View>
       )}
@@ -665,18 +718,12 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
           contentContainerStyle={styles.editModal}
         >
           <Text style={[typography.h2, { color: brandColors.textPrimary, marginBottom: spacing.md }]}>
-            Decline Bid
+            {t('taskDetails.decline.title')}
           </Text>
           <Text style={[typography.bodySm, { color: brandColors.textMuted, marginBottom: spacing.md }]}>
-            Select a reason so the fixer can improve future bids.
+            {t('taskDetails.decline.description')}
           </Text>
-          {([
-            ['PRICE_TOO_HIGH', 'Price too high'],
-            ['BAD_TIMING', 'Bad timing'],
-            ['CHOSE_ANOTHER', 'Chose another fixer'],
-            ['NOT_QUALIFIED', 'Not the right fit'],
-            ['OTHER', 'Other'],
-          ] as const).map(([value, label]) => (
+          {(['PRICE_TOO_HIGH', 'BAD_TIMING', 'CHOSE_ANOTHER', 'NOT_QUALIFIED', 'OTHER'] as const).map((value) => (
             <Pressable
               key={value}
               style={[
@@ -694,18 +741,18 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
                 typography.body,
                 { color: rejectionReason === value ? brandColors.primary : brandColors.textPrimary },
               ]}>
-                {label}
+                {t(`taskDetails.decline.reasons.${value}`)}
               </Text>
             </Pressable>
           ))}
           <FInput
-            label="Note (optional)"
+            label={t('taskDetails.decline.note')}
             value={rejectionNote}
             onChangeText={setRejectionNote}
             multiline
             numberOfLines={2}
             maxLength={500}
-            placeholder="Add details if you'd like..."
+            placeholder={t('taskDetails.decline.notePlaceholder')}
           />
           <FButton
             onPress={confirmDeclineBid}
@@ -713,10 +760,10 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
             fullWidth
             style={{ marginTop: spacing.md }}
           >
-            Confirm Decline
+            {t('taskDetails.decline.confirm')}
           </FButton>
           <FButton variant="outline" onPress={() => setRejectingBidId(null)} fullWidth style={{ marginTop: spacing.sm }}>
-            Cancel
+            {t('common.cancel')}
           </FButton>
         </Modal>
       </Portal>
@@ -724,7 +771,7 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
       {/* Completion Photos (shown for IN_PROGRESS and COMPLETED) */}
       {(task.status === 'IN_PROGRESS' || task.status === 'COMPLETED') && (task.completion_photos?.length ?? 0) > 0 && (
         <View style={styles.section}>
-          <FSectionHeader title="Completion Photos" accentColor={brandColors.primary} />
+          <FSectionHeader title={t('taskDetails.completion.photos')} accentColor={brandColors.primary} />
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
             {task.completion_photos.map((url, i) => (
               <Image key={i} source={{ uri: url }} style={{ width: 100, height: 100, borderRadius: radii.md }} />
@@ -847,7 +894,7 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
       {/* CANCELED: Reopen */}
       {task.status === 'CANCELED' && (
         <View style={styles.section}>
-          <FSectionHeader title="Canceled" accentColor={brandColors.danger} />
+          <FSectionHeader title={t('taskDetails.completion.canceled')} accentColor={brandColors.danger} />
           <FCard>
             <View style={styles.canceledContent}>
               <MaterialCommunityIcons
@@ -856,10 +903,10 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
                 color={brandColors.textMuted}
               />
               <Text style={[typography.body, { color: brandColors.textMuted, textAlign: 'center' }]}>
-                This task was canceled. Reopen it to re-post it to the discovery feed for fixers to bid on again.
+                {t('taskDetails.completion.canceledMessage')}
               </Text>
               <FButton onPress={reopenTask} fullWidth icon="refresh">
-                Reopen Task
+                {t('taskDetails.completion.reopenTask')}
               </FButton>
             </View>
           </FCard>

--- a/frontend/src/screens/TaskDetailsFixer.tsx
+++ b/frontend/src/screens/TaskDetailsFixer.tsx
@@ -58,6 +58,9 @@ interface Task {
   media_urls: string[];
   completion_photos: string[];
   general_location_name: string;
+  is_payment_confirmed: boolean;
+  requester_completed: boolean;
+  fixer_completed: boolean;
   created_at: string;
   requester_id: string;
   assigned_fixer_id?: string | null;
@@ -78,14 +81,7 @@ interface ExistingBid {
   auto_rejected_winning_rating?: number | null;
 }
 
-const REJECTION_LABELS: Record<string, string> = {
-  PRICE_TOO_HIGH: 'Price too high',
-  BAD_TIMING: 'Bad timing',
-  CHOSE_ANOTHER: 'Another fixer was chosen',
-  NOT_QUALIFIED: 'Not the right fit',
-  TASK_CANCELED: 'Task was canceled',
-  OTHER: 'Other reason',
-};
+// Rejection labels now come from i18n: taskDetailsFixer.rejectionReasons.*
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const CAROUSEL_HEIGHT = 260;
@@ -453,7 +449,7 @@ export default function TaskDetailsFixer({ route }: Props) {
                 {existingBid.status === 'REJECTED' && existingBid.rejection_reason && (
                   <View style={{ marginTop: spacing.xs, gap: spacing.xs }}>
                     <Text style={[typography.bodySm, { color: brandColors.textSecondary }]}>
-                      Reason: {REJECTION_LABELS[existingBid.rejection_reason] ?? 'Rejected'}
+                      {t('taskDetailsFixer.completion.reason')}: {t(`taskDetailsFixer.rejectionReasons.${existingBid.rejection_reason}`, { defaultValue: existingBid.rejection_reason })}
                     </Text>
                     {existingBid.rejection_note ? (
                       <Text style={[typography.bodySm, { color: brandColors.textMuted, fontStyle: 'italic' }]}>
@@ -479,7 +475,7 @@ export default function TaskDetailsFixer({ route }: Props) {
           {existingBid?.status === 'ACCEPTED' && task.status === 'IN_PROGRESS' && (
             <View style={{ gap: spacing.md }}>
               <Divider style={styles.divider} />
-              <Text style={[typography.h3, { color: brandColors.textPrimary }]}>Completion Photos</Text>
+              <Text style={[typography.h3, { color: brandColors.textPrimary }]}>{t('taskDetailsFixer.completion.photos')}</Text>
               {(task.completion_photos?.length ?? 0) > 0 && (
                 <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }}>
                   {task.completion_photos.map((url, i) => (
@@ -512,17 +508,63 @@ export default function TaskDetailsFixer({ route }: Props) {
                       completion_photos: allPhotos,
                     });
                     setTask((prev) => prev ? { ...prev, completion_photos: allPhotos } : prev);
-                    Alert.alert('Uploaded', 'Completion photos added and saved to your portfolio.');
+                    Alert.alert(t('taskDetailsFixer.completion.uploaded'), t('taskDetailsFixer.completion.uploadedMessage'));
                   } catch {
-                    Alert.alert('Error', 'Failed to upload completion photos.');
+                    Alert.alert(t('common.error'), t('taskDetailsFixer.completion.uploadError'));
                   } finally {
                     setUploadingPhotos(false);
                   }
                 }}
                 fullWidth
               >
-                Add Completion Photos
+                {t('taskDetailsFixer.completion.addPhotos')}
               </FButton>
+            </View>
+          )}
+
+          {/* Mark Completed — only after payment confirmed */}
+          {existingBid?.status === 'ACCEPTED' && task.status === 'IN_PROGRESS' && (
+            <View style={{ marginTop: spacing.md, gap: spacing.sm }}>
+              <Divider style={styles.divider} />
+              {!task.is_payment_confirmed && (
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+                  <MaterialCommunityIcons name="clock-outline" size={20} color={brandColors.textMuted} />
+                  <Text style={[typography.body, { color: brandColors.textMuted, flex: 1 }]}>
+                    {t('taskDetailsFixer.completion.waitingPayment')}
+                  </Text>
+                </View>
+              )}
+              {task.is_payment_confirmed && (
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs, marginBottom: spacing.xs }}>
+                  <MaterialCommunityIcons name="check-circle" size={16} color={brandColors.success} />
+                  <Text style={[typography.caption, { color: brandColors.success }]}>{t('taskDetailsFixer.completion.paymentConfirmed')}</Text>
+                </View>
+              )}
+              {task.is_payment_confirmed && !task.fixer_completed && (
+                <FButton
+                  variant="primary"
+                  icon="check-circle-outline"
+                  onPress={async () => {
+                    try {
+                      await api.put(`/api/tasks/${task.id}/confirm-completion`);
+                      fetchData();
+                    } catch {
+                      Alert.alert(t('common.error'), t('taskDetails.alerts.failedComplete'));
+                    }
+                  }}
+                  fullWidth
+                >
+                  {t('taskDetailsFixer.completion.markCompleted')}
+                </FButton>
+              )}
+              {task.is_payment_confirmed && task.fixer_completed && !task.requester_completed && (
+                <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm }}>
+                  <MaterialCommunityIcons name="clock-outline" size={20} color={brandColors.warning} />
+                  <Text style={[typography.body, { color: brandColors.textMuted, flex: 1 }]}>
+                    {t('taskDetailsFixer.completion.waitingRequester')}
+                  </Text>
+                </View>
+              )}
             </View>
           )}
 


### PR DESCRIPTION
## Summary
- **Dual-confirm task completion**: payment confirmed → requester confirms → fixer confirms → COMPLETED
- **Past conversations on separate page** with delete option (new `PastConversationsScreen` + `DELETE /api/tasks/:id/messages` endpoint)
- **Report review modal**: clickable reason buttons with optional details field (required for Other), details shown in admin panel
- **URL-based web navigation**: refresh preserves current page instead of resetting to home
- **Push notification toggle persistence**: state survives page refresh on web (AsyncStorage) and native (permission check)
- **Globe icon** for language toggle (replaces EN/עב chips)
- **Hide verification section** from fixer profile after approved
- **Disable cancel task** after payment confirmed
- **Fix mojibake** (Â· → ·, â‚ª → ₪) in i18n JSON files
- **Lower Bayesian m** from 3 to 1 for rating calculation
- **Chat read-only** for canceled tasks
- **i18n keys** for completion flow, decline modal, discovery cards, time ago, past conversations

## Test plan
- [x] Backend: 237 tests (236 pass, 1 pre-existing directions test failure unrelated to changes)
- [x] Frontend: 18 suites, 159 tests all pass
- [x] TypeScript: both workspaces compile clean
- [x] New tests: 6 tests for `DELETE /api/tasks/:id/messages` (completed task, fixer access, in-progress rejection, non-participant, 404, 401)
- [ ] Manual: verify web refresh preserves navigation state
- [ ] Manual: verify push toggle state persists after refresh
- [ ] Manual: verify past conversations page shows completed/canceled tasks with delete

