### PR TITLE
feat: role chips on conversation list and notification center

### DIFF
--- a/backend/prisma/migrations/20260606124303_add_notification_user_role/migration.sql
+++ b/backend/prisma/migrations/20260606124303_add_notification_user_role/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Notification" ADD COLUMN     "user_role" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -222,6 +222,7 @@ model Notification {
   type                NotificationType
   related_entity_id   String
   related_entity_type String
+  user_role           String?
   is_read             Boolean          @default(false)
   created_at          DateTime         @default(now())
 

--- a/backend/src/routes/messages.ts
+++ b/backend/src/routes/messages.ts
@@ -122,6 +122,7 @@ router.get('/conversations', async (req: Request, res: Response, next: NextFunct
           taskId: task.id,
           taskTitle: task.title,
           taskStatus: task.status,
+          userRole: task.requester_id === userId ? 'requester' : 'fixer',
           otherParty,
           lastMessage: lastMessage
             ? { content: lastMessage.content, timestamp: lastMessage.created_at }

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -26,6 +26,7 @@ export async function sendNotification(
   type: NotificationType,
   relatedEntityId: string,
   relatedEntityType: string,
+  userRole?: string,
 ): Promise<void> {
   try {
     // 1. Always persist to DB
@@ -37,6 +38,7 @@ export async function sendNotification(
         type,
         related_entity_id: relatedEntityId,
         related_entity_type: relatedEntityType,
+        user_role: userRole ?? null,
       },
     });
 

--- a/backend/src/socket/index.ts
+++ b/backend/src/socket/index.ts
@@ -134,6 +134,7 @@ export function initSocket(httpServer: HttpServer): SocketServer {
             : false;
 
           if (!recipientInRoom) {
+            const recipientRole = recipientId === task.requester_id ? 'requester' : 'fixer';
             await sendNotification(
               recipientId,
               'New message',
@@ -141,6 +142,7 @@ export function initSocket(httpServer: HttpServer): SocketServer {
               NotificationType.NEW_MESSAGE,
               taskId,
               'Task',
+              recipientRole,
             );
           }
         } catch (err) {

--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -11,6 +11,7 @@ export interface AppNotification {
   type: string;
   related_entity_id: string | null;
   related_entity_type: string | null;
+  user_role: string | null;
   is_read: boolean;
   created_at: string;
   updated_at: string;

--- a/frontend/src/screens/ConversationListScreen.tsx
+++ b/frontend/src/screens/ConversationListScreen.tsx
@@ -20,6 +20,7 @@ export interface Conversation {
   taskId: string;
   taskTitle: string;
   taskStatus?: string;
+  userRole: 'requester' | 'fixer';
   otherParty: OtherParty | null;
   lastMessage: { content: string; timestamp: string } | null;
   unreadCount: number;
@@ -142,6 +143,9 @@ export default function ConversationListScreen({ route }: { route?: { params?: {
               <Text style={[typography.caption, { color: brandColors.textMuted, textAlign: isRTL ? 'right' : 'left' }]} numberOfLines={1}>
                 {item.taskTitle}
               </Text>
+              <View style={[styles.rolePill, { backgroundColor: item.userRole === 'requester' ? brandColors.primary : brandColors.secondary }]}>
+                <Text style={styles.rolePillText}>{t(`mode.${item.userRole}`)}</Text>
+              </View>
               <View style={styles.bottomRow}>
                 <Text
                   style={[
@@ -222,6 +226,19 @@ const styles = StyleSheet.create({
   badgeText: {
     color: brandColors.white,
     fontSize: 11,
+    fontWeight: '700',
+    lineHeight: 14,
+  },
+  rolePill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: radii.sm,
+    marginTop: 2,
+  },
+  rolePillText: {
+    color: brandColors.white,
+    fontSize: 10,
     fontWeight: '700',
     lineHeight: 14,
   },

--- a/frontend/src/screens/NotificationCenterScreen.tsx
+++ b/frontend/src/screens/NotificationCenterScreen.tsx
@@ -12,7 +12,7 @@ import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import { useLanguage } from '../context/LanguageContext';
-import { useNotificationContext, type AppNotification } from '../context/NotificationContext';
+import { useNotificationContext, type AppNotification, FIXER_NOTIF_TYPES, REQUESTER_NOTIF_TYPES } from '../context/NotificationContext';
 import LoadingScreen from '../components/LoadingScreen';
 import EmptyState from '../components/EmptyState';
 import { FButton } from '../components/ui';
@@ -30,6 +30,13 @@ const NOTIFICATION_ICONS: Record<string, string> = {
 
 function getIcon(type: string): string {
   return NOTIFICATION_ICONS[type] ?? 'bell-outline';
+}
+
+function getNotificationRole(n: AppNotification): 'requester' | 'fixer' | null {
+  if (n.user_role === 'requester' || n.user_role === 'fixer') return n.user_role;
+  if (FIXER_NOTIF_TYPES.includes(n.type)) return 'fixer';
+  if (REQUESTER_NOTIF_TYPES.includes(n.type)) return 'requester';
+  return null;
 }
 
 function getAccentColor(type: string): string {
@@ -59,6 +66,7 @@ function NotificationItem({
   const { isRTL } = useLanguage();
   const accent = getAccentColor(notification.type);
   const icon = getIcon(notification.type);
+  const role = getNotificationRole(notification);
 
   const timeAgo = (dateStr: string): string => {
     const diff = Date.now() - new Date(dateStr).getTime();
@@ -97,6 +105,11 @@ function NotificationItem({
           >
             {notification.title}
           </Text>
+          {role && (
+            <View style={[styles.rolePill, { backgroundColor: role === 'requester' ? brandColors.primary : brandColors.secondary }]}>
+              <Text style={styles.rolePillText}>{t(`mode.${role}`)}</Text>
+            </View>
+          )}
           <Text
             style={[typography.bodySm, { color: brandColors.textSecondary, marginTop: 2, textAlign: isRTL ? 'right' : 'left' }]}
             numberOfLines={2}
@@ -301,5 +314,19 @@ const styles = StyleSheet.create({
     height: 1,
     backgroundColor: brandColors.outlineLight,
     marginLeft: spacing.lg + 40 + spacing.md, // aligned with content
+  },
+  rolePill: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 6,
+    marginTop: 3,
+    marginBottom: 2,
+  },
+  rolePillText: {
+    color: brandColors.white,
+    fontSize: 10,
+    fontWeight: '700',
+    lineHeight: 14,
   },
 });


### PR DESCRIPTION
## Summary

- Each conversation row in the Messages tab now shows a small colored pill — **blue for Requester, amber for Fixer** — so users with a unified inbox can immediately tell which role they played in each task conversation.
- Notification center items show the same role chip for all notification types where the role is deterministic: bid-related types (e.g. `BID_ACCEPTED` → Fixer, `NEW_BID` → Requester) are derived from the type constant on the frontend; `NEW_MESSAGE` role is now stored in a new nullable `user_role` column on the `Notification` table and set at send time in the socket handler.

## Changes

| Area | File | What changed |
|------|------|-------------|
| Backend | `routes/messages.ts` | Added `userRole` field to each conversation in the API response |
| Backend | `prisma/schema.prisma` | Added `user_role String?` to `Notification` model |
| Backend | `services/notificationService.ts` | Added optional `userRole` param, persisted to DB |
| Backend | `socket/index.ts` | Derives recipient role and passes it when sending `NEW_MESSAGE` notifications |
| Frontend | `screens/ConversationListScreen.tsx` | Interface field + role chip UI + styles |
| Frontend | `context/NotificationContext.tsx` | Added `user_role` to `AppNotification` interface |
| Frontend | `screens/NotificationCenterScreen.tsx` | `getNotificationRole()` helper + role chip in `NotificationItem` |

## Migration

`20260606124303_add_notification_user_role` — adds a nullable `TEXT` column to the `Notification` table. Existing rows get `NULL` (no chip shown for old notifications, which is acceptable).

## Test plan

- [ ] Log in as a user with both requester and fixer conversations → each Messages row shows the correct blue/amber chip
- [ ] Open Notification center → bid-related notifications show the correct chip immediately; send a new message and verify the NEW_MESSAGE notification shows a chip on the recipient's side
- [ ] All 237 backend tests pass (`npm test --workspace backend`)
- [ ] All 159 frontend tests pass (`npm test --workspace frontend`)
- [ ] TypeScript clean on both workspaces (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)