### PR TITLE
fix: RTL layout flip on toolbar and fixer profile

### DIFF
--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -190,7 +190,10 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
         },
       ]}
     >
-      <View style={[styles.desktopBarInner, styles.forceLtr]}>
+      <View
+        ref={(el: unknown) => { if (el && Platform.OS === 'web') { (el as HTMLElement).dir = 'ltr'; } }}
+        style={styles.desktopBarInner}
+      >
         <View style={styles.desktopLeft}>
           <Pressable
             accessibilityRole="button"
@@ -626,8 +629,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: spacing.lg,
   },
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  forceLtr: Platform.OS === 'web' ? { direction: 'ltr' } as any : {},
   // Logo + workspace badge on the left; flex: 1 so it occupies an equal side to actions.
   desktopLeft: {
     flex: 1,

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -351,6 +351,10 @@ export default function FixerProfileScreen() {
           end={heroGradientFixer.end}
           style={[styles.profileHero, isWide && styles.profileHeroWide]}
         >
+          <View
+            ref={(el: unknown) => { if (el && Platform.OS === 'web') { (el as HTMLElement).dir = 'ltr'; } }}
+            style={styles.heroInnerRow}
+          >
           <View style={styles.avatarWrapper}>
             <Pressable
               onPress={() => profile?.avatar_url ? setViewingAvatar(true) : void pickNewAvatar()}
@@ -416,6 +420,7 @@ export default function FixerProfileScreen() {
             </Text>
           </Pressable>
 
+          </View>
         </LinearGradient>
 
         <View style={[styles.profileGrid, isWide && styles.profileGridWide]}>
@@ -930,12 +935,16 @@ const styles = StyleSheet.create({
     borderBottomWidth: 3,
     borderBottomColor: brandColors.secondary,
     overflow: 'hidden' as const,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ...(Platform.OS === 'web' ? { direction: 'ltr' } : {}) as any,
     ...shadows.md,
   },
   profileHeroWide: {
     padding: spacing.xl,
+  },
+  heroInnerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.lg,
+    flex: 1,
   },
   avatarWrapper: {
     position: 'relative',


### PR DESCRIPTION
## Summary
- `StyleSheet` `direction` property gets stripped by React Native Web, causing the toolbar and fixer profile hero to flip in RTL mode
- Fixed by using `ref` callback to set `dir='ltr'` directly on the DOM element
- Toolbar and fixer profile hero now stay in LTR layout (same positions as English) with only text translated

## Test plan
- [ ] Switch to Hebrew — top toolbar stays in same position (logo left, actions right)
- [ ] Fixer profile: avatar left, name center, rating right — same as English
- [ ] All 240 frontend tests pass