### PR TITLE
fix: fixer profile name no longer truncates

### DIFF
--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -412,8 +412,10 @@ export default function FixerProfileScreen() {
               </View>
               <Text style={[styles.headerKicker, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.headerKicker')}</Text>
             </View>
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs, alignSelf: 'flex-start' }}>
-              <Text style={[styles.heroName, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]} numberOfLines={2}>{displayName}</Text>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
+              <View style={{ flex: 1 }}>
+                <Text style={[styles.heroName, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{displayName}</Text>
+              </View>
               {profile?.verification_status === 'APPROVED' && (
                 <MaterialCommunityIcons name="check-decagram" size={22} color="#29B6F6" />
               )}
@@ -1061,7 +1063,6 @@ const styles = StyleSheet.create({
     fontWeight: '800',
     letterSpacing: 0,
     color: brandColors.textPrimary,
-    flex: 1,
   },
   heroEmail: {
     ...typography.bodySm,


### PR DESCRIPTION
## Summary

- Wraps the `heroName` `Text` in `<View style={{ flex: 1 }}>` so React Native can properly bound the text measurement and trigger multi-line wrapping
- Removes `alignSelf: 'flex-start'` from the outer name row `View` (previously attempted fix — still needed)
- Removes `flex: 1` from the `heroName` StyleSheet entry (the wrapper `View` now owns the flex, making it a no-op on the `Text`)
- Removes `numberOfLines={2}` so the name wraps naturally without an ellipsis cutoff

**Root cause:** In React Native, placing `flex: 1` directly on a `Text` node inside a `flexDirection: 'row'` container does not reliably trigger multi-line wrapping in deeply nested flex layouts. The text measures at one line and truncates. The correct pattern is to place `flex: 1` on a `View` wrapper and let the `Text` inside fill its bounded parent.

## Test plan

- [ ] Open Fixer Profile screen — full name ("David Cohen", "Guy Zilberstein") is visible without truncation
- [ ] Verification badge (checkmark icon) still appears to the right of the name when the fixer is verified
- [ ] Long names wrap to a second line rather than showing "…"
- [ ] Layout looks correct in both LTR and RTL modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)