### PR TITLE
test: audit fix coverage

### DIFF
--- a/backend/src/__tests__/routes/bids.test.ts
+++ b/backend/src/__tests__/routes/bids.test.ts
@@ -284,6 +284,37 @@ describe('PUT /api/bids/:id/cancel-accepted', () => {
       .set('Authorization', FIXER_AUTH);
     expect(res.status).toBe(400);
   });
+
+  it('sends a notification to the requester when fixer cancels accepted bid', async () => {
+    await createOpenTask();
+    const bid = await fixerSubmitsBid();
+    __setUid('test-uid');
+    await request(app).put(`/api/bids/${bid.id}/accept`).set('Authorization', REQUESTER_AUTH);
+
+    __setUid('fixer-uid');
+    await request(app)
+      .put(`/api/bids/${bid.id}/cancel-accepted`)
+      .set('Authorization', FIXER_AUTH);
+
+    const notifications = await prisma.notification.findMany({
+      where: { title: 'Fixer Canceled' },
+    });
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].user_id).not.toBe(fixerId); // goes to requester, not fixer
+  });
+
+  it('returns 403 when requester tries to cancel-accepted', async () => {
+    await createOpenTask();
+    const bid = await fixerSubmitsBid();
+    __setUid('test-uid');
+    await request(app).put(`/api/bids/${bid.id}/accept`).set('Authorization', REQUESTER_AUTH);
+
+    // Requester shouldn't be able to use this endpoint
+    const res = await request(app)
+      .put(`/api/bids/${bid.id}/cancel-accepted`)
+      .set('Authorization', REQUESTER_AUTH);
+    expect(res.status).toBe(403);
+  });
 });
 
 // ── PUT /api/bids/:id/reactivate ──────────────────────────────────────────────

--- a/backend/src/__tests__/routes/tasks.test.ts
+++ b/backend/src/__tests__/routes/tasks.test.ts
@@ -885,3 +885,155 @@ describe('Task urgency', () => {
     expect(res.body.tasks.every((t: { urgency: string }) => t.urgency === 'TODAY')).toBe(true);
   });
 });
+
+// ── Confirm-completion race condition guard ─────────────────────────────────
+
+describe('PUT /api/tasks/:id/confirm-completion (race condition guard)', () => {
+  it('returns 409 if requester tries to double-confirm', async () => {
+    const task = await createTask();
+    await acceptBid(task.id);
+    // Confirm payment first
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-payment`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    // First confirm
+    __setUid('test-uid');
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    // Second confirm — should be 409
+    const res = await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', REQUESTER_AUTH);
+    expect(res.status).toBe(409);
+  });
+
+  it('returns 409 if fixer tries to double-confirm', async () => {
+    const task = await createTask();
+    await acceptBid(task.id);
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-payment`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    __setUid('fixer-uid');
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', FIXER_AUTH);
+
+    const res = await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', FIXER_AUTH);
+    expect(res.status).toBe(409);
+  });
+
+  it('sets fixer_completed_at timestamp when fixer confirms', async () => {
+    const task = await createTask();
+    await acceptBid(task.id);
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-payment`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    __setUid('fixer-uid');
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', FIXER_AUTH);
+
+    const updated = await prisma.task.findUnique({ where: { id: task.id } });
+    expect(updated!.fixer_completed).toBe(true);
+    expect(updated!.fixer_completed_at).not.toBeNull();
+  });
+});
+
+// ── Cancellation sends notification ─────────────────────────────────────────
+
+describe('PUT /api/tasks/:id/status — cancel notifications', () => {
+  it('canceling an IN_PROGRESS task creates a notification for the fixer', async () => {
+    const task = await createTask();
+    await acceptBid(task.id);
+
+    __setUid('test-uid');
+    await request(app)
+      .put(`/api/tasks/${task.id}/status`)
+      .set('Authorization', REQUESTER_AUTH)
+      .send({ status: 'CANCELED' });
+
+    const notifications = await prisma.notification.findMany({
+      where: { title: 'Task Canceled' },
+    });
+    expect(notifications.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('cannot cancel an IN_PROGRESS task after payment is confirmed', async () => {
+    const task = await createTask();
+    await acceptBid(task.id);
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-payment`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    const res = await request(app)
+      .put(`/api/tasks/${task.id}/status`)
+      .set('Authorization', REQUESTER_AUTH)
+      .send({ status: 'CANCELED' });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── Review nudge on completion ──────────────────────────────────────────────
+
+describe('PUT /api/tasks/:id/confirm-completion — review nudge', () => {
+  it('sends a review nudge notification when task is completed', async () => {
+    const task = await createTask();
+    await acceptBid(task.id);
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-payment`)
+      .set('Authorization', REQUESTER_AUTH);
+    await completeTaskFull(task.id);
+
+    const nudges = await prisma.notification.findMany({
+      where: { title: 'Leave a Review' },
+    });
+    expect(nudges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not send review nudge if review already exists', async () => {
+    const task = await createTask();
+    const bidId = await acceptBid(task.id);
+
+    // Get the fixer user ID
+    const bid = await prisma.bid.findUnique({ where: { id: bidId } });
+
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-payment`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    // Requester confirms first
+    __setUid('test-uid');
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', REQUESTER_AUTH);
+
+    // Create a review before fixer confirms
+    const requester = await prisma.user.findFirst({ where: { firebase_uid: 'test-uid' } });
+    await prisma.review.create({
+      data: {
+        task_id: task.id,
+        reviewer_id: requester!.id,
+        reviewee_id: bid!.fixer_id,
+        rating: 5,
+      },
+    });
+
+    // Fixer confirms — completes the task
+    __setUid('fixer-uid');
+    await request(app)
+      .put(`/api/tasks/${task.id}/confirm-completion`)
+      .set('Authorization', FIXER_AUTH);
+
+    const nudges = await prisma.notification.findMany({
+      where: { title: 'Leave a Review' },
+    });
+    expect(nudges).toHaveLength(0);
+  });
+});

--- a/backend/src/__tests__/utils/completionChecker.test.ts
+++ b/backend/src/__tests__/utils/completionChecker.test.ts
@@ -1,0 +1,185 @@
+jest.mock('../../config/firebaseAdmin', () => {
+  let currentUid = 'req-uid';
+  return {
+    __esModule: true,
+    default: {
+      auth: () => ({
+        verifyIdToken: jest.fn().mockImplementation(() => Promise.resolve({ uid: currentUid })),
+      }),
+      apps: [{}],
+    },
+    __setUid: (uid: string) => { currentUid = uid; },
+  };
+});
+
+import request from 'supertest';
+import app from '../../app';
+import { prisma } from '../../config/prisma';
+import { cleanDatabase, createTestUser } from '../setup';
+import { checkPendingCompletions } from '../../utils/completionChecker';
+
+const REQUESTER_AUTH = 'Bearer req-token';
+const FIXER_AUTH = 'Bearer fix-token';
+const { __setUid } = jest.requireMock('../../config/firebaseAdmin') as { __setUid: (uid: string) => void };
+
+beforeEach(async () => {
+  await cleanDatabase();
+  __setUid('req-uid');
+  await createTestUser({ firebase_uid: 'req-uid', email: 'req@test.com' });
+  await createTestUser({ firebase_uid: 'fix-uid', email: 'fix@test.com' });
+});
+afterAll(() => prisma.$disconnect());
+
+const validTask = {
+  title: 'Test task',
+  description: 'Needs fixing',
+  category: 'PLUMBING',
+  general_location_name: 'Tel Aviv',
+  exact_address: '1 Test St',
+  lat: 32.08,
+  lng: 34.78,
+};
+
+// Helper: create task via API, accept bid, confirm payment, fixer confirms completion,
+// then back-date fixer_completed_at to simulate elapsed time
+async function createPendingTask(hoursAgo: number) {
+  __setUid('req-uid');
+  const taskRes = await request(app)
+    .post('/api/tasks')
+    .set('Authorization', REQUESTER_AUTH)
+    .send(validTask);
+  const taskId = taskRes.body.task.id as string;
+
+  // Fixer submits bid
+  __setUid('fix-uid');
+  const bidRes = await request(app)
+    .post(`/api/tasks/${taskId}/bids`)
+    .set('Authorization', FIXER_AUTH)
+    .send({ offered_price: 100, description: 'I can do it.' });
+  const bidId = bidRes.body.bid.id as string;
+
+  // Requester accepts bid
+  __setUid('req-uid');
+  await request(app)
+    .put(`/api/bids/${bidId}/accept`)
+    .set('Authorization', REQUESTER_AUTH);
+
+  // Confirm payment
+  await request(app)
+    .put(`/api/tasks/${taskId}/confirm-payment`)
+    .set('Authorization', REQUESTER_AUTH);
+
+  // Fixer confirms completion
+  __setUid('fix-uid');
+  await request(app)
+    .put(`/api/tasks/${taskId}/confirm-completion`)
+    .set('Authorization', FIXER_AUTH);
+
+  // Back-date fixer_completed_at
+  await prisma.task.update({
+    where: { id: taskId },
+    data: {
+      fixer_completed_at: new Date(Date.now() - hoursAgo * 60 * 60 * 1000),
+    },
+  });
+
+  // Clear notifications created during setup
+  await prisma.notification.deleteMany();
+
+  __setUid('req-uid');
+  return taskId;
+}
+
+describe('checkPendingCompletions', () => {
+  it('does nothing for tasks where fixer completed less than 48h ago', async () => {
+    const taskId = await createPendingTask(24);
+
+    await checkPendingCompletions();
+
+    const updated = await prisma.task.findUnique({ where: { id: taskId } });
+    expect(updated!.status).toBe('IN_PROGRESS');
+
+    const notifications = await prisma.notification.findMany();
+    expect(notifications).toHaveLength(0);
+  });
+
+  it('sends a reminder notification after 48h', async () => {
+    const taskId = await createPendingTask(72);
+
+    await checkPendingCompletions();
+
+    const updated = await prisma.task.findUnique({ where: { id: taskId } });
+    expect(updated!.status).toBe('IN_PROGRESS');
+
+    const notifications = await prisma.notification.findMany({
+      where: { title: 'Confirm Completion' },
+    });
+    expect(notifications).toHaveLength(1);
+  });
+
+  it('does not send duplicate reminders within 48h', async () => {
+    await createPendingTask(72);
+
+    await checkPendingCompletions();
+    await checkPendingCompletions();
+
+    const notifications = await prisma.notification.findMany({
+      where: { title: 'Confirm Completion' },
+    });
+    expect(notifications).toHaveLength(1);
+  });
+
+  it('auto-completes task after 7 days', async () => {
+    const taskId = await createPendingTask(7 * 24 + 1);
+
+    await checkPendingCompletions();
+
+    const updated = await prisma.task.findUnique({ where: { id: taskId } });
+    expect(updated!.status).toBe('COMPLETED');
+    expect(updated!.requester_completed).toBe(true);
+    expect(updated!.completed_at).not.toBeNull();
+
+    // Should notify both parties
+    const autoCompleteNotifs = await prisma.notification.findMany({
+      where: { title: 'Task Auto-Completed' },
+    });
+    expect(autoCompleteNotifs).toHaveLength(1);
+
+    const fixerNotifs = await prisma.notification.findMany({
+      where: { title: 'Task Completed' },
+    });
+    expect(fixerNotifs).toHaveLength(1);
+  });
+
+  it('sends review nudge on auto-complete only if no review exists', async () => {
+    await createPendingTask(7 * 24 + 1);
+
+    await checkPendingCompletions();
+
+    const reviewNudge = await prisma.notification.findMany({
+      where: { title: 'Leave a Review' },
+    });
+    expect(reviewNudge).toHaveLength(1);
+  });
+
+  it('skips review nudge on auto-complete if review already exists', async () => {
+    const taskId = await createPendingTask(7 * 24 + 1);
+
+    const task = await prisma.task.findUnique({ where: { id: taskId } });
+    await prisma.review.create({
+      data: {
+        task_id: taskId,
+        reviewer_id: task!.requester_id,
+        reviewee_id: task!.assigned_fixer_id!,
+        rating: 5,
+      },
+    });
+
+    await checkPendingCompletions();
+
+    const reviewNudge = await prisma.notification.findMany({
+      where: { title: 'Leave a Review' },
+    });
+    expect(reviewNudge).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/__tests__/OnboardingNudge.test.tsx
+++ b/frontend/src/components/__tests__/OnboardingNudge.test.tsx
@@ -1,0 +1,161 @@
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+  initReactI18next: { type: '3rdParty', init: jest.fn() },
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+  DefaultTheme: {
+    dark: false,
+    colors: {
+      primary: '#007AFF',
+      background: '#fff',
+      card: '#fff',
+      text: '#000',
+      border: '#ccc',
+      notification: '#f00',
+    },
+    fonts: {
+      regular: { fontFamily: 'System', fontWeight: '400' as const },
+      medium: { fontFamily: 'System', fontWeight: '500' as const },
+      bold: { fontFamily: 'System', fontWeight: '700' as const },
+      heavy: { fontFamily: 'System', fontWeight: '900' as const },
+    },
+  },
+}));
+
+import React from 'react';
+import { render, waitFor, fireEvent } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import api from '../../api/axiosInstance';
+import OnboardingNudge from '../OnboardingNudge';
+
+const mockApi = api as jest.Mocked<typeof api>;
+const mockNavigate = jest.fn();
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  mockAsyncStorage.getItem.mockResolvedValue(null);
+  mockAsyncStorage.setItem.mockResolvedValue();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('OnboardingNudge', () => {
+  it('shows modal for users with incomplete profile', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { user: { full_name: 'Test', avatar_url: null, bio: null, phone_number: null } },
+    });
+
+    const { queryByText } = render(<OnboardingNudge />);
+
+    // Fast-forward past the 2s delay
+    jest.advanceTimersByTime(2500);
+    await waitFor(() => {
+      expect(queryByText('onboarding.title')).toBeTruthy();
+    });
+  });
+
+  it('does not show modal if profile is complete', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { user: { full_name: 'Test', avatar_url: 'http://img.com/a.png', bio: 'Hi', phone_number: '123' } },
+    });
+
+    const { queryByText } = render(<OnboardingNudge />);
+    jest.advanceTimersByTime(2500);
+
+    // Wait for the async storage call (marks as dismissed)
+    await waitFor(() => {
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('onboarding_nudge_dismissed', 'true');
+    });
+    expect(queryByText('onboarding.title')).toBeNull();
+  });
+
+  it('does not show modal if previously dismissed', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('true');
+
+    const { queryByText } = render(<OnboardingNudge />);
+    jest.advanceTimersByTime(2500);
+
+    await waitFor(() => {
+      expect(mockAsyncStorage.getItem).toHaveBeenCalled();
+    });
+    expect(queryByText('onboarding.title')).toBeNull();
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+
+  it('dismiss button persists dismissal and hides modal', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { user: { full_name: 'Test', avatar_url: null, bio: null, phone_number: null } },
+    });
+
+    const { queryByText, getByText } = render(<OnboardingNudge />);
+    jest.advanceTimersByTime(2500);
+
+    await waitFor(() => {
+      expect(queryByText('onboarding.title')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('onboarding.later'));
+    await waitFor(() => {
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('onboarding_nudge_dismissed', 'true');
+    });
+  });
+
+  it('complete profile button navigates to Settings', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { user: { full_name: 'Test', avatar_url: null, bio: null, phone_number: null } },
+    });
+
+    const { queryByText, getByText } = render(<OnboardingNudge />);
+    jest.advanceTimersByTime(2500);
+
+    await waitFor(() => {
+      expect(queryByText('onboarding.title')).toBeTruthy();
+    });
+
+    fireEvent.press(getByText('onboarding.completeProfile'));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('Settings');
+    });
+  });
+
+  it('shows modal if even one field is present but others missing', async () => {
+    // Has bio but no avatar or phone — still shows (all three must be missing for nudge)
+    mockApi.get.mockResolvedValue({
+      data: { user: { full_name: 'Test', avatar_url: null, bio: 'Hello', phone_number: null } },
+    });
+
+    const { queryByText } = render(<OnboardingNudge />);
+    jest.advanceTimersByTime(2500);
+
+    // Profile is NOT incomplete (bio is present), so it should dismiss
+    await waitFor(() => {
+      expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('onboarding_nudge_dismissed', 'true');
+    });
+    expect(queryByText('onboarding.title')).toBeNull();
+  });
+
+  it('handles API error gracefully', async () => {
+    mockApi.get.mockRejectedValue(new Error('Network error'));
+
+    const { queryByText } = render(<OnboardingNudge />);
+    jest.advanceTimersByTime(2500);
+
+    await waitFor(() => {
+      expect(mockApi.get).toHaveBeenCalled();
+    });
+    expect(queryByText('onboarding.title')).toBeNull();
+  });
+});

--- a/frontend/src/hooks/__tests__/useUnreadMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useUnreadMessages.test.ts
@@ -30,13 +30,13 @@ describe('useUnreadMessages', () => {
     expect(result.current.unreadCount).toBe(0);
   });
 
-  it('sums unreadCount across all conversations', async () => {
+  it('sums unreadCount only from IN_PROGRESS conversations', async () => {
     mockApi.get.mockResolvedValue({
       data: {
         conversations: [
-          { taskId: 't1', unreadCount: 3 },
-          { taskId: 't2', unreadCount: 5 },
-          { taskId: 't3', unreadCount: 0 },
+          { taskId: 't1', unreadCount: 3, taskStatus: 'IN_PROGRESS' },
+          { taskId: 't2', unreadCount: 5, taskStatus: 'IN_PROGRESS' },
+          { taskId: 't3', unreadCount: 0, taskStatus: 'IN_PROGRESS' },
         ],
       },
     });
@@ -45,13 +45,29 @@ describe('useUnreadMessages', () => {
     await waitFor(() => expect(result.current.unreadCount).toBe(8));
   });
 
+  it('excludes unread counts from non-IN_PROGRESS conversations', async () => {
+    mockApi.get.mockResolvedValue({
+      data: {
+        conversations: [
+          { taskId: 't1', unreadCount: 3, taskStatus: 'IN_PROGRESS' },
+          { taskId: 't2', unreadCount: 5, taskStatus: 'COMPLETED' },
+          { taskId: 't3', unreadCount: 2, taskStatus: 'CANCELED' },
+          { taskId: 't4', unreadCount: 4, taskStatus: 'OPEN' },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useUnreadMessages());
+    await waitFor(() => expect(result.current.unreadCount).toBe(3));
+  });
+
   it('refetch function updates the count', async () => {
-    mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 2 }] } });
+    mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 2, taskStatus: 'IN_PROGRESS' }] } });
 
     const { result } = renderHook(() => useUnreadMessages());
     await waitFor(() => expect(result.current.unreadCount).toBe(2));
 
-    mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 0 }] } });
+    mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 0, taskStatus: 'IN_PROGRESS' }] } });
     await act(async () => { await result.current.refetch(); });
 
     expect(result.current.unreadCount).toBe(0);


### PR DESCRIPTION
## Summary
- New test file for `completionChecker` utility (48h reminder, 7-day auto-complete, dedup, review nudge skip)
- Extended `tasks.test.ts` with race condition guard tests (double-confirm 409), cancel notification, review nudge logic
- Extended `bids.test.ts` with cancel-accepted notification and authorization tests
- Updated `useUnreadMessages.test.ts` to verify IN_PROGRESS-only filtering
- New test file for `OnboardingNudge` component (show/hide, dismiss, navigation, API error)

## Test plan
- [ ] `npm test --workspace backend` — all new tests pass
- [ ] `npm test --workspace frontend` — all new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)