### PR TITLE
fix: use sdkVersion runtimeVersion policy for Expo Go

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -40,7 +40,7 @@
       "url": "https://u.expo.dev/590098a4-2855-46b2-8afe-066e14687968"
     },
     "runtimeVersion": {
-      "policy": "appVersion"
+      "policy": "sdkVersion"
     },
     "extra": {
       "eas": {


### PR DESCRIPTION
## Summary
- Changes `runtimeVersion.policy` in `frontend/app.json` from `"appVersion"` to `"sdkVersion"`
- `appVersion` was tagging every EAS Update bundle with runtime `"1.0.0"`, which Expo Go SDK 54 does not recognize → blank screen on every auto-publish
- `sdkVersion` tags bundles as `"exposdk:54.0.0"`, which Expo Go SDK 54 accepts correctly

## Test plan
- [ ] Merge this PR → auto-publish workflow fires → new bundle tagged `exposdk:54.0.0`
- [ ] Open Expo Go and reload the app → should load without a blank screen
- [ ] Confirm `eas channel:list` shows `Runtime version: exposdk:54.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)