### PR TITLE
chore: set Expo project owner to fixit.dev org

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,6 +1,7 @@
 {
   "expo": {
     "name": "FixIt",
+    "owner": "fixit.dev",
     "slug": "fixit",
     "version": "1.0.0",
     "orientation": "portrait",


### PR DESCRIPTION
## Summary
- Adds `"owner": "fixit.dev"` to `frontend/app.json` following the transfer of the Expo project from the personal `guyzilberstein` account to the `fixit.dev` organization on expo.dev
- This allows teammates to access the app via Expo Go once they are invited to the `fixit.dev` org
- EAS confirmed the new owner: `@fixit.dev/fixit` (project ID unchanged)

## Test plan
- [ ] `npx eas project:info` in `frontend/` shows `@fixit.dev/fixit` as owner
- [ ] Teammate invited to `fixit.dev` org can open the app in Expo Go without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)