### PR TITLE
fix: move EAS workflow file to frontend/.eas/workflows (correct project root)

### DIFF
--- a/frontend/.eas/workflows/update.yml
+++ b/frontend/.eas/workflows/update.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update:
+    name: EAS Update
+    type: update
+    params:
+      channel: production
+      message: Auto update from ${{ github.sha }}


### PR DESCRIPTION
## Summary

The `.eas/workflows/update.yml` file was at the **git repo root**, but Expo resolves workflow files relative to the **Expo project root** (`frontend/`). So Expo was looking for `frontend/.eas/workflows/update.yml` and silently finding nothing — hence "No workflows yet" in the dashboard.

This moves the file to `frontend/.eas/workflows/update.yml` so Expo's GitHub integration detects and runs it on every push to `main`.

## Test plan

- [x] Verified with `eas workflow:run` — the old location errored with `Failed to read "/frontend/.eas/workflows/update.yml"`
- [ ] After merge: push to main should trigger an EAS Update automatically on the Expo dashboard Workflows panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)