### PR TITLE
feat: verification photos, admin i18n & chat notifications

### DIFF
--- a/backend/prisma/migrations/20260614120000_add_verification_selfie/migration.sql
+++ b/backend/prisma/migrations/20260614120000_add_verification_selfie/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN "verification_selfie_url" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -101,6 +101,7 @@ model User {
   avg_response_time_minutes  Float?
   verification_status        VerificationStatus @default(NONE)
   verification_photo_url     String?
+  verification_selfie_url    String?
   is_fixer                   Boolean            @default(false)
   is_admin                   Boolean            @default(false)
   email_verified             Boolean            @default(false)

--- a/backend/src/__tests__/routes/admin.test.ts
+++ b/backend/src/__tests__/routes/admin.test.ts
@@ -161,7 +161,7 @@ describe('GET /api/admin/pending-verifications', () => {
     await request(app)
       .post('/api/users/me/verification')
       .set('Authorization', FIXER_AUTH)
-      .send({ verification_photo_url: 'https://example.com/id.jpg' });
+      .send({ verification_photo_url: 'https://example.com/id.jpg', verification_selfie_url: 'https://example.com/selfie.jpg' });
 
     __setUid('admin-uid');
     const res = await request(app)
@@ -189,7 +189,7 @@ describe('POST /api/admin/users/:id/verify', () => {
     await request(app)
       .post('/api/users/me/verification')
       .set('Authorization', FIXER_AUTH)
-      .send({ verification_photo_url: 'https://example.com/id.jpg' });
+      .send({ verification_photo_url: 'https://example.com/id.jpg', verification_selfie_url: 'https://example.com/selfie.jpg' });
     const meRes = await request(app).get('/api/users/me').set('Authorization', FIXER_AUTH);
     fixerDbId = meRes.body.user.id;
   });

--- a/backend/src/__tests__/routes/users.test.ts
+++ b/backend/src/__tests__/routes/users.test.ts
@@ -172,28 +172,34 @@ describe('POST /api/users/me/push-token', () => {
 });
 
 describe('POST /api/users/me/verification', () => {
-  it('submits verification photo', async () => {
+  const verificationPayload = {
+    verification_photo_url: 'https://example.com/id.jpg',
+    verification_selfie_url: 'https://example.com/selfie.jpg',
+  };
+
+  it('submits verification photos', async () => {
     const res = await request(app)
       .post('/api/users/me/verification')
       .set('Authorization', AUTH)
-      .send({ verification_photo_url: 'https://example.com/id.jpg' });
+      .send(verificationPayload);
     expect(res.status).toBe(200);
 
     const user = await prisma.user.findFirst({ where: { firebase_uid: 'test-uid' } });
     expect(user?.verification_status).toBe('PENDING');
     expect(user?.verification_photo_url).toBe('https://example.com/id.jpg');
+    expect(user?.verification_selfie_url).toBe('https://example.com/selfie.jpg');
   });
 
   it('returns 409 if already pending', async () => {
     await request(app)
       .post('/api/users/me/verification')
       .set('Authorization', AUTH)
-      .send({ verification_photo_url: 'https://example.com/id.jpg' });
+      .send(verificationPayload);
 
     const res = await request(app)
       .post('/api/users/me/verification')
       .set('Authorization', AUTH)
-      .send({ verification_photo_url: 'https://example.com/id2.jpg' });
+      .send(verificationPayload);
     expect(res.status).toBe(409);
   });
 
@@ -206,15 +212,23 @@ describe('POST /api/users/me/verification', () => {
     const res = await request(app)
       .post('/api/users/me/verification')
       .set('Authorization', AUTH)
-      .send({ verification_photo_url: 'https://example.com/id.jpg' });
+      .send(verificationPayload);
     expect(res.status).toBe(409);
+  });
+
+  it('returns 400 for missing selfie URL', async () => {
+    const res = await request(app)
+      .post('/api/users/me/verification')
+      .set('Authorization', AUTH)
+      .send({ verification_photo_url: 'https://example.com/id.jpg' });
+    expect(res.status).toBe(400);
   });
 
   it('returns 400 for invalid URL', async () => {
     const res = await request(app)
       .post('/api/users/me/verification')
       .set('Authorization', AUTH)
-      .send({ verification_photo_url: 'not-a-url' });
+      .send({ verification_photo_url: 'not-a-url', verification_selfie_url: 'https://example.com/selfie.jpg' });
     expect(res.status).toBe(400);
   });
 });

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -121,6 +121,7 @@ router.get(
             email: true,
             avatar_url: true,
             verification_photo_url: true,
+            verification_selfie_url: true,
             created_at: true,
           },
           orderBy: { updated_at: 'asc' },
@@ -155,19 +156,11 @@ router.post(
         data: { verification_status: status },
       });
 
-      // Notify the fixer
-      await prisma.notification.create({
-        data: {
-          user_id: user.id,
-          title: action === 'approve' ? 'Verification approved!' : 'Verification rejected',
-          body: action === 'approve'
-            ? 'Your identity has been verified. A badge will now appear on your profile.'
-            : 'Your verification was not approved. You can resubmit with a clearer photo.',
-          type: action === 'approve' ? 'VERIFICATION_APPROVED' : 'VERIFICATION_REJECTED',
-          related_entity_id: user.id,
-          related_entity_type: 'user',
-        },
-      });
+      // Notify the fixer (i18n-aware)
+      const ntKey = action === 'approve' ? 'verificationApproved' : 'verificationRejected';
+      const notifType = action === 'approve' ? 'VERIFICATION_APPROVED' : 'VERIFICATION_REJECTED';
+      const nt = await getNotificationText(user.id, ntKey);
+      await sendNotification(user.id, nt.title, nt.body, notifType, user.id, 'user', 'fixer');
 
       res.json({ message: `Verification ${action}d` });
     } catch (err) {

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -45,10 +45,16 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 
 // PUT /api/notifications/read-all — mark all notifications as read
 // Must be defined BEFORE /:id/read so Express doesn't match "read-all" as :id
+// Optional ?mode=requester|fixer — only marks notifications for that role as read
 router.put('/read-all', async (req: Request, res: Response, next: NextFunction) => {
   try {
+    const mode = req.query.mode as string | undefined;
+    const modeFilter = (mode === 'requester' || mode === 'fixer')
+      ? { OR: [{ user_role: mode }, { user_role: null }] }
+      : {};
+
     await prisma.notification.updateMany({
-      where: { user_id: req.user.id, is_read: false },
+      where: { user_id: req.user.id, is_read: false, ...modeFilter },
       data: { is_read: true },
     });
 

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -247,6 +247,7 @@ router.post('/me/verification', validate(submitVerificationSchema), async (req: 
       data: {
         verification_status: 'PENDING',
         verification_photo_url: req.body.verification_photo_url,
+        verification_selfie_url: req.body.verification_selfie_url,
       },
     });
     res.json({ message: 'Verification submitted' });

--- a/backend/src/schemas.ts
+++ b/backend/src/schemas.ts
@@ -86,6 +86,7 @@ export const createPortfolioItemSchema = z.object({
 
 export const submitVerificationSchema = z.object({
   verification_photo_url: z.url(),
+  verification_selfie_url: z.url(),
 });
 
 export const completionPhotosSchema = z.object({

--- a/backend/src/socket/index.ts
+++ b/backend/src/socket/index.ts
@@ -48,6 +48,10 @@ export function initSocket(httpServer: HttpServer): SocketServer {
   io.on('connection', (socket: Socket) => {
     const authedSocket = socket as AuthenticatedSocket;
 
+    // Join a personal room so we can push events (e.g. notification updates)
+    // to a specific user regardless of which chat rooms they've joined
+    socket.join(`user_${authedSocket.userId}`);
+
     // join_chat — only the task requester or the accepted fixer may join
     socket.on('join_chat', async (taskId: string) => {
       try {
@@ -124,7 +128,33 @@ export function initSocket(httpServer: HttpServer): SocketServer {
 
           io.to(`task_chat_${taskId}`).emit('receive_message', message);
 
-          // Push-notify recipient only if they are not currently in the room
+          // Always create/update a bell notification (deduplicated per task)
+          const existingNotif = await prisma.notification.findFirst({
+            where: {
+              user_id: recipientId,
+              type: NotificationType.NEW_MESSAGE,
+              related_entity_id: taskId,
+              is_read: false,
+            },
+          });
+
+          const recipientRole = recipientId === task.requester_id ? 'requester' : 'fixer';
+          const senderName = message.sender.full_name;
+          const msgNt = await getNotificationText(recipientId, 'newMessage', { senderName, taskTitle: task.title });
+
+          if (existingNotif) {
+            await prisma.notification.update({
+              where: { id: existingNotif.id },
+              data: { title: msgNt.title, body: msgNt.body },
+            });
+          } else {
+            await sendNotification(recipientId, msgNt.title, msgNt.body, NotificationType.NEW_MESSAGE, taskId, 'Task', recipientRole);
+          }
+
+          // Notify recipient's personal room so bell badge refreshes instantly
+          io.to(`user_${recipientId}`).emit('notification_update');
+
+          // Send mobile push only if recipient is not currently in this chat room
           const room = io.sockets.adapter.rooms.get(`task_chat_${taskId}`);
           const recipientInRoom = room
             ? [...room].some((sid) => {
@@ -134,9 +164,24 @@ export function initSocket(httpServer: HttpServer): SocketServer {
             : false;
 
           if (!recipientInRoom) {
-            const recipientRole = recipientId === task.requester_id ? 'requester' : 'fixer';
-            const msgNt = await getNotificationText(recipientId, 'newMessage', {});
-            await sendNotification(recipientId, msgNt.title, content.trim(), NotificationType.NEW_MESSAGE, taskId, 'Task', recipientRole);
+            try {
+              const user = await prisma.user.findUnique({
+                where: { id: recipientId },
+                select: { push_token: true },
+              });
+              const { Expo } = await import('expo-server-sdk');
+              if (user?.push_token && Expo.isExpoPushToken(user.push_token)) {
+                const expo = new Expo();
+                await expo.sendPushNotificationsAsync([{
+                  to: user.push_token,
+                  title: msgNt.title,
+                  body: msgNt.body,
+                  data: { type: NotificationType.NEW_MESSAGE, relatedEntityId: taskId, relatedEntityType: 'Task' },
+                }]);
+              }
+            } catch (pushErr) {
+              console.error('[socket] push notification error', pushErr);
+            }
           }
         } catch (err) {
           console.error('[socket] send_message error', err);

--- a/backend/src/utils/notificationMessages.ts
+++ b/backend/src/utils/notificationMessages.ts
@@ -178,13 +178,13 @@ const messages: Record<string, Record<Lang, (vars: Record<string, string>) => No
     }),
   },
   newMessage: {
-    en: () => ({
-      title: 'New message',
-      body: '',
+    en: (v) => ({
+      title: `New message from ${v.senderName}`,
+      body: `Regarding "${v.taskTitle}"`,
     }),
-    he: () => ({
-      title: 'הודעה חדשה',
-      body: '',
+    he: (v) => ({
+      title: `הודעה חדשה מ-${v.senderName}`,
+      body: `בנוגע ל-"${v.taskTitle}"`,
     }),
   },
   certificationApproved: {
@@ -195,6 +195,26 @@ const messages: Record<string, Record<Lang, (vars: Record<string, string>) => No
     he: (v) => ({
       title: 'ההסמכה אושרה!',
       body: `ההסמכה שלך ב${v.category} אושרה. תג יופיע כעת בפרופיל שלך.`,
+    }),
+  },
+  verificationApproved: {
+    en: () => ({
+      title: 'Verification Approved!',
+      body: 'Your identity has been verified. A badge will now appear on your profile.',
+    }),
+    he: () => ({
+      title: 'האימות אושר!',
+      body: 'זהותך אומתה. תג יופיע כעת בפרופיל שלך.',
+    }),
+  },
+  verificationRejected: {
+    en: () => ({
+      title: 'Verification Rejected',
+      body: 'Your verification was not approved. You can resubmit with a clearer photo.',
+    }),
+    he: () => ({
+      title: 'האימות נדחה',
+      body: 'האימות שלך לא אושר. תוכל לשלוח שוב עם תמונה ברורה יותר.',
     }),
   },
   certificationRejected: {

--- a/frontend/src/components/HamburgerMenu.tsx
+++ b/frontend/src/components/HamburgerMenu.tsx
@@ -35,6 +35,7 @@ interface HamburgerMenuProps {
   onNotificationsPress?: () => void;
   onSettingsPress: () => void;
   notificationCount?: number;
+  otherModeBadge?: number;
 }
 
 export default function HamburgerMenu({
@@ -53,6 +54,7 @@ export default function HamburgerMenu({
   onNotificationsPress,
   onSettingsPress,
   notificationCount = 0,
+  otherModeBadge = 0,
 }: HamburgerMenuProps) {
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
@@ -121,6 +123,7 @@ export default function HamburgerMenu({
                 icon={isRTL ? 'chevron-right' : 'chevron-left'}
                 label={t('menu.openRequester')}
                 description={t('menu.backToRequester')}
+                badge={otherModeBadge > 0 ? String(otherModeBadge) : undefined}
                 isRTL={isRTL}
                 onPress={() => { onModeChange('requester'); (onRequesterHomePress ?? (() => {}))(); onClose(); }}
               />
@@ -233,7 +236,13 @@ export default function HamburgerMenu({
                     {fixerActivated ? t('menu.fixerWorkspaceDesc') : t('menu.becomeFixerDesc')}
                   </Text>
                 </View>
-                <MaterialCommunityIcons name={isRTL ? 'chevron-left' : 'chevron-right'} size={20} color={brandColors.textMuted} />
+                {otherModeBadge > 0 ? (
+                  <View style={styles.menuBadge}>
+                    <Text style={styles.menuBadgeText}>{otherModeBadge}</Text>
+                  </View>
+                ) : (
+                  <MaterialCommunityIcons name={isRTL ? 'chevron-left' : 'chevron-right'} size={20} color={brandColors.textMuted} />
+                )}
               </Pressable>
             </>
           )}

--- a/frontend/src/context/NotificationContext.tsx
+++ b/frontend/src/context/NotificationContext.tsx
@@ -34,10 +34,10 @@ interface NotificationContextValue {
   notifications: AppNotification[];
   loading: boolean;
   error: string | null;
-  unreadCount: (typeFilter?: string[]) => number;
+  unreadCount: (typeFilter?: string[], roleFilter?: string) => number;
   refetch: () => Promise<void>;
   markAsRead: (id: string) => Promise<void>;
-  markAllAsRead: () => Promise<void>;
+  markAllAsRead: (mode?: string) => Promise<void>;
   deleteOne: (id: string) => Promise<void>;
   deleteAll: () => Promise<void>;
   getFiltered: (typeFilter?: string[]) => AppNotification[];
@@ -76,10 +76,15 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     }
   }, [fetchNotifications]);
 
-  const markAllAsRead = useCallback(async () => {
-    setNotifications((prev) => prev.map((n) => ({ ...n, is_read: true })));
+  const markAllAsRead = useCallback(async (mode?: string) => {
+    setNotifications((prev) => prev.map((n) => {
+      if (mode && n.user_role !== null && n.user_role !== mode) return n;
+      return { ...n, is_read: true };
+    }));
     try {
-      await api.put('/api/notifications/read-all');
+      const params: Record<string, string> = {};
+      if (mode) params.mode = mode;
+      await api.put('/api/notifications/read-all', null, { params });
     } catch {
       fetchNotifications();
     }
@@ -104,10 +109,13 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   }, [fetchNotifications]);
 
   const unreadCount = useCallback(
-    (typeFilter?: string[]) => {
-      const filtered = typeFilter
+    (typeFilter?: string[], roleFilter?: string) => {
+      let filtered = typeFilter
         ? notifications.filter((n) => typeFilter.includes(n.type))
         : notifications;
+      if (roleFilter) {
+        filtered = filtered.filter((n) => n.user_role === roleFilter || n.user_role === null);
+      }
       return filtered.filter((n) => !n.is_read).length;
     },
     [notifications],
@@ -134,21 +142,27 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     return () => { if (intervalRef.current) clearInterval(intervalRef.current); };
   }, [fetchNotifications]);
 
-  // Global socket listener — refresh bell badge instantly on any incoming message,
-  // regardless of which screen the user is currently on.
+  // Global socket listener — refresh bell badge instantly on notification_update
+  // (sent to the user's personal room) or on any incoming message.
   useEffect(() => {
     let mounted = true;
     let cleanup: (() => void) | null = null;
 
     void (async () => {
       const socket = await getSocket();
-      const handler = (msg: { sender?: { firebase_uid?: string } }) => {
-        // Only refresh notifications for messages received from someone else
+      const notifHandler = () => {
+        if (mounted) void fetchNotifications();
+      };
+      const msgHandler = (msg: { sender?: { firebase_uid?: string } }) => {
         const sentByMe = msg?.sender?.firebase_uid === auth.currentUser?.uid;
         if (mounted && !sentByMe) void fetchNotifications();
       };
-      socket.on('receive_message', handler);
-      cleanup = () => socket.off('receive_message', handler);
+      socket.on('notification_update', notifHandler);
+      socket.on('receive_message', msgHandler);
+      cleanup = () => {
+        socket.off('notification_update', notifHandler);
+        socket.off('receive_message', msgHandler);
+      };
     })();
 
     return () => {

--- a/frontend/src/context/__tests__/NotificationContext.test.tsx
+++ b/frontend/src/context/__tests__/NotificationContext.test.tsx
@@ -89,7 +89,7 @@ describe('NotificationContext', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => { await result.current.markAllAsRead(); });
-    expect(mockApi.put).toHaveBeenCalledWith('/api/notifications/read-all');
+    expect(mockApi.put).toHaveBeenCalledWith('/api/notifications/read-all', null, { params: {} });
     expect(result.current.notifications.every((n) => n.is_read)).toBe(true);
   });
 

--- a/frontend/src/context/__tests__/NotificationContext.test.tsx
+++ b/frontend/src/context/__tests__/NotificationContext.test.tsx
@@ -5,7 +5,7 @@ import api from '../../api/axiosInstance';
 
 const mockApi = api as jest.Mocked<typeof api>;
 
-const makeNotif = (overrides: Partial<{ id: string; type: string; is_read: boolean }> = {}) => ({
+const makeNotif = (overrides: Partial<{ id: string; type: string; is_read: boolean; user_role: string | null }> = {}) => ({
   id: overrides.id ?? 'n1',
   user_id: 'u1',
   title: 'Hello',
@@ -13,6 +13,7 @@ const makeNotif = (overrides: Partial<{ id: string; type: string; is_read: boole
   type: overrides.type ?? 'NEW_BID',
   related_entity_id: 'task-1',
   related_entity_type: 'Task',
+  user_role: overrides.user_role !== undefined ? overrides.user_role : null,
   is_read: overrides.is_read ?? false,
   created_at: new Date().toISOString(),
   updated_at: new Date().toISOString(),
@@ -207,6 +208,42 @@ describe('NotificationContext', () => {
     const callsBefore = mockApi.get.mock.calls.length;
     await act(async () => { await result.current.deleteOne('n1'); });
     await waitFor(() => expect(mockApi.get.mock.calls.length).toBeGreaterThan(callsBefore));
+  });
+
+  it('unreadCount filters by roleFilter when provided', async () => {
+    const notifs = [
+      makeNotif({ id: 'n1', type: 'NEW_MESSAGE', user_role: 'fixer', is_read: false }),
+      makeNotif({ id: 'n2', type: 'NEW_MESSAGE', user_role: 'requester', is_read: false }),
+      makeNotif({ id: 'n3', type: 'NEW_BID', user_role: null, is_read: false }),
+    ];
+    mockApi.get.mockResolvedValue({ data: { notifications: notifs } });
+
+    const { result } = renderHook(() => useNotificationContext(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // fixer role: n1 (fixer) + n3 (null) = 2
+    expect(result.current.unreadCount(['NEW_MESSAGE', 'NEW_BID'], 'fixer')).toBe(2);
+    // requester role: n2 (requester) + n3 (null) = 2
+    expect(result.current.unreadCount(['NEW_MESSAGE', 'NEW_BID'], 'requester')).toBe(2);
+    // only NEW_MESSAGE + fixer: n1 only = 1
+    expect(result.current.unreadCount(['NEW_MESSAGE'], 'fixer')).toBe(1);
+  });
+
+  it('markAllAsRead with mode only marks matching role notifications', async () => {
+    const notifs = [
+      makeNotif({ id: 'n1', type: 'NEW_MESSAGE', user_role: 'fixer', is_read: false }),
+      makeNotif({ id: 'n2', type: 'NEW_MESSAGE', user_role: 'requester', is_read: false }),
+    ];
+    mockApi.get.mockResolvedValue({ data: { notifications: notifs } });
+
+    const { result } = renderHook(() => useNotificationContext(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => { await result.current.markAllAsRead('fixer'); });
+    expect(mockApi.put).toHaveBeenCalledWith('/api/notifications/read-all', null, { params: { mode: 'fixer' } });
+    // n1 (fixer) should be read, n2 (requester) should remain unread
+    expect(result.current.notifications.find((n) => n.id === 'n1')?.is_read).toBe(true);
+    expect(result.current.notifications.find((n) => n.id === 'n2')?.is_read).toBe(false);
   });
 
   it('refetches (rollback) when deleteAll API call fails', async () => {

--- a/frontend/src/hooks/__tests__/useUnreadMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useUnreadMessages.test.ts
@@ -25,12 +25,12 @@ describe('useUnreadMessages', () => {
     mockApi.get.mockResolvedValue({ data: { conversations: [] } });
 
     const { result } = renderHook(() => useUnreadMessages());
-    await waitFor(() => expect(mockApi.get).toHaveBeenCalledWith('/api/conversations'));
+    await waitFor(() => expect(mockApi.get).toHaveBeenCalledWith('/api/conversations', { params: {} }));
 
     expect(result.current.unreadCount).toBe(0);
   });
 
-  it('sums unreadCount only from IN_PROGRESS conversations', async () => {
+  it('counts conversations with unread messages from IN_PROGRESS tasks', async () => {
     mockApi.get.mockResolvedValue({
       data: {
         conversations: [
@@ -42,10 +42,11 @@ describe('useUnreadMessages', () => {
     });
 
     const { result } = renderHook(() => useUnreadMessages());
-    await waitFor(() => expect(result.current.unreadCount).toBe(8));
+    // 2 conversations with unread (t1, t2), not sum of messages (8)
+    await waitFor(() => expect(result.current.unreadCount).toBe(2));
   });
 
-  it('excludes unread counts from non-IN_PROGRESS conversations', async () => {
+  it('excludes non-IN_PROGRESS conversations from count', async () => {
     mockApi.get.mockResolvedValue({
       data: {
         conversations: [
@@ -58,14 +59,15 @@ describe('useUnreadMessages', () => {
     });
 
     const { result } = renderHook(() => useUnreadMessages());
-    await waitFor(() => expect(result.current.unreadCount).toBe(3));
+    // Only t1 is IN_PROGRESS with unread → 1 conversation
+    await waitFor(() => expect(result.current.unreadCount).toBe(1));
   });
 
   it('refetch function updates the count', async () => {
     mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 2, taskStatus: 'IN_PROGRESS' }] } });
 
     const { result } = renderHook(() => useUnreadMessages());
-    await waitFor(() => expect(result.current.unreadCount).toBe(2));
+    await waitFor(() => expect(result.current.unreadCount).toBe(1));
 
     mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 0, taskStatus: 'IN_PROGRESS' }] } });
     await act(async () => { await result.current.refetch(); });

--- a/frontend/src/hooks/__tests__/useUnreadMessages.test.ts
+++ b/frontend/src/hooks/__tests__/useUnreadMessages.test.ts
@@ -84,6 +84,30 @@ describe('useUnreadMessages', () => {
     expect(result.current.unreadCount).toBe(0);
   });
 
+  it('passes mode param to API when provided', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { conversations: [{ taskId: 't1', unreadCount: 1, taskStatus: 'IN_PROGRESS' }] },
+    });
+
+    const { result } = renderHook(() => useUnreadMessages('fixer'));
+    await waitFor(() => {
+      expect(mockApi.get).toHaveBeenCalledWith('/api/conversations', { params: { mode: 'fixer' } });
+      expect(result.current.unreadCount).toBe(1);
+    });
+  });
+
+  it('passes requester mode param to API', async () => {
+    mockApi.get.mockResolvedValue({
+      data: { conversations: [{ taskId: 't1', unreadCount: 2, taskStatus: 'IN_PROGRESS' }] },
+    });
+
+    const { result } = renderHook(() => useUnreadMessages('requester'));
+    await waitFor(() => {
+      expect(mockApi.get).toHaveBeenCalledWith('/api/conversations', { params: { mode: 'requester' } });
+      expect(result.current.unreadCount).toBe(1);
+    });
+  });
+
   it('listens to socket events for real-time updates', async () => {
     mockApi.get.mockResolvedValue({ data: { conversations: [{ taskId: 't1', unreadCount: 1 }] } });
 

--- a/frontend/src/hooks/useUnreadMessages.ts
+++ b/frontend/src/hooks/useUnreadMessages.ts
@@ -6,27 +6,31 @@ import { auth } from '../config/firebase';
 const POLL_INTERVAL = 5_000;
 
 /**
- * Tracks total unread message count across all conversations.
+ * Tracks total unread message count across conversations.
+ * Accepts an optional mode ('requester' | 'fixer') to filter by role.
  * Refreshes on socket `receive_message` events and periodically.
  */
-export function useUnreadMessages() {
+export function useUnreadMessages(mode?: 'requester' | 'fixer') {
   const [unreadCount, setUnreadCount] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetch = useCallback(async () => {
     if (!auth.currentUser) return;
     try {
-      const res = await api.get('/api/conversations');
+      const params: Record<string, string> = {};
+      if (mode) params.mode = mode;
+      const res = await api.get('/api/conversations', { params });
       const conversations: { unreadCount: number; taskStatus?: string }[] = res.data.conversations ?? [];
-      // Only count unread messages from active (IN_PROGRESS) conversations
+      // Count conversations with unread messages (not individual messages)
+      // so multiple messages from the same person count as one badge unit
       const total = conversations
-        .filter((c) => c.taskStatus === 'IN_PROGRESS')
-        .reduce((sum, c) => sum + c.unreadCount, 0);
+        .filter((c) => c.taskStatus === 'IN_PROGRESS' && c.unreadCount > 0)
+        .length;
       setUnreadCount(total);
     } catch {
       // non-fatal
     }
-  }, []);
+  }, [mode]);
 
   useEffect(() => {
     void fetch();

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1035,8 +1035,12 @@
       "verifiedMsg": "Your identity has been verified. A badge appears on your public profile.",
       "pending": "Pending review",
       "pendingMsg": "Your verification photo is being reviewed by an admin.",
-      "uploadMsg": "Upload a photo of your ID to get a verified badge on your profile. This helps requesters trust you.",
-      "uploadBtn": "Upload ID Photo"
+      "uploadMsg": "Upload a photo of your ID and a selfie to get a verified badge on your profile. This helps requesters trust you.",
+      "startBtn": "Start Verification",
+      "pickPhotosMsg": "Upload a photo of your ID and a selfie of your face. Both are required.",
+      "idLabel": "ID Photo",
+      "selfieLabel": "Selfie",
+      "submitBtn": "Submit for Review"
     },
     "certifications": {
       "kicker": "Credentials",
@@ -1650,6 +1654,55 @@
     }
   },
   "admin": {
+    "header": {
+      "kicker": "FixIt Admin",
+      "title": "Review Moderation"
+    },
+    "tabs": {
+      "reviews": "Reviews ({{count}})",
+      "verifications": "Verifications ({{count}})",
+      "certifications": "Certifications ({{count}})"
+    },
+    "reviews": {
+      "reviewer": "Reviewer",
+      "reviewee": "Reviewee",
+      "task": "Task: {{title}}",
+      "reports": "Reports ({{count}}):",
+      "by": "by {{name}}",
+      "hideReview": "Hide Review",
+      "dismiss": "Dismiss"
+    },
+    "verifications": {
+      "reject": "Reject",
+      "approve": "Approve",
+      "idPhoto": "ID Photo",
+      "selfie": "Selfie",
+      "submitted": "Submitted: {{date}}"
+    },
+    "certifications": {
+      "reject": "Reject",
+      "approve": "Approve",
+      "submitted": "Submitted: {{date}}"
+    },
+    "reasons": {
+      "SPAM": "Spam",
+      "OFFENSIVE": "Offensive",
+      "MISLEADING": "Misleading",
+      "OTHER": "Other"
+    },
+    "categories": {
+      "ELECTRICITY": "Electricity",
+      "PLUMBING": "Plumbing"
+    },
+    "empty": {
+      "reviewsTitle": "All clear!",
+      "reviewsMessage": "No flagged reviews to moderate.",
+      "verificationsTitle": "No pending verifications",
+      "verificationsMessage": "All verification requests have been handled.",
+      "certificationsTitle": "No pending certifications",
+      "certificationsMessage": "All certification requests have been handled."
+    },
+    "loading": "Loading flagged reviews...",
     "errors": {
       "loadFlagged": "Failed to load flagged reviews",
       "hideReview": "Failed to hide review",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -661,6 +661,7 @@
       "markCompleted": "Mark as Completed",
       "payFixer": "Pay Fixer",
       "confirmPayment": "Confirm Payment",
+      "paidCash": "Paid in Cash",
       "leaveReview": "Leave a Review",
       "editTask": "Edit Task",
       "chatWithBidder": "Chat"

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -1041,8 +1041,12 @@
       "verifiedMsg": "זהותך אומתה. תג מופיע בפרופיל הציבורי שלך.",
       "pending": "ממתין לסקירה",
       "pendingMsg": "תמונת האימות שלך נמצאת בסקירה על ידי מנהל.",
-      "uploadMsg": "העלה תמונה של תעודת הזהות שלך כדי לקבל תג מאומת בפרופיל שלך. זה עוזר למזמינים לבטוח בך.",
-      "uploadBtn": "העלה תמונת תעודת זהות"
+      "uploadMsg": "העלה תמונה של תעודת הזהות שלך וסלפי כדי לקבל תג מאומת בפרופיל שלך. זה עוזר למזמינים לבטוח בך.",
+      "startBtn": "התחל אימות",
+      "pickPhotosMsg": "העלה תמונה של תעודת הזהות שלך וסלפי של הפנים שלך. שניהם נדרשים.",
+      "idLabel": "תעודת זהות",
+      "selfieLabel": "סלפי",
+      "submitBtn": "שלח לבדיקה"
     },
     "certifications": {
       "kicker": "הסמכות",
@@ -1664,6 +1668,55 @@
     }
   },
   "admin": {
+    "header": {
+      "kicker": "FixIt ניהול",
+      "title": "ניהול ביקורות"
+    },
+    "tabs": {
+      "reviews": "ביקורות ({{count}})",
+      "verifications": "אימותים ({{count}})",
+      "certifications": "הסמכות ({{count}})"
+    },
+    "reviews": {
+      "reviewer": "מבקר",
+      "reviewee": "מבוקר",
+      "task": "משימה: {{title}}",
+      "reports": "דיווחים ({{count}}):",
+      "by": "על ידי {{name}}",
+      "hideReview": "הסתר ביקורת",
+      "dismiss": "דחה"
+    },
+    "verifications": {
+      "reject": "דחה",
+      "approve": "אשר",
+      "idPhoto": "תעודת זהות",
+      "selfie": "סלפי",
+      "submitted": "הוגש: {{date}}"
+    },
+    "certifications": {
+      "reject": "דחה",
+      "approve": "אשר",
+      "submitted": "הוגש: {{date}}"
+    },
+    "reasons": {
+      "SPAM": "ספאם",
+      "OFFENSIVE": "פוגעני",
+      "MISLEADING": "מטעה",
+      "OTHER": "אחר"
+    },
+    "categories": {
+      "ELECTRICITY": "חשמל",
+      "PLUMBING": "אינסטלציה"
+    },
+    "empty": {
+      "reviewsTitle": "הכל נקי!",
+      "reviewsMessage": "אין ביקורות מסומנות לניהול.",
+      "verificationsTitle": "אין אימותים ממתינים",
+      "verificationsMessage": "כל בקשות האימות טופלו.",
+      "certificationsTitle": "אין הסמכות ממתינות",
+      "certificationsMessage": "כל בקשות ההסמכה טופלו."
+    },
+    "loading": "טוען ביקורות מסומנות...",
     "errors": {
       "loadFlagged": "טעינת הביקורות המסומנות נכשלה",
       "hideReview": "הסתרת הביקורת נכשלה",

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -661,6 +661,7 @@
       "markCompleted": "סמן כהושלם",
       "payFixer": "שלם לפיקסר",
       "confirmPayment": "אשר תשלום",
+      "paidCash": "שולם במזומן",
       "leaveReview": "כתוב ביקורת",
       "editTask": "ערוך משימה",
       "chatWithBidder": "שוחח"

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -82,8 +82,8 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
   const mode: Mode = route.name === 'FixerMode' ? 'fixer' : 'requester';
   const typeFilter = mode === 'fixer' ? FIXER_NOTIF_TYPES : REQUESTER_NOTIF_TYPES;
   const { unreadCount } = useNotificationContext();
-  const notificationCount = unreadCount(typeFilter);
-  const { unreadCount: unreadMsgCount } = useUnreadMessages();
+  const notificationCount = unreadCount(typeFilter, mode);
+  const { unreadCount: unreadMsgCount } = useUnreadMessages(mode);
   const { language, changeLanguage, isRTL } = useLanguage();
   const { t } = useTranslation();
 
@@ -176,7 +176,6 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
         { label: t('nav.home'),     screen: 'Dashboard', icon: 'home-outline' },
         { label: t('nav.myTasks'),  screen: 'MyTasks',   icon: 'clipboard-list-outline' },
         { label: t('nav.messages'), screen: 'Messages',  icon: 'chat-outline' },
-        { label: t('nav.account'),  screen: 'Profile',   icon: 'account-circle-outline' },
       ];
 
   return (
@@ -345,7 +344,7 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
   const mode: Mode = route.name === 'FixerMode' ? 'fixer' : 'requester';
   const typeFilter = mode === 'fixer' ? FIXER_NOTIF_TYPES : REQUESTER_NOTIF_TYPES;
   const { unreadCount } = useNotificationContext();
-  const notificationCount = unreadCount(typeFilter);
+  const notificationCount = unreadCount(typeFilter, mode);
   const { language, changeLanguage } = useLanguage();
 
   useEffect(() => {

--- a/frontend/src/navigation/AppNavigator.tsx
+++ b/frontend/src/navigation/AppNavigator.tsx
@@ -80,10 +80,15 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
   const [activeScreenOverride, setActiveScreenOverride] = useState<string | null>(null);
   const [fixerActivated, setFixerActivated] = useState(true); // default true avoids flicker
   const mode: Mode = route.name === 'FixerMode' ? 'fixer' : 'requester';
+  const otherMode: Mode = mode === 'fixer' ? 'requester' : 'fixer';
   const typeFilter = mode === 'fixer' ? FIXER_NOTIF_TYPES : REQUESTER_NOTIF_TYPES;
+  const otherTypeFilter = mode === 'fixer' ? REQUESTER_NOTIF_TYPES : FIXER_NOTIF_TYPES;
   const { unreadCount } = useNotificationContext();
   const notificationCount = unreadCount(typeFilter, mode);
+  const otherModeNotifCount = unreadCount(otherTypeFilter, otherMode);
   const { unreadCount: unreadMsgCount } = useUnreadMessages(mode);
+  const { unreadCount: otherMsgCount } = useUnreadMessages(otherMode);
+  const otherModeBadge = otherModeNotifCount + otherMsgCount;
   const { language, changeLanguage, isRTL } = useLanguage();
   const { t } = useTranslation();
 
@@ -316,6 +321,11 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
                 {fixerActivated ? t('nav.workspace.openFixer') : t('nav.workspace.becomeFixer')}
               </Text>
               {!isRTL && fixerActivated && <MaterialCommunityIcons name="chevron-right" size={13} color={brandColors.secondaryDark} />}
+              {otherModeBadge > 0 && (
+                <View style={styles.inlineBadge}>
+                  <Text style={styles.inlineBadgeText}>{otherModeBadge > 9 ? '9+' : otherModeBadge}</Text>
+                </View>
+              )}
             </Pressable>
           ) : (
             <Pressable
@@ -327,6 +337,11 @@ function DesktopHeader({ navigation, route }: BottomTabHeaderProps) {
             >
               <MaterialCommunityIcons name={isRTL ? 'chevron-right' : 'chevron-left'} size={14} color={brandColors.primary} />
               <Text style={styles.desktopBackHomeBtnText}>{t('nav.workspace.openRequester')}</Text>
+              {otherModeBadge > 0 && (
+                <View style={styles.inlineBadge}>
+                  <Text style={styles.inlineBadgeText}>{otherModeBadge > 9 ? '9+' : otherModeBadge}</Text>
+                </View>
+              )}
             </Pressable>
           )}
         </View>
@@ -342,9 +357,14 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [fixerActivated, setFixerActivated] = useState(true);
   const mode: Mode = route.name === 'FixerMode' ? 'fixer' : 'requester';
+  const otherMode: Mode = mode === 'fixer' ? 'requester' : 'fixer';
   const typeFilter = mode === 'fixer' ? FIXER_NOTIF_TYPES : REQUESTER_NOTIF_TYPES;
+  const otherTypeFilter = mode === 'fixer' ? REQUESTER_NOTIF_TYPES : FIXER_NOTIF_TYPES;
   const { unreadCount } = useNotificationContext();
   const notificationCount = unreadCount(typeFilter, mode);
+  const otherModeNotifCount = unreadCount(otherTypeFilter, otherMode);
+  const { unreadCount: otherMsgCount } = useUnreadMessages(otherMode);
+  const otherModeBadge = otherModeNotifCount + otherMsgCount;
   const { language, changeLanguage } = useLanguage();
 
   useEffect(() => {
@@ -506,6 +526,7 @@ function MobileHeader({ navigation, route }: BottomTabHeaderProps) {
         onNotificationsPress={openNotifications}
         onSettingsPress={openSettings}
         notificationCount={notificationCount}
+        otherModeBadge={otherModeBadge}
       />
     </>
   );
@@ -842,6 +863,24 @@ const styles = StyleSheet.create({
     fontWeight: '800' as const,
     color: brandColors.white,
     lineHeight: 12,
+  },
+
+  // Inline badge (for workspace switcher buttons)
+  inlineBadge: {
+    minWidth: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: brandColors.danger,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+    marginLeft: spacing.xs,
+  },
+  inlineBadgeText: {
+    color: '#fff',
+    fontSize: 10,
+    fontWeight: '700',
+    lineHeight: 14,
   },
 
   // Notification badge

--- a/frontend/src/navigation/FixerTabs.tsx
+++ b/frontend/src/navigation/FixerTabs.tsx
@@ -31,7 +31,7 @@ export default function FixerTabs() {
   const { t } = useTranslation();
   const { width } = useWindowDimensions();
   const useDesktopNavigation = Platform.OS === 'web' && width >= 900;
-  const { unreadCount } = useUnreadMessages();
+  const { unreadCount } = useUnreadMessages('fixer');
 
   return (
     <Tab.Navigator

--- a/frontend/src/navigation/RequesterTabs.tsx
+++ b/frontend/src/navigation/RequesterTabs.tsx
@@ -40,7 +40,7 @@ export default function RequesterTabs() {
   const { t } = useTranslation();
   const { width } = useWindowDimensions();
   const useDesktopNavigation = Platform.OS === 'web' && width >= 900;
-  const { unreadCount } = useUnreadMessages();
+  const { unreadCount } = useUnreadMessages('requester');
   const [tutorialState, setTutorialState] = useState<'checking' | 'show' | 'done'>('checking');
 
   useEffect(() => {

--- a/frontend/src/screens/AdminScreen.tsx
+++ b/frontend/src/screens/AdminScreen.tsx
@@ -19,6 +19,7 @@ import LoadingScreen from '../components/LoadingScreen';
 import EmptyState from '../components/EmptyState';
 import { FButton, FCard } from '../components/ui';
 import { useTranslation } from 'react-i18next';
+import { useLanguage } from '../context/LanguageContext';
 import { brandColors, spacing, radii, typography, shadows } from '../theme';
 
 type AdminTab = 'reviews' | 'verifications' | 'certifications';
@@ -49,6 +50,7 @@ interface PendingVerification {
   email: string;
   avatar_url: string | null;
   verification_photo_url: string | null;
+  verification_selfie_url: string | null;
   created_at: string;
 }
 
@@ -66,16 +68,9 @@ interface PendingCertification {
   };
 }
 
-const CERT_CATEGORY_LABELS: Record<string, { label: string; color: string }> = {
-  ELECTRICITY: { label: 'Electricity', color: '#D4A017' },
-  PLUMBING: { label: 'Plumbing', color: '#0D7C6E' },
-};
-
-const REASON_LABELS: Record<string, string> = {
-  SPAM: 'Spam',
-  OFFENSIVE: 'Offensive',
-  MISLEADING: 'Misleading',
-  OTHER: 'Other',
+const CERT_CATEGORY_COLORS: Record<string, string> = {
+  ELECTRICITY: '#D4A017',
+  PLUMBING: '#0D7C6E',
 };
 
 function StarRow({ rating }: { rating: number }) {
@@ -95,6 +90,7 @@ function StarRow({ rating }: { rating: number }) {
 
 export default function AdminScreen() {
   const { t } = useTranslation();
+  const { language, changeLanguage } = useLanguage();
   const [activeTab, setActiveTab] = useState<AdminTab>('reviews');
   const [reviews, setReviews] = useState<FlaggedReview[]>([]);
   const [verifications, setVerifications] = useState<PendingVerification[]>([]);
@@ -210,33 +206,41 @@ export default function AdminScreen() {
     await signOut(auth);
   };
 
-  if (loading) return <LoadingScreen label="Loading flagged reviews..." />;
+  if (loading) return <LoadingScreen label={t('admin.loading')} />;
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
+      <View style={[styles.header, { direction: 'ltr' }]}>
         <View style={styles.headerLeft}>
           <View style={styles.headerIconShell}>
             <MaterialCommunityIcons name="shield-account" size={20} color={brandColors.secondary} />
           </View>
-          <View>
-            <Text style={styles.headerKicker}>FixIt Admin</Text>
-            <Text style={styles.headerTitle}>Review Moderation</Text>
-          </View>
+          <Text style={styles.headerTitle}>{t('admin.header.kicker')}</Text>
         </View>
-        <Pressable onPress={() => void handleLogout()} style={styles.logoutBtn}>
-          <MaterialCommunityIcons name="logout" size={18} color={brandColors.danger} />
-        </Pressable>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.md }}>
+          <Pressable
+            onPress={() => void changeLanguage(language === 'en' ? 'he' : 'en')}
+            style={styles.langBtn}
+          >
+            <MaterialCommunityIcons name="web" size={22} color={brandColors.secondary} />
+            <View style={styles.langBadge}>
+              <Text style={styles.langBadgeText}>{language === 'en' ? 'EN' : 'עב'}</Text>
+            </View>
+          </Pressable>
+          <Pressable onPress={() => void handleLogout()} style={styles.logoutBtn}>
+            <MaterialCommunityIcons name="logout" size={18} color={brandColors.danger} />
+          </Pressable>
+        </View>
       </View>
 
-      <View style={styles.tabRow}>
+      <View style={[styles.tabRow, { direction: 'ltr' }]}>
         <Pressable
           style={[styles.tab, activeTab === 'reviews' && styles.tabActive]}
           onPress={() => setActiveTab('reviews')}
         >
           <MaterialCommunityIcons name="flag-outline" size={16} color={activeTab === 'reviews' ? brandColors.primary : brandColors.textMuted} />
           <Text style={[typography.bodyMedium, { color: activeTab === 'reviews' ? brandColors.primary : brandColors.textMuted }]}>
-            Reviews ({reviews.length})
+            {t('admin.tabs.reviews', { count: reviews.length })}
           </Text>
         </Pressable>
         <Pressable
@@ -245,7 +249,7 @@ export default function AdminScreen() {
         >
           <MaterialCommunityIcons name="shield-check-outline" size={16} color={activeTab === 'verifications' ? brandColors.primary : brandColors.textMuted} />
           <Text style={[typography.bodyMedium, { color: activeTab === 'verifications' ? brandColors.primary : brandColors.textMuted }]}>
-            Verifications ({verifications.length})
+            {t('admin.tabs.verifications', { count: verifications.length })}
           </Text>
         </Pressable>
         <Pressable
@@ -254,7 +258,7 @@ export default function AdminScreen() {
         >
           <MaterialCommunityIcons name="certificate-outline" size={16} color={activeTab === 'certifications' ? brandColors.primary : brandColors.textMuted} />
           <Text style={[typography.bodyMedium, { color: activeTab === 'certifications' ? brandColors.primary : brandColors.textMuted }]}>
-            Certifications ({pendingCerts.length})
+            {t('admin.tabs.certifications', { count: pendingCerts.length })}
           </Text>
         </Pressable>
       </View>
@@ -265,17 +269,17 @@ export default function AdminScreen() {
           keyExtractor={(item) => item.id}
           contentContainerStyle={styles.list}
           renderItem={({ item }) => {
-            const catMeta = CERT_CATEGORY_LABELS[item.category];
+            const catColor = CERT_CATEGORY_COLORS[item.category] ?? brandColors.primary;
             return (
-              <FCard style={{ ...styles.reviewCard, borderLeftColor: catMeta?.color ?? brandColors.primary }}>
+              <FCard style={{ ...styles.reviewCard, borderLeftColor: catColor }}>
                 <View style={styles.reviewMeta}>
                   <View style={{ flex: 1 }}>
                     <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>{item.fixer.full_name}</Text>
                     <Text style={[typography.caption, { color: brandColors.textMuted }]}>{item.fixer.email}</Text>
                   </View>
-                  <View style={[styles.reasonBadge, { backgroundColor: (catMeta?.color ?? brandColors.primary) + '20' }]}>
-                    <Text style={[typography.caption, { color: catMeta?.color ?? brandColors.primary, fontWeight: '700' }]}>
-                      {catMeta?.label ?? item.category}
+                  <View style={[styles.reasonBadge, { backgroundColor: catColor + '20' }]}>
+                    <Text style={[typography.caption, { color: catColor, fontWeight: '700' }]}>
+                      {t(`admin.categories.${item.category}`, { defaultValue: item.category })}
                     </Text>
                   </View>
                 </View>
@@ -287,7 +291,7 @@ export default function AdminScreen() {
                 )}
 
                 <Text style={[typography.caption, { color: brandColors.textMuted }]}>
-                  Submitted: {new Date(item.created_at).toLocaleDateString()}
+                  {t('admin.certifications.submitted', { date: new Date(item.created_at).toLocaleDateString() })}
                 </Text>
 
                 <View style={styles.actions}>
@@ -298,7 +302,7 @@ export default function AdminScreen() {
                     onPress={() => void handleCertReview(item.id, 'reject')}
                     style={{ flex: 1 }}
                   >
-                    Reject
+                    {t('admin.certifications.reject')}
                   </FButton>
                   <FButton
                     size="sm"
@@ -306,7 +310,7 @@ export default function AdminScreen() {
                     onPress={() => void handleCertReview(item.id, 'approve')}
                     style={{ flex: 1 }}
                   >
-                    Approve
+                    {t('admin.certifications.approve')}
                   </FButton>
                 </View>
               </FCard>
@@ -315,8 +319,8 @@ export default function AdminScreen() {
           ListEmptyComponent={
             <EmptyState
               icon="certificate-outline"
-              title="No pending certifications"
-              message="All certification requests have been handled."
+              title={t('admin.empty.certificationsTitle')}
+              message={t('admin.empty.certificationsMessage')}
             />
           }
           ItemSeparatorComponent={() => <View style={{ height: spacing.sm }} />}
@@ -334,20 +338,36 @@ export default function AdminScreen() {
                   <Text style={[typography.caption, { color: brandColors.textMuted }]}>{item.email}</Text>
                 </View>
                 <Text style={[typography.caption, { color: brandColors.textMuted }]}>
-                  {new Date(item.created_at).toLocaleDateString()}
+                  {t('admin.verifications.submitted', { date: new Date(item.created_at).toLocaleDateString() })}
                 </Text>
               </View>
-              {item.verification_photo_url && (
-                <Pressable onPress={() => setViewingPhotoUrl(item.verification_photo_url)}>
-                  <Image
-                    source={{ uri: item.verification_photo_url }}
-                    style={{ width: '100%', height: 200, borderRadius: radii.md, marginVertical: spacing.sm }}
-                    resizeMode="contain"
-                  />
-                  <Text style={[typography.caption, { color: brandColors.primary, textAlign: 'center', marginBottom: spacing.xs }]}>
-                    Tap to view full size
-                  </Text>
-                </Pressable>
+              {(item.verification_photo_url || item.verification_selfie_url) && (
+                <View style={{ flexDirection: 'row', gap: spacing.sm, marginVertical: spacing.sm }}>
+                  {item.verification_photo_url && (
+                    <Pressable onPress={() => setViewingPhotoUrl(item.verification_photo_url)} style={{ flex: 1 }}>
+                      <Image
+                        source={{ uri: item.verification_photo_url }}
+                        style={{ width: '100%', height: 160, borderRadius: radii.md }}
+                        resizeMode="contain"
+                      />
+                      <Text style={[typography.caption, { color: brandColors.primary, textAlign: 'center', marginTop: spacing.xs }]}>
+                        {t('admin.verifications.idPhoto')}
+                      </Text>
+                    </Pressable>
+                  )}
+                  {item.verification_selfie_url && (
+                    <Pressable onPress={() => setViewingPhotoUrl(item.verification_selfie_url)} style={{ flex: 1 }}>
+                      <Image
+                        source={{ uri: item.verification_selfie_url }}
+                        style={{ width: '100%', height: 160, borderRadius: radii.md }}
+                        resizeMode="contain"
+                      />
+                      <Text style={[typography.caption, { color: brandColors.primary, textAlign: 'center', marginTop: spacing.xs }]}>
+                        {t('admin.verifications.selfie')}
+                      </Text>
+                    </Pressable>
+                  )}
+                </View>
               )}
               <View style={styles.actions}>
                 <FButton
@@ -357,7 +377,7 @@ export default function AdminScreen() {
                   onPress={() => void handleVerify(item.id, 'reject')}
                   style={{ flex: 1 }}
                 >
-                  Reject
+                  {t('admin.verifications.reject')}
                 </FButton>
                 <FButton
                   size="sm"
@@ -365,7 +385,7 @@ export default function AdminScreen() {
                   onPress={() => void handleVerify(item.id, 'approve')}
                   style={{ flex: 1 }}
                 >
-                  Approve
+                  {t('admin.verifications.approve')}
                 </FButton>
               </View>
             </FCard>
@@ -373,8 +393,8 @@ export default function AdminScreen() {
           ListEmptyComponent={
             <EmptyState
               icon="shield-check-outline"
-              title="No pending verifications"
-              message="All verification requests have been handled."
+              title={t('admin.empty.verificationsTitle')}
+              message={t('admin.empty.verificationsMessage')}
             />
           }
           ItemSeparatorComponent={() => <View style={{ height: spacing.sm }} />}
@@ -388,14 +408,14 @@ export default function AdminScreen() {
           <FCard style={styles.reviewCard}>
             <View style={styles.reviewMeta}>
               <View style={styles.metaBlock}>
-                <Text style={[typography.caption, { color: brandColors.textMuted }]}>Reviewer</Text>
+                <Text style={[typography.caption, { color: brandColors.textMuted }]}>{t('admin.reviews.reviewer')}</Text>
                 <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>
                   {item.reviewer.full_name}
                 </Text>
               </View>
               <MaterialCommunityIcons name="arrow-right" size={16} color={brandColors.textMuted} />
               <View style={styles.metaBlock}>
-                <Text style={[typography.caption, { color: brandColors.textMuted }]}>Reviewee</Text>
+                <Text style={[typography.caption, { color: brandColors.textMuted }]}>{t('admin.reviews.reviewee')}</Text>
                 <Text style={[typography.bodyMedium, { color: brandColors.textPrimary }]}>
                   {item.reviewee.full_name}
                 </Text>
@@ -404,7 +424,7 @@ export default function AdminScreen() {
 
             {item.task && (
               <Text style={[typography.caption, { color: brandColors.textMuted, marginBottom: spacing.xs }]}>
-                Task: {item.task.title}
+                {t('admin.reviews.task', { title: item.task.title })}
               </Text>
             )}
 
@@ -420,18 +440,18 @@ export default function AdminScreen() {
 
             <View style={styles.reportsSection}>
               <Text style={[typography.bodyMedium, { color: brandColors.danger, marginBottom: spacing.xs }]}>
-                Reports ({item.reports.length}):
+                {t('admin.reviews.reports', { count: item.reports.length })}
               </Text>
               {item.reports.map((report) => (
                 <View key={report.id} style={{ marginBottom: spacing.xs }}>
                   <View style={styles.reportRow}>
                     <View style={[styles.reasonBadge, { backgroundColor: brandColors.dangerSoft }]}>
                       <Text style={[typography.caption, { color: brandColors.danger }]}>
-                        {REASON_LABELS[report.reason] ?? report.reason}
+                        {t(`admin.reasons.${report.reason}`, { defaultValue: report.reason })}
                       </Text>
                     </View>
                     <Text style={[typography.bodySm, { color: brandColors.textMuted, flex: 1 }]}>
-                      by {report.reporter.full_name}
+                      {t('admin.reviews.by', { name: report.reporter.full_name })}
                     </Text>
                   </View>
                   {report.details ? (
@@ -451,7 +471,7 @@ export default function AdminScreen() {
                 onPress={() => void handleHide(item.id)}
                 style={{ flex: 1 }}
               >
-                Hide Review
+                {t('admin.reviews.hideReview')}
               </FButton>
               <FButton
                 variant="secondary"
@@ -460,7 +480,7 @@ export default function AdminScreen() {
                 onPress={() => void handleDismiss(item.id)}
                 style={{ flex: 1 }}
               >
-                Dismiss
+                {t('admin.reviews.dismiss')}
               </FButton>
             </View>
           </FCard>
@@ -468,8 +488,8 @@ export default function AdminScreen() {
         ListEmptyComponent={
           <EmptyState
             icon="check-circle-outline"
-            title="All clear!"
-            message="No flagged reviews to moderate."
+            title={t('admin.empty.reviewsTitle')}
+            message={t('admin.empty.reviewsMessage')}
           />
         }
         ItemSeparatorComponent={() => <View style={{ height: spacing.sm }} />}
@@ -553,16 +573,30 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: 'rgba(241,181,69,0.22)',
   },
-  headerKicker: {
-    ...typography.caption,
-    color: brandColors.secondary,
-    letterSpacing: 0.8,
-    textTransform: 'uppercase',
-  },
   headerTitle: {
     fontSize: 18,
     fontWeight: '700',
     color: brandColors.textOnDark,
+  },
+  langBtn: {
+    position: 'relative' as const,
+    padding: spacing.xs,
+  },
+  langBadge: {
+    position: 'absolute' as const,
+    bottom: 0,
+    right: -2,
+    backgroundColor: brandColors.primary,
+    borderRadius: 6,
+    paddingHorizontal: 3,
+    minWidth: 16,
+    alignItems: 'center' as const,
+  },
+  langBadgeText: {
+    fontSize: 8,
+    fontWeight: '800' as const,
+    color: brandColors.white,
+    lineHeight: 12,
   },
   logoutBtn: {
     flexDirection: 'row',

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -109,6 +109,9 @@ export default function FixerProfileScreen() {
   const [pushEnabled, setPushEnabled] = useState(false);
   const [pushLoading, setPushLoading] = useState(false);
   const [uploadingVerification, setUploadingVerification] = useState(false);
+  const [verificationExpanded, setVerificationExpanded] = useState(false);
+  const [idPhotoUri, setIdPhotoUri] = useState<string | null>(null);
+  const [selfieUri, setSelfieUri] = useState<string | null>(null);
   const [certifications, setCertifications] = useState<Certification[]>([]);
   const [uploadingCert, setUploadingCert] = useState<string | null>(null);
   const [langOpen, setLangOpen] = useState(false);
@@ -276,18 +279,33 @@ export default function FixerProfileScreen() {
     }
   };
 
-  const handleSubmitVerification = async () => {
+  const pickVerificationPhoto = async (target: 'id' | 'selfie') => {
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: 'images',
       quality: 0.8,
       allowsEditing: true,
     });
-    if (result.canceled || !profile) return;
+    if (result.canceled) return;
+    if (target === 'id') setIdPhotoUri(result.assets[0].uri);
+    else setSelfieUri(result.assets[0].uri);
+  };
+
+  const handleSubmitVerification = async () => {
+    if (!idPhotoUri || !selfieUri || !profile) return;
     setUploadingVerification(true);
     try {
-      const url = await uploadImage(result.assets[0].uri, `verification/${profile.id}/${Date.now()}.jpg`);
-      await api.post('/api/users/me/verification', { verification_photo_url: url });
+      const [idUrl, selfieUrl] = await Promise.all([
+        uploadImage(idPhotoUri, `verification/${profile.id}/id_${Date.now()}.jpg`),
+        uploadImage(selfieUri, `verification/${profile.id}/selfie_${Date.now()}.jpg`),
+      ]);
+      await api.post('/api/users/me/verification', {
+        verification_photo_url: idUrl,
+        verification_selfie_url: selfieUrl,
+      });
       setProfile(p => p ? { ...p, verification_status: 'PENDING' } : p);
+      setVerificationExpanded(false);
+      setIdPhotoUri(null);
+      setSelfieUri(null);
       Alert.alert(t('fixerProfile.alerts.verificationSubmitted.title'), t('fixerProfile.alerts.verificationSubmitted.message'));
     } catch {
       Alert.alert(t('common.error'), t('fixerProfile.alerts.verificationError'));
@@ -669,20 +687,69 @@ export default function FixerProfileScreen() {
                       {t('fixerProfile.verification.pendingMsg')}
                     </Text>
                   </View>
-                ) : (
+                ) : !verificationExpanded ? (
                   <>
                     <Text style={[typography.body, { color: brandColors.textMuted, marginBottom: spacing.md, textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
                       {t('fixerProfile.verification.uploadMsg')}
                     </Text>
                     <FButton
                       variant="secondary"
-                      icon="camera-outline"
-                      onPress={() => void handleSubmitVerification()}
-                      loading={uploadingVerification}
-                      disabled={uploadingVerification}
+                      icon="shield-check-outline"
+                      onPress={() => setVerificationExpanded(true)}
                       fullWidth
                     >
-                      {t('fixerProfile.verification.uploadBtn')}
+                      {t('fixerProfile.verification.startBtn')}
+                    </FButton>
+                  </>
+                ) : (
+                  <>
+                    <Text style={[typography.body, { color: brandColors.textMuted, marginBottom: spacing.lg, textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                      {t('fixerProfile.verification.pickPhotosMsg')}
+                    </Text>
+                    <View style={styles.verificationPhotos}>
+                      {/* ID Photo */}
+                      <View style={styles.verificationPhotoSlot}>
+                        <Pressable
+                          onPress={() => void pickVerificationPhoto('id')}
+                          style={[styles.verificationPhotoBtn, idPhotoUri && styles.verificationPhotoBtnFilled]}
+                        >
+                          {idPhotoUri ? (
+                            <Image source={{ uri: idPhotoUri }} style={styles.verificationPhotoPreview} />
+                          ) : (
+                            <MaterialCommunityIcons name="plus" size={32} color={brandColors.primary} />
+                          )}
+                        </Pressable>
+                        <Text style={[typography.caption, { color: brandColors.textMuted, textAlign: 'center', marginTop: spacing.xs }]}>
+                          {t('fixerProfile.verification.idLabel')}
+                        </Text>
+                      </View>
+                      {/* Selfie */}
+                      <View style={styles.verificationPhotoSlot}>
+                        <Pressable
+                          onPress={() => void pickVerificationPhoto('selfie')}
+                          style={[styles.verificationPhotoBtn, selfieUri && styles.verificationPhotoBtnFilled]}
+                        >
+                          {selfieUri ? (
+                            <Image source={{ uri: selfieUri }} style={styles.verificationPhotoPreview} />
+                          ) : (
+                            <MaterialCommunityIcons name="plus" size={32} color={brandColors.primary} />
+                          )}
+                        </Pressable>
+                        <Text style={[typography.caption, { color: brandColors.textMuted, textAlign: 'center', marginTop: spacing.xs }]}>
+                          {t('fixerProfile.verification.selfieLabel')}
+                        </Text>
+                      </View>
+                    </View>
+                    <FButton
+                      variant="primary"
+                      icon="send"
+                      onPress={() => void handleSubmitVerification()}
+                      loading={uploadingVerification}
+                      disabled={uploadingVerification || !idPhotoUri || !selfieUri}
+                      fullWidth
+                      style={{ marginTop: spacing.lg }}
+                    >
+                      {t('fixerProfile.verification.submitBtn')}
                     </FButton>
                   </>
                 )}
@@ -1082,6 +1149,35 @@ const styles = StyleSheet.create({
     padding: spacing.md,
     borderRadius: radii.md,
     backgroundColor: brandColors.surfaceAlt,
+  },
+  verificationPhotos: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: spacing.xl,
+  },
+  verificationPhotoSlot: {
+    alignItems: 'center',
+  },
+  verificationPhotoBtn: {
+    width: 100,
+    height: 100,
+    borderRadius: radii.lg,
+    borderWidth: 2,
+    borderColor: brandColors.outline,
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: brandColors.surfaceAlt,
+  },
+  verificationPhotoBtnFilled: {
+    borderStyle: 'solid',
+    borderColor: brandColors.primary,
+    overflow: 'hidden',
+  },
+  verificationPhotoPreview: {
+    width: '100%',
+    height: '100%',
+    borderRadius: radii.lg - 2,
   },
   chipsWrap: {
     flexDirection: 'row',

--- a/frontend/src/screens/NotificationCenterScreen.tsx
+++ b/frontend/src/screens/NotificationCenterScreen.tsx
@@ -156,9 +156,9 @@ export default function NotificationCenterScreen() {
     React.useCallback(() => {
       refetch().then(() => {
         // Mark all as read after a short delay so user sees the unread styling briefly
-        setTimeout(() => markAllAsRead(), 1500);
+        setTimeout(() => markAllAsRead(activeMode), 1500);
       });
-    }, [refetch, markAllAsRead]),
+    }, [refetch, markAllAsRead, activeMode]),
   );
 
   const handleDeleteAll = () => {
@@ -218,7 +218,7 @@ export default function NotificationCenterScreen() {
       {filtered.length > 0 && (
         <View style={styles.topBar}>
           {unreadCount > 0 ? (
-            <FButton variant="ghost" size="sm" onPress={markAllAsRead}>
+            <FButton variant="ghost" size="sm" onPress={() => markAllAsRead(activeMode)}>
               {t('notifications.markAllRead')}
             </FButton>
           ) : (

--- a/frontend/src/screens/TaskDetails.tsx
+++ b/frontend/src/screens/TaskDetails.tsx
@@ -630,12 +630,17 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
                     </Text>
                   </>
                 ) : (
-                  <View style={styles.noPaymentLink}>
-                    <MaterialCommunityIcons name="information-outline" size={20} color={brandColors.textMuted} />
-                    <Text style={[typography.body, { color: brandColors.textMuted, flex: 1 , writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
-                      {t('taskDetails.payment.noPaymentLink')}
-                    </Text>
-                  </View>
+                  <>
+                    <View style={styles.noPaymentLink}>
+                      <MaterialCommunityIcons name="information-outline" size={20} color={brandColors.textMuted} />
+                      <Text style={[typography.body, { color: brandColors.textMuted, flex: 1 , writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                        {t('taskDetails.payment.noPaymentLink')}
+                      </Text>
+                    </View>
+                    <FButton variant="outline" icon="cash" onPress={confirmPayment} loading={actionLoading === 'payment'} disabled={actionLoading !== null} fullWidth style={{ marginTop: spacing.sm }}>
+                      {t('taskDetails.actions.paidCash')}
+                    </FButton>
+                  </>
                 )}
               </FCard>
             )}
@@ -857,19 +862,24 @@ export default function TaskDetails({ route, navigation }: { route: any; navigat
                     </Text>
                   </>
                 ) : (
-                  <View style={styles.noPaymentLink}>
-                    <MaterialCommunityIcons name="information-outline" size={20} color={brandColors.textMuted} />
-                    <Text style={[typography.body, { color: brandColors.textMuted, flex: 1 , writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
-                      {t('taskDetails.payment.noPaymentLink')}
-                    </Text>
-                    {acceptedBid?.fixer?.phone_number && (
-                      <Pressable onPress={() => Linking.openURL(`tel:${acceptedBid.fixer!.phone_number}`)}>
-                        <Text style={[typography.label, { color: brandColors.primaryMuted }]}>
-                          {acceptedBid.fixer.phone_number}
-                        </Text>
-                      </Pressable>
-                    )}
-                  </View>
+                  <>
+                    <View style={styles.noPaymentLink}>
+                      <MaterialCommunityIcons name="information-outline" size={20} color={brandColors.textMuted} />
+                      <Text style={[typography.body, { color: brandColors.textMuted, flex: 1 , writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                        {t('taskDetails.payment.noPaymentLink')}
+                      </Text>
+                      {acceptedBid?.fixer?.phone_number && (
+                        <Pressable onPress={() => Linking.openURL(`tel:${acceptedBid.fixer!.phone_number}`)}>
+                          <Text style={[typography.label, { color: brandColors.primaryMuted }]}>
+                            {acceptedBid.fixer.phone_number}
+                          </Text>
+                        </Pressable>
+                      )}
+                    </View>
+                    <FButton variant="outline" icon="cash" onPress={confirmPayment} loading={actionLoading === 'payment'} disabled={actionLoading !== null} fullWidth style={{ marginTop: spacing.sm }}>
+                      {t('taskDetails.actions.paidCash')}
+                    </FButton>
+                  </>
                 )}
               </View>
             )}


### PR DESCRIPTION
## Summary
- **Fixer verification two-photo flow**: ID photo + selfie with plus-button UI
- **Admin screen i18n**: Full Hebrew translation with globe language toggle, LTR toolbar preserved
- **Admin notifications i18n**: Verification & certification approval/rejection use `getNotificationText`
- **Chat notification dedup**: Multiple messages from same person = one bell notification per conversation
- **Notification text**: Shows "New message from {name}" / "Regarding {task title}" (i18n-aware)
- **Mode-separated badges**: Bell and message counts are scoped to active mode (fixer/requester)
- **markAllAsRead scoped by mode**: Reading notifications in fixer mode doesn't clear requester notifications
- **Other-mode badge on workspace switcher**: Shows unread count from the other mode on the switch button
- **Paid in Cash button**: When fixer has no payment link, requester can confirm cash payment to proceed with completion flow
- **Removed Account tab** from requester desktop toolbar
- **Removed "Review Moderation"** subtitle from admin header

## Test plan
- [ ] Register as fixer, submit verification with ID photo + selfie
- [ ] Admin approves/rejects verification — check notification language matches user preference
- [ ] Send chat messages — verify bell shows one notification per conversation, not per message
- [ ] Check notification text shows sender name and task title
- [ ] Switch between fixer/requester modes — verify badge counts are independent
- [ ] Open notifications in fixer mode — switch to requester mode — verify requester notifications still show unread
- [ ] Workspace switcher button shows badge with other mode's unread count
- [ ] Fixer with no payment link — requester sees "Paid in Cash" button, can confirm and proceed
- [ ] Admin screen: toggle language — verify all text translates, toolbar stays LTR
- [ ] All 264 frontend tests pass, backend typecheck clean

