### PR TITLE
fix: unified message inbox + add migration step to Railway deploy

### DIFF
--- a/backend/railway.json
+++ b/backend/railway.json
@@ -5,7 +5,7 @@
     "buildCommand": "npm install && npm run build"
   },
   "deploy": {
-    "startCommand": "npm start",
+    "startCommand": "npx prisma migrate deploy && npm start",
     "healthcheckPath": "/health",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 3

--- a/frontend/src/navigation/FixerTabs.tsx
+++ b/frontend/src/navigation/FixerTabs.tsx
@@ -69,7 +69,6 @@ export default function FixerTabs() {
       <Tab.Screen
         name="Messages"
         component={ConversationListScreen}
-        initialParams={{ mode: 'fixer' }}
         options={{
           tabBarLabel: t('nav.messages'),
           tabBarBadge: unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : undefined,

--- a/frontend/src/navigation/RequesterTabs.tsx
+++ b/frontend/src/navigation/RequesterTabs.tsx
@@ -73,7 +73,6 @@ export default function RequesterTabs() {
       <Tab.Screen
         name="Messages"
         component={ConversationListScreen}
-        initialParams={{ mode: 'requester' }}
         options={{
           tabBarLabel: t('nav.messages'),
           tabBarBadge: unreadCount > 0 ? (unreadCount > 99 ? '99+' : unreadCount) : undefined,


### PR DESCRIPTION
- Remove mode filter (requester/fixer) from Messages tab in both RequesterTabs and FixerTabs — conversations now show all chats regardless of which role the user is currently in, matching the unread badge which was already counting all conversations
- railway.json: run npx prisma migrate deploy before npm start so pending migrations are applied on every Railway deploy