### PR TITLE
feat: verified badge + RTL layout fixes

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -38,6 +38,7 @@ const users = [
     email: 'shick@example.com',
     phone_number: '0504444444',
     specializations: [Category.ELECTRICITY, Category.PLUMBING],
+    verification_status: 'APPROVED' as const,
   },
   {
     firebase_uid: 'sUegu2QaPlVsiYlUdvcK0LuJWOf1',

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -932,7 +932,8 @@
       "trades": "Trades",
       "photos": "Photos",
       "profileCompletion": "Profile",
-      "tapToView": "Tap to view reviews"
+      "tapToView": "Tap to view reviews",
+      "new": "New"
     },
     "pushNotifications": {
       "label": "Push Notifications",
@@ -1055,6 +1056,11 @@
     "review": "review",
     "reviews": "reviews",
     "respondsIn": "Responds in ~{{value}} {{unit}}",
+    "timeUnit": {
+      "min": "min",
+      "hr": "hr",
+      "days": "days"
+    },
     "tasksCompleted_one": "{{count}} task completed",
     "tasksCompleted_other": "{{count}} tasks completed",
     "report": {

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -936,7 +936,8 @@
       "trades": "מקצועות",
       "photos": "תמונות",
       "profileCompletion": "פרופיל",
-      "tapToView": "לחץ לצפייה בביקורות"
+      "tapToView": "לחץ לצפייה בביקורות",
+      "new": "חדש"
     },
     "pushNotifications": {
       "label": "התראות",
@@ -1063,6 +1064,11 @@
     "review": "ביקורת",
     "reviews": "ביקורות",
     "respondsIn": "מגיב תוך ~{{value}} {{unit}}",
+    "timeUnit": {
+      "min": "דק׳",
+      "hr": "שע׳",
+      "days": "ימים"
+    },
     "tasksCompleted_one": "משימה אחת הושלמה",
     "tasksCompleted_two": "{{count}} משימות הושלמו",
     "tasksCompleted_many": "{{count}} משימות הושלמו",

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -189,8 +189,8 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
         },
       ]}
     >
-      <View style={styles.desktopBarInner}>
-        <View style={[styles.desktopLeft, { flexDirection: isRTL ? 'row-reverse' : 'row' }]}>
+      <View style={[styles.desktopBarInner, styles.forceLtr]}>
+        <View style={styles.desktopLeft}>
           <Pressable
             accessibilityRole="button"
             accessibilityLabel="Go to FixIt home"
@@ -201,12 +201,12 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
           </Pressable>
 
           {mode === 'fixer' ? (
-            <View style={[styles.modeLabel, { flexDirection: isRTL ? 'row-reverse' : 'row' }]}>
+            <View style={styles.modeLabel}>
               <MaterialCommunityIcons name="wrench-outline" size={13} color="#fff" />
               <Text style={styles.modeLabelText}>{t('nav.workspace.fixerBadge')}</Text>
             </View>
           ) : (
-            <View style={[styles.modeLabel, styles.modeLabelRequester, { flexDirection: isRTL ? 'row-reverse' : 'row' }]}>
+            <View style={[styles.modeLabel, styles.modeLabelRequester]}>
               <MaterialCommunityIcons name="home-outline" size={13} color="#fff" />
               <Text style={styles.modeLabelText}>{t('nav.workspace.requesterBadge')}</Text>
             </View>
@@ -620,6 +620,8 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     gap: spacing.lg,
   },
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  forceLtr: Platform.OS === 'web' ? { direction: 'ltr' } as any : {},
   // Logo + nav tabs grouped together on the left; actions sit on the right.
   desktopLeft: {
     flexDirection: 'row',

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -388,15 +388,15 @@ export default function FixerProfileScreen() {
               <View style={styles.headerIconShell}>
                 <MaterialCommunityIcons name="account-hard-hat-outline" size={17} color={brandColors.secondaryDark} />
               </View>
-              <Text style={[styles.headerKicker, { textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.headerKicker')}</Text>
+              <Text style={[styles.headerKicker, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.headerKicker')}</Text>
             </View>
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
-              <Text style={[styles.heroName, { textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]} numberOfLines={2}>{displayName}</Text>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs, alignSelf: 'flex-start' }}>
+              <Text style={[styles.heroName, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]} numberOfLines={2}>{displayName}</Text>
               {profile?.verification_status === 'APPROVED' && (
                 <MaterialCommunityIcons name="check-decagram" size={22} color="#29B6F6" />
               )}
             </View>
-            <Text style={[styles.heroEmail, { textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]} numberOfLines={1}>{profile?.email}</Text>
+            <Text style={[styles.heroEmail, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]} numberOfLines={1}>{profile?.email}</Text>
           </View>
 
           <Pressable
@@ -408,7 +408,7 @@ export default function FixerProfileScreen() {
             }}
           >
             <Text style={styles.heroStatValue}>
-              {avgRating != null && avgRating > 0 ? avgRating.toFixed(1) : 'New'}
+              {avgRating != null && avgRating > 0 ? avgRating.toFixed(1) : t('fixerProfile.stats.new')}
             </Text>
             <Text style={[styles.heroStatLabel, { writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.stats.rating')}</Text>
             <Text numberOfLines={1} style={[typography.caption, { color: brandColors.secondaryDark, marginTop: spacing.xs, textDecorationLine: 'underline', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
@@ -924,12 +924,14 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     flexGrow: 0,
     flexShrink: 0,
-    flexDirection: 'row',
-    alignItems: 'center',
+    flexDirection: 'row' as const,
+    alignItems: 'center' as const,
     gap: spacing.lg,
     borderBottomWidth: 3,
     borderBottomColor: brandColors.secondary,
-    overflow: 'hidden',
+    overflow: 'hidden' as const,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ...(Platform.OS === 'web' ? { direction: 'ltr' } : {}) as any,
     ...shadows.md,
   },
   profileHeroWide: {

--- a/frontend/src/screens/PublicProfileScreen.tsx
+++ b/frontend/src/screens/PublicProfileScreen.tsx
@@ -253,9 +253,9 @@ export default function PublicProfileScreen({ route }: { route: any }) {
   }
 
   const formatResponseTime = (minutes: number): string => {
-    if (minutes < 60) return t('publicProfile.respondsIn', { value: Math.round(minutes), unit: 'min' });
-    if (minutes < 1440) return t('publicProfile.respondsIn', { value: Math.round(minutes / 60), unit: 'hr' });
-    return t('publicProfile.respondsIn', { value: Math.round(minutes / 1440), unit: 'days' });
+    if (minutes < 60) return t('publicProfile.respondsIn', { value: Math.round(minutes), unit: t('publicProfile.timeUnit.min') });
+    if (minutes < 1440) return t('publicProfile.respondsIn', { value: Math.round(minutes / 60), unit: t('publicProfile.timeUnit.hr') });
+    return t('publicProfile.respondsIn', { value: Math.round(minutes / 1440), unit: t('publicProfile.timeUnit.days') });
   };
 
   const avgRating = profile?.average_rating_as_fixer;
@@ -283,7 +283,7 @@ export default function PublicProfileScreen({ route }: { route: any }) {
           )}
 
           {/* Name + verified badge */}
-          <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.sm, marginTop: spacing.md }}>
+          <View style={{ flexDirection: isRTL ? 'row-reverse' : 'row', alignItems: 'center', gap: spacing.sm, marginTop: spacing.md }}>
             <Text style={[typography.h2, { color: brandColors.textPrimary }]}>
               {profile?.full_name ?? 'User'}
             </Text>

--- a/frontend/src/screens/RequesterDashboard.tsx
+++ b/frontend/src/screens/RequesterDashboard.tsx
@@ -180,7 +180,7 @@ export default function RequesterDashboard({ navigation }: Props) {
         {latestOpenTask && (() => {
           const meta = CATEGORY_METADATA[latestOpenTask.category as keyof typeof CATEGORY_METADATA];
           return (
-            <View style={[styles.quickAccess, isRTL && styles.quickAccessRTL]}>
+            <View style={styles.quickAccess}>
               <Pressable
                 onPress={() => navigation.navigate('TaskDetails', { taskId: latestOpenTask.id })}
                 accessibilityRole="button"

--- a/frontend/src/screens/TaskDetails.tsx
+++ b/frontend/src/screens/TaskDetails.tsx
@@ -35,6 +35,7 @@ interface Bid {
     phone_number: string | null;
     payment_link: string | null;
     avatar_url: string | null;
+    verification_status?: string | null;
   };
 }
 
@@ -474,9 +475,14 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
                   >
                   <Avatar.Icon size={44} icon="account" style={{ backgroundColor: brandColors.primaryMuted }} />
                   <View style={styles.bidInfo}>
-                    <Text style={[typography.h3, { color: brandColors.textPrimary, textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
-                      {bid.fixer?.full_name || 'Fixer'}
-                    </Text>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
+                      <Text style={[typography.h3, { color: brandColors.textPrimary, textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                        {bid.fixer?.full_name || 'Fixer'}
+                      </Text>
+                      {bid.fixer?.verification_status === 'APPROVED' && (
+                        <MaterialCommunityIcons name="check-decagram" size={16} color="#29B6F6" />
+                      )}
+                    </View>
                     {bid.fixer?.average_rating_as_fixer != null ? (
                       <View style={styles.ratingRow}>
                         <StarRating rating={bid.fixer.average_rating_as_fixer} size={14} />


### PR DESCRIPTION
## Summary
- Blue verified badge (וי כחול) next to fixer name in profile, public profile, and bid list
- Top navbar and fixer hero section keep LTR layout in Hebrew mode (no position flipping)
- Response time translated to Hebrew (דק׳/שע׳/ימים instead of min/hr/days)
- Dashboard latest-task circle stays on left in RTL
- Seed data: Guy Shick marked as verified for demo

## Test plan
- [ ] Switch to Hebrew — top navbar stays in same position, only text translates
- [ ] Fixer profile: name + verified badge on left, rating on right (same as English)
- [ ] Public profile: badge next to name, response time shows Hebrew units
- [ ] Dashboard: latest task circle stays on left side
- [ ] Bid list in task details: verified badge shows next to fixer name

