### PR TITLE
feat: admin confirmation dialogs + web auto-logout

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -18,6 +18,7 @@ import { AccessibilityProvider } from './src/context/AccessibilityContext';
 import { LanguageProvider } from './src/context/LanguageContext';
 import AccessibilityWidget from './src/components/AccessibilityWidget';
 import GlobalCelebration from './src/components/GlobalCelebration';
+import IdleLogoutWarning from './src/components/IdleLogoutWarning';
 import OnboardingNudge from './src/components/OnboardingNudge';
 import LoadingScreen from './src/components/LoadingScreen';
 import {
@@ -215,6 +216,7 @@ function RootContent() {
     return (
       <NavigationContainer theme={navigationTheme} documentTitle={{ formatter: () => 'FixIt' }}>
         <AdminNavigator />
+        {Platform.OS === 'web' && <IdleLogoutWarning onLogout={() => void handleAuthLogOut()} />}
       </NavigationContainer>
     );
   }
@@ -233,6 +235,7 @@ function RootContent() {
         <OnboardingNudge />
       </NavigationContainer>
       <GlobalCelebration />
+      {Platform.OS === 'web' && <IdleLogoutWarning onLogout={() => void handleAuthLogOut()} />}
     </NotificationProvider>
     </ActiveModeProvider>
   );

--- a/frontend/src/components/IdleLogoutWarning.tsx
+++ b/frontend/src/components/IdleLogoutWarning.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { View, Text } from 'react-native';
+import { Modal, Portal } from 'react-native-paper';
+import { useIdleTimer } from '../hooks/useIdleTimer';
+import { FButton } from './ui';
+import { brandColors, radii, spacing, typography } from '../theme';
+
+const IDLE_MS = 28 * 60 * 1000;
+const WARNING_S = 120;
+
+export default function IdleLogoutWarning({ onLogout }: { onLogout: () => void }) {
+  const [showWarning, setShowWarning] = useState(false);
+  const [secondsLeft, setSecondsLeft] = useState(WARNING_S);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startWarning = useCallback(() => {
+    setSecondsLeft(WARNING_S);
+    setShowWarning(true);
+    countdownRef.current = setInterval(() => {
+      setSecondsLeft((s) => {
+        if (s <= 1) {
+          clearInterval(countdownRef.current!);
+          onLogout();
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+  }, [onLogout]);
+
+  const { reset } = useIdleTimer({
+    onIdle: startWarning,
+    timeoutMs: IDLE_MS,
+    enabled: !showWarning,
+  });
+
+  const extend = useCallback(() => {
+    setShowWarning(false);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+    reset();
+  }, [reset]);
+
+  useEffect(() => () => {
+    if (countdownRef.current) clearInterval(countdownRef.current);
+  }, []);
+
+  const mins = Math.floor(secondsLeft / 60);
+  const secs = String(secondsLeft % 60).padStart(2, '0');
+
+  return (
+    <Portal>
+      <Modal
+        visible={showWarning}
+        dismissable={false}
+        contentContainerStyle={{
+          marginHorizontal: spacing.xl,
+          borderRadius: radii.xl,
+          backgroundColor: brandColors.surface,
+          padding: spacing.xl,
+          alignItems: 'center',
+          gap: spacing.lg,
+        }}
+      >
+        <Text style={[typography.h3, { color: brandColors.textPrimary, textAlign: 'center' }]}>
+          Session Expiring
+        </Text>
+        <Text style={[typography.body, { color: brandColors.textSecondary, textAlign: 'center' }]}>
+          {"You've been inactive. You'll be logged out in "}
+          <Text style={{ fontWeight: '700', color: brandColors.danger }}>
+            {mins}:{secs}
+          </Text>
+          {' to protect your account.'}
+        </Text>
+        <View style={{ width: '100%' }}>
+          <FButton onPress={extend} fullWidth>
+            Stay Logged In
+          </FButton>
+        </View>
+      </Modal>
+    </Portal>
+  );
+}

--- a/frontend/src/hooks/__tests__/useIdleTimer.test.ts
+++ b/frontend/src/hooks/__tests__/useIdleTimer.test.ts
@@ -1,0 +1,141 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+import { useIdleTimer } from '../useIdleTimer';
+
+const EVENTS = ['mousemove', 'mousedown', 'keydown', 'scroll', 'touchstart'] as const;
+
+// window is not available in the node test environment — provide a mock for the
+// full test file lifetime so React's deferred cleanup can always reference it.
+const mockAddEvent = jest.fn();
+const mockRemoveEvent = jest.fn();
+
+beforeAll(() => {
+  (global as Record<string, unknown>).window = {
+    addEventListener: mockAddEvent,
+    removeEventListener: mockRemoveEvent,
+  };
+});
+
+afterAll(() => {
+  delete (global as Record<string, unknown>).window;
+});
+
+describe('useIdleTimer', () => {
+  const originalOS = Platform.OS;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockAddEvent.mockReset();
+    mockRemoveEvent.mockReset();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    Object.defineProperty(Platform, 'OS', { value: originalOS, configurable: true });
+  });
+
+  describe('on native (Platform.OS !== "web")', () => {
+    beforeEach(() => {
+      Object.defineProperty(Platform, 'OS', { value: 'ios', configurable: true });
+    });
+
+    it('does not register event listeners', () => {
+      const onIdle = jest.fn();
+      renderHook(() => useIdleTimer({ onIdle, timeoutMs: 1000, enabled: true }));
+      expect(mockAddEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not fire onIdle after timeoutMs', () => {
+      const onIdle = jest.fn();
+      renderHook(() => useIdleTimer({ onIdle, timeoutMs: 1000, enabled: true }));
+      act(() => { jest.advanceTimersByTime(1000); });
+      expect(onIdle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on web with enabled = false', () => {
+    beforeEach(() => {
+      Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+    });
+
+    it('does not register event listeners', () => {
+      const onIdle = jest.fn();
+      renderHook(() => useIdleTimer({ onIdle, timeoutMs: 1000, enabled: false }));
+      expect(mockAddEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not fire onIdle after timeoutMs', () => {
+      const onIdle = jest.fn();
+      renderHook(() => useIdleTimer({ onIdle, timeoutMs: 1000, enabled: false }));
+      act(() => { jest.advanceTimersByTime(1000); });
+      expect(onIdle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on web with enabled = true', () => {
+    beforeEach(() => {
+      Object.defineProperty(Platform, 'OS', { value: 'web', configurable: true });
+    });
+
+    it('registers all 5 event listeners with passive flag', () => {
+      const onIdle = jest.fn();
+      renderHook(() => useIdleTimer({ onIdle, timeoutMs: 5000, enabled: true }));
+      expect(mockAddEvent).toHaveBeenCalledTimes(5);
+      const registeredEvents = mockAddEvent.mock.calls.map((call: unknown[]) => call[0]);
+      EVENTS.forEach((e) => expect(registeredEvents).toContain(e));
+      mockAddEvent.mock.calls.forEach((call: unknown[]) => {
+        expect(call[2]).toEqual({ passive: true });
+      });
+    });
+
+    it('fires onIdle after timeoutMs with no activity', () => {
+      const onIdle = jest.fn();
+      renderHook(() => useIdleTimer({ onIdle, timeoutMs: 5000, enabled: true }));
+      expect(onIdle).not.toHaveBeenCalled();
+      act(() => { jest.advanceTimersByTime(5000); });
+      expect(onIdle).toHaveBeenCalledTimes(1);
+    });
+
+    it('reset() defers the timer when called before expiry', () => {
+      const onIdle = jest.fn();
+      const { result } = renderHook(() =>
+        useIdleTimer({ onIdle, timeoutMs: 5000, enabled: true }),
+      );
+      act(() => { jest.advanceTimersByTime(4000); });
+      expect(onIdle).not.toHaveBeenCalled();
+      act(() => { result.current.reset(); });
+      act(() => { jest.advanceTimersByTime(4000); });
+      expect(onIdle).not.toHaveBeenCalled();
+      act(() => { jest.advanceTimersByTime(1001); });
+      expect(onIdle).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes all event listeners and cancels timer on unmount', () => {
+      const onIdle = jest.fn();
+      const { unmount } = renderHook(() =>
+        useIdleTimer({ onIdle, timeoutMs: 5000, enabled: true }),
+      );
+      unmount();
+      expect(mockRemoveEvent).toHaveBeenCalledTimes(5);
+      const removedEvents = mockRemoveEvent.mock.calls.map((call: unknown[]) => call[0]);
+      EVENTS.forEach((e) => expect(removedEvents).toContain(e));
+      act(() => { jest.advanceTimersByTime(5000); });
+      expect(onIdle).not.toHaveBeenCalled();
+    });
+
+    it('removes listeners and cancels timer when enabled switches to false', () => {
+      const onIdle = jest.fn();
+      const { rerender } = renderHook(
+        ({ enabled }: { enabled: boolean }) =>
+          useIdleTimer({ onIdle, timeoutMs: 5000, enabled }),
+        { initialProps: { enabled: true } },
+      );
+      expect(mockAddEvent).toHaveBeenCalledTimes(5);
+      rerender({ enabled: false });
+      expect(mockRemoveEvent).toHaveBeenCalledTimes(5);
+      act(() => { jest.advanceTimersByTime(5000); });
+      expect(onIdle).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/hooks/useIdleTimer.ts
+++ b/frontend/src/hooks/useIdleTimer.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+
+const EVENTS = ['mousemove', 'mousedown', 'keydown', 'scroll', 'touchstart'] as const;
+
+export function useIdleTimer({
+  onIdle,
+  timeoutMs,
+  enabled,
+}: {
+  onIdle: () => void;
+  timeoutMs: number;
+  enabled: boolean;
+}) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reset = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(onIdle, timeoutMs);
+  }, [onIdle, timeoutMs]);
+
+  useEffect(() => {
+    if (Platform.OS !== 'web' || !enabled) return;
+    EVENTS.forEach((e) => window.addEventListener(e, reset, { passive: true }));
+    reset();
+    return () => {
+      EVENTS.forEach((e) => window.removeEventListener(e, reset));
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [reset, enabled]);
+
+  return { reset };
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1711,6 +1711,38 @@
       "verification": "Failed to {{action}} verification",
       "certification": "Failed to {{action}} certification",
       "downloadPhoto": "Failed to download photo"
+    },
+    "confirm": {
+      "approveVerification": {
+        "title": "Approve {{name}}?",
+        "message": "This will grant them verified fixer status.",
+        "confirmLabel": "Approve"
+      },
+      "rejectVerification": {
+        "title": "Reject {{name}}?",
+        "message": "This will decline their verification request.",
+        "confirmLabel": "Reject"
+      },
+      "approveCertification": {
+        "title": "Approve {{name}}?",
+        "message": "This will approve their certification.",
+        "confirmLabel": "Approve"
+      },
+      "rejectCertification": {
+        "title": "Reject {{name}}?",
+        "message": "This will decline their certification request.",
+        "confirmLabel": "Reject"
+      },
+      "hideReview": {
+        "title": "Hide review by {{name}}?",
+        "message": "This will hide the review from public view.",
+        "confirmLabel": "Hide"
+      },
+      "dismissReports": {
+        "title": "Dismiss reports for {{name}}'s review?",
+        "message": "The reports will be cleared and the review kept visible.",
+        "confirmLabel": "Dismiss"
+      }
     }
   }
 }

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -1725,6 +1725,38 @@
       "verification": "{{action}} האימות נכשל",
       "certification": "{{action}} ההסמכה נכשל",
       "downloadPhoto": "הורדת התמונה נכשלה"
+    },
+    "confirm": {
+      "approveVerification": {
+        "title": "לאשר את {{name}}?",
+        "message": "פעולה זו תעניק להם מעמד מתקן מאומת.",
+        "confirmLabel": "אשר"
+      },
+      "rejectVerification": {
+        "title": "לדחות את {{name}}?",
+        "message": "פעולה זו תדחה את בקשת האימות שלהם.",
+        "confirmLabel": "דחה"
+      },
+      "approveCertification": {
+        "title": "לאשר את {{name}}?",
+        "message": "פעולה זו תאשר את ההסמכה שלהם.",
+        "confirmLabel": "אשר"
+      },
+      "rejectCertification": {
+        "title": "לדחות את {{name}}?",
+        "message": "פעולה זו תדחה את בקשת ההסמכה שלהם.",
+        "confirmLabel": "דחה"
+      },
+      "hideReview": {
+        "title": "להסתיר ביקורת של {{name}}?",
+        "message": "פעולה זו תסתיר את הביקורת מהצפייה הציבורית.",
+        "confirmLabel": "הסתר"
+      },
+      "dismissReports": {
+        "title": "לדחות דיווחים על ביקורת של {{name}}?",
+        "message": "הדיווחים יימחקו והביקורת תישאר גלויה.",
+        "confirmLabel": "דחה"
+      }
     }
   }
 }

--- a/frontend/src/screens/AdminScreen.tsx
+++ b/frontend/src/screens/AdminScreen.tsx
@@ -142,64 +142,120 @@ export default function AdminScreen() {
     }, [fetchFlagged, fetchVerifications, fetchCertifications]),
   );
 
-  const handleHide = async (reviewId: string) => {
-    try {
-      await api.post(`/api/admin/reviews/${reviewId}/hide`);
-      setReviews((prev) => prev.filter((r) => r.id !== reviewId));
-    } catch {
-      const msg = t('admin.errors.hideReview');
-      if (Platform.OS === 'web') {
-        // eslint-disable-next-line no-alert
-        window.alert(msg);
-      } else {
-        Alert.alert(t('common.error'), msg);
-      }
+  const confirmAction = (
+    title: string,
+    message: string,
+    confirmLabel: string,
+    destructive: boolean,
+    onConfirm: () => void,
+  ) => {
+    if (Platform.OS === 'web') {
+      // eslint-disable-next-line no-alert
+      if (window.confirm(`${title}\n\n${message}`)) onConfirm();
+      return;
     }
+    Alert.alert(title, message, [
+      { text: t('common.cancel'), style: 'cancel' },
+      { text: confirmLabel, style: destructive ? 'destructive' : 'default', onPress: onConfirm },
+    ]);
   };
 
-  const handleDismiss = async (reviewId: string) => {
-    try {
-      await api.post(`/api/admin/reviews/${reviewId}/dismiss`);
-      setReviews((prev) => prev.filter((r) => r.id !== reviewId));
-    } catch {
-      const msg = t('admin.errors.dismissReports');
-      if (Platform.OS === 'web') {
-        // eslint-disable-next-line no-alert
-        window.alert(msg);
-      } else {
-        Alert.alert(t('common.error'), msg);
-      }
-    }
+  const handleHide = (reviewId: string, displayName: string) => {
+    confirmAction(
+      `Hide review by ${displayName}?`,
+      'This will hide the review from public view.',
+      'Hide',
+      true,
+      async () => {
+        try {
+          await api.post(`/api/admin/reviews/${reviewId}/hide`);
+          setReviews((prev) => prev.filter((r) => r.id !== reviewId));
+        } catch {
+          const msg = t('admin.errors.hideReview');
+          if (Platform.OS === 'web') {
+            // eslint-disable-next-line no-alert
+            window.alert(msg);
+          } else {
+            Alert.alert(t('common.error'), msg);
+          }
+        }
+      },
+    );
   };
 
-  const handleVerify = async (userId: string, action: 'approve' | 'reject') => {
-    try {
-      await api.post(`/api/admin/users/${userId}/verify`, { action });
-      setVerifications((prev) => prev.filter((v) => v.id !== userId));
-    } catch {
-      const msg = t('admin.errors.verification', { action });
-      if (Platform.OS === 'web') {
-        // eslint-disable-next-line no-alert
-        window.alert(msg);
-      } else {
-        Alert.alert(t('common.error'), msg);
-      }
-    }
+  const handleDismiss = (reviewId: string, displayName: string) => {
+    confirmAction(
+      `Dismiss reports for ${displayName}'s review?`,
+      'The reports will be cleared and the review kept visible.',
+      'Dismiss',
+      false,
+      async () => {
+        try {
+          await api.post(`/api/admin/reviews/${reviewId}/dismiss`);
+          setReviews((prev) => prev.filter((r) => r.id !== reviewId));
+        } catch {
+          const msg = t('admin.errors.dismissReports');
+          if (Platform.OS === 'web') {
+            // eslint-disable-next-line no-alert
+            window.alert(msg);
+          } else {
+            Alert.alert(t('common.error'), msg);
+          }
+        }
+      },
+    );
   };
 
-  const handleCertReview = async (certId: string, action: 'approve' | 'reject') => {
-    try {
-      await api.post(`/api/admin/certifications/${certId}/review`, { action });
-      setPendingCerts((prev) => prev.filter((c) => c.id !== certId));
-    } catch {
-      const msg = t('admin.errors.certification', { action });
-      if (Platform.OS === 'web') {
-        // eslint-disable-next-line no-alert
-        window.alert(msg);
-      } else {
-        Alert.alert(t('common.error'), msg);
-      }
-    }
+  const handleVerify = (userId: string, action: 'approve' | 'reject', displayName: string) => {
+    const isApprove = action === 'approve';
+    confirmAction(
+      isApprove ? `Approve ${displayName}?` : `Reject ${displayName}?`,
+      isApprove
+        ? 'This will grant them verified fixer status.'
+        : 'This will decline their verification request.',
+      isApprove ? 'Approve' : 'Reject',
+      !isApprove,
+      async () => {
+        try {
+          await api.post(`/api/admin/users/${userId}/verify`, { action });
+          setVerifications((prev) => prev.filter((v) => v.id !== userId));
+        } catch {
+          const msg = t('admin.errors.verification', { action });
+          if (Platform.OS === 'web') {
+            // eslint-disable-next-line no-alert
+            window.alert(msg);
+          } else {
+            Alert.alert(t('common.error'), msg);
+          }
+        }
+      },
+    );
+  };
+
+  const handleCertReview = (certId: string, action: 'approve' | 'reject', displayName: string) => {
+    const isApprove = action === 'approve';
+    confirmAction(
+      isApprove ? `Approve ${displayName}?` : `Reject ${displayName}?`,
+      isApprove
+        ? 'This will approve their certification.'
+        : 'This will decline their certification request.',
+      isApprove ? 'Approve' : 'Reject',
+      !isApprove,
+      async () => {
+        try {
+          await api.post(`/api/admin/certifications/${certId}/review`, { action });
+          setPendingCerts((prev) => prev.filter((c) => c.id !== certId));
+        } catch {
+          const msg = t('admin.errors.certification', { action });
+          if (Platform.OS === 'web') {
+            // eslint-disable-next-line no-alert
+            window.alert(msg);
+          } else {
+            Alert.alert(t('common.error'), msg);
+          }
+        }
+      },
+    );
   };
 
   const handleLogout = async () => {
@@ -296,7 +352,7 @@ export default function AdminScreen() {
                     variant="outline"
                     size="sm"
                     icon="close-circle-outline"
-                    onPress={() => void handleCertReview(item.id, 'reject')}
+                    onPress={() => handleCertReview(item.id, 'reject', item.fixer.full_name)}
                     style={{ flex: 1 }}
                   >
                     {t('admin.certifications.reject')}
@@ -304,7 +360,7 @@ export default function AdminScreen() {
                   <FButton
                     size="sm"
                     icon="check-circle-outline"
-                    onPress={() => void handleCertReview(item.id, 'approve')}
+                    onPress={() => handleCertReview(item.id, 'approve', item.fixer.full_name)}
                     style={{ flex: 1 }}
                   >
                     {t('admin.certifications.approve')}
@@ -371,7 +427,7 @@ export default function AdminScreen() {
                   variant="outline"
                   size="sm"
                   icon="close-circle-outline"
-                  onPress={() => void handleVerify(item.id, 'reject')}
+                  onPress={() => handleVerify(item.id, 'reject', item.full_name)}
                   style={{ flex: 1 }}
                 >
                   {t('admin.verifications.reject')}
@@ -379,7 +435,7 @@ export default function AdminScreen() {
                 <FButton
                   size="sm"
                   icon="check-circle-outline"
-                  onPress={() => void handleVerify(item.id, 'approve')}
+                  onPress={() => handleVerify(item.id, 'approve', item.full_name)}
                   style={{ flex: 1 }}
                 >
                   {t('admin.verifications.approve')}
@@ -465,7 +521,7 @@ export default function AdminScreen() {
                 variant="outline"
                 size="sm"
                 icon="eye-off-outline"
-                onPress={() => void handleHide(item.id)}
+                onPress={() => handleHide(item.id, item.reviewer.full_name)}
                 style={{ flex: 1 }}
               >
                 {t('admin.reviews.hideReview')}
@@ -474,7 +530,7 @@ export default function AdminScreen() {
                 variant="secondary"
                 size="sm"
                 icon="check-circle-outline"
-                onPress={() => void handleDismiss(item.id)}
+                onPress={() => handleDismiss(item.id, item.reviewer.full_name)}
                 style={{ flex: 1 }}
               >
                 {t('admin.reviews.dismiss')}

--- a/frontend/src/screens/AdminScreen.tsx
+++ b/frontend/src/screens/AdminScreen.tsx
@@ -162,9 +162,9 @@ export default function AdminScreen() {
 
   const handleHide = (reviewId: string, displayName: string) => {
     confirmAction(
-      `Hide review by ${displayName}?`,
-      'This will hide the review from public view.',
-      'Hide',
+      t('admin.confirm.hideReview.title', { name: displayName }),
+      t('admin.confirm.hideReview.message'),
+      t('admin.confirm.hideReview.confirmLabel'),
       true,
       async () => {
         try {
@@ -185,9 +185,9 @@ export default function AdminScreen() {
 
   const handleDismiss = (reviewId: string, displayName: string) => {
     confirmAction(
-      `Dismiss reports for ${displayName}'s review?`,
-      'The reports will be cleared and the review kept visible.',
-      'Dismiss',
+      t('admin.confirm.dismissReports.title', { name: displayName }),
+      t('admin.confirm.dismissReports.message'),
+      t('admin.confirm.dismissReports.confirmLabel'),
       false,
       async () => {
         try {
@@ -208,12 +208,11 @@ export default function AdminScreen() {
 
   const handleVerify = (userId: string, action: 'approve' | 'reject', displayName: string) => {
     const isApprove = action === 'approve';
+    const verifyKey = isApprove ? 'approveVerification' : 'rejectVerification';
     confirmAction(
-      isApprove ? `Approve ${displayName}?` : `Reject ${displayName}?`,
-      isApprove
-        ? 'This will grant them verified fixer status.'
-        : 'This will decline their verification request.',
-      isApprove ? 'Approve' : 'Reject',
+      t(`admin.confirm.${verifyKey}.title`, { name: displayName }),
+      t(`admin.confirm.${verifyKey}.message`),
+      t(`admin.confirm.${verifyKey}.confirmLabel`),
       !isApprove,
       async () => {
         try {
@@ -234,12 +233,11 @@ export default function AdminScreen() {
 
   const handleCertReview = (certId: string, action: 'approve' | 'reject', displayName: string) => {
     const isApprove = action === 'approve';
+    const certKey = isApprove ? 'approveCertification' : 'rejectCertification';
     confirmAction(
-      isApprove ? `Approve ${displayName}?` : `Reject ${displayName}?`,
-      isApprove
-        ? 'This will approve their certification.'
-        : 'This will decline their certification request.',
-      isApprove ? 'Approve' : 'Reject',
+      t(`admin.confirm.${certKey}.title`, { name: displayName }),
+      t(`admin.confirm.${certKey}.message`),
+      t(`admin.confirm.${certKey}.confirmLabel`),
       !isApprove,
       async () => {
         try {

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -395,9 +395,7 @@ export default function FixerProfileScreen() {
         <Text style={[styles.headerKicker, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.headerKicker')}</Text>
       </View>
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
-        <View style={{ flex: 1 }}>
-          <Text style={[styles.heroName, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{displayName}</Text>
-        </View>
+        <Text style={[styles.heroName, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr', flexShrink: 1 }]}>{displayName}</Text>
         {profile?.verification_status === 'APPROVED' && (
           <MaterialCommunityIcons name="check-decagram" size={22} color="#29B6F6" />
         )}

--- a/frontend/src/screens/FixerProfileScreen.tsx
+++ b/frontend/src/screens/FixerProfileScreen.tsx
@@ -352,6 +352,74 @@ export default function FixerProfileScreen() {
   const currentPaymentLinkValid = currentPaymentLink.length > 0 && isValidUrl(currentPaymentLink);
   const hasSpecializationChanges = !sameStringSet(specializations, profile?.specializations ?? []);
 
+  const heroAvatarContent = (
+    <View style={styles.avatarWrapper}>
+      <Pressable
+        onPress={() => profile?.avatar_url ? setViewingAvatar(true) : void pickNewAvatar()}
+        accessibilityRole="button"
+        accessibilityLabel={profile?.avatar_url ? 'View profile photo' : 'Add profile photo'}
+        accessibilityState={{ busy: uploadingAvatar }}
+      >
+        {profile?.avatar_url ? (
+          <Avatar.Image size={104} source={{ uri: profile.avatar_url }} />
+        ) : (
+          <Avatar.Icon
+            size={104}
+            icon="account"
+            style={{ backgroundColor: brandColors.primaryMuted }}
+          />
+        )}
+      </Pressable>
+      <Pressable
+        style={styles.cameraBadge}
+        onPress={() => void pickNewAvatar()}
+        accessibilityRole="button"
+        accessibilityLabel="Change profile photo"
+        accessibilityState={{ busy: uploadingAvatar }}
+      >
+        {uploadingAvatar ? (
+          <MaterialCommunityIcons name="loading" size={14} color={brandColors.white} />
+        ) : (
+          <MaterialCommunityIcons name="camera" size={14} color={brandColors.white} />
+        )}
+      </Pressable>
+    </View>
+  );
+
+  const heroCopyInner = (
+    <>
+      <View style={styles.headerKickerRow}>
+        <View style={styles.headerIconShell}>
+          <MaterialCommunityIcons name="account-hard-hat-outline" size={17} color={brandColors.secondaryDark} />
+        </View>
+        <Text style={[styles.headerKicker, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.headerKicker')}</Text>
+      </View>
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
+        <View style={{ flex: 1 }}>
+          <Text style={[styles.heroName, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{displayName}</Text>
+        </View>
+        {profile?.verification_status === 'APPROVED' && (
+          <MaterialCommunityIcons name="check-decagram" size={22} color="#29B6F6" />
+        )}
+      </View>
+      <Text style={[styles.heroEmail, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]} numberOfLines={1}>{profile?.email}</Text>
+    </>
+  );
+
+  const heroRatingStat = (
+    <Pressable
+      style={styles.heroStat}
+      onPress={() => { if (profile?.id) navigation.navigate('PublicProfile', { userId: profile.id }); }}
+    >
+      <Text style={styles.heroStatValue}>
+        {avgRating != null && avgRating > 0 ? avgRating.toFixed(1) : t('fixerProfile.stats.new')}
+      </Text>
+      <Text style={[styles.heroStatLabel, { writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.stats.rating')}</Text>
+      <Text numberOfLines={1} style={[typography.caption, { color: brandColors.secondaryDark, marginTop: spacing.xs, textDecorationLine: 'underline', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+        {t('fixerProfile.stats.tapToView')}
+      </Text>
+    </Pressable>
+  );
 
   return (
     <ScrollView
@@ -369,82 +437,26 @@ export default function FixerProfileScreen() {
           end={heroGradientFixer.end}
           style={[styles.profileHero, isWide && styles.profileHeroWide]}
         >
-          <View
-            ref={(el: unknown) => { if (el && Platform.OS === 'web') { (el as HTMLElement).dir = 'ltr'; } }}
-            style={styles.heroInnerRow}
-          >
-          <View style={styles.heroTopRow}>
-            <View style={styles.avatarWrapper}>
-              <Pressable
-                onPress={() => profile?.avatar_url ? setViewingAvatar(true) : void pickNewAvatar()}
-                accessibilityRole="button"
-                accessibilityLabel={profile?.avatar_url ? 'View profile photo' : 'Add profile photo'}
-                accessibilityState={{ busy: uploadingAvatar }}
-              >
-                {profile?.avatar_url ? (
-                  <Avatar.Image size={104} source={{ uri: profile.avatar_url }} />
-                ) : (
-                  <Avatar.Icon
-                    size={104}
-                    icon="account"
-                    style={{ backgroundColor: brandColors.primaryMuted }}
-                  />
-                )}
-              </Pressable>
-              <Pressable
-                style={styles.cameraBadge}
-                onPress={() => void pickNewAvatar()}
-                accessibilityRole="button"
-                accessibilityLabel="Change profile photo"
-                accessibilityState={{ busy: uploadingAvatar }}
-              >
-                {uploadingAvatar ? (
-                  <MaterialCommunityIcons name="loading" size={14} color={brandColors.white} />
-                ) : (
-                  <MaterialCommunityIcons name="camera" size={14} color={brandColors.white} />
-                )}
-              </Pressable>
+          {Platform.OS === 'web' ? (
+            // Web: horizontal row — avatar | copy (flex:1) | rating
+            <View
+              ref={(el: unknown) => { if (el) (el as HTMLElement).dir = 'ltr'; }}
+              style={{ flex: 1, flexDirection: 'row', alignItems: 'center', gap: spacing.lg }}
+            >
+              {heroAvatarContent}
+              <View style={[styles.heroCopy, { flex: 1 }]}>{heroCopyInner}</View>
+              {heroRatingStat}
             </View>
-
-            <View style={{ flex: 1, alignItems: 'center' }}>
-              <Pressable
-                style={styles.heroStat}
-                onPress={() => {
-                  if (profile?.id) {
-                    navigation.navigate('PublicProfile', { userId: profile.id });
-                  }
-                }}
-              >
-                <Text style={styles.heroStatValue}>
-                  {avgRating != null && avgRating > 0 ? avgRating.toFixed(1) : t('fixerProfile.stats.new')}
-                </Text>
-                <Text style={[styles.heroStatLabel, { writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.stats.rating')}</Text>
-                <Text numberOfLines={1} style={[typography.caption, { color: brandColors.secondaryDark, marginTop: spacing.xs, textDecorationLine: 'underline', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
-                  {t('fixerProfile.stats.tapToView')}
-                </Text>
-              </Pressable>
-            </View>
-          </View>
-
-          <View style={styles.heroCopy}>
-            <View style={styles.headerKickerRow}>
-              <View style={styles.headerIconShell}>
-                <MaterialCommunityIcons name="account-hard-hat-outline" size={17} color={brandColors.secondaryDark} />
+          ) : (
+            // Native: avatar+rating top row, copy below
+            <View style={styles.heroInnerRow}>
+              <View style={styles.heroTopRow}>
+                {heroAvatarContent}
+                <View style={{ flex: 1, alignItems: 'center' }}>{heroRatingStat}</View>
               </View>
-              <Text style={[styles.headerKicker, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{t('fixerProfile.headerKicker')}</Text>
+              <View style={styles.heroCopy}>{heroCopyInner}</View>
             </View>
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: spacing.xs }}>
-              <View style={{ flex: 1 }}>
-                <Text style={[styles.heroName, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>{displayName}</Text>
-              </View>
-              {profile?.verification_status === 'APPROVED' && (
-                <MaterialCommunityIcons name="check-decagram" size={22} color="#29B6F6" />
-              )}
-            </View>
-            <Text style={[styles.heroEmail, { textAlign: 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]} numberOfLines={1}>{profile?.email}</Text>
-          </View>
-
-          </View>
+          )}
         </LinearGradient>
 
         <View style={[styles.profileGrid, isWide && styles.profileGridWide]}>


### PR DESCRIPTION
## Summary

### Admin Confirmation Dialogs
All admin actions now require a confirmation before executing — no more accidental approvals/rejections.

- **Approve verification / certification** → "Approve [Name]? — This will grant them verified status." → [Cancel] [Approve]
- **Reject verification / certification** → "Reject [Name]? — This will decline their request." → [Cancel] [**Reject** (destructive)]
- **Hide review** → "Hide review by [Name]? — This will hide the review from public view." → [Cancel] [**Hide** (destructive)]
- **Dismiss reports** → "Dismiss reports for [Name]'s review?" → [Cancel] [Dismiss]

Uses `window.confirm()` on web, `Alert.alert()` on native — consistent with the existing pattern across the app.

### Web Auto-Logout (30 min inactivity)
Protects accounts on shared/public computers.

- After **28 minutes** of no mousemove/click/keydown/scroll → warning modal appears with a **2-minute countdown**
- Modal shows: *"You've been inactive. You'll be logged out in 1:43 to protect your account."*
- **"Stay Logged In"** button resets the 28-minute timer
- If ignored for 2 minutes → `handleAuthLogOut()` is called (disconnects socket + Firebase signOut)
- Applies to both admin and regular authenticated users, **web-only** (`Platform.OS === 'web'` guard)

**New files:**
- `frontend/src/hooks/useIdleTimer.ts` — idle detection hook
- `frontend/src/components/IdleLogoutWarning.tsx` — warning modal component

## Test plan
- [ ] Admin: Tap Approve/Reject on a verification → confirmation dialog with the person's name appears → Cancel does nothing, Confirm executes
- [ ] Admin: Reject button shows destructive (red) styling on iOS / bold on Android
- [ ] Web: Set `IDLE_MS` to `5000` (5s) for testing → warning appears after 5s with countdown → "Stay Logged In" dismisses and resets → ignoring logs out
- [ ] Web: Moving mouse/typing resets the timer (no warning fires while active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)