### PR TITLE
fix: completion/cancellation UX for requester & fixer

### DIFF
--- a/backend/src/routes/bids.ts
+++ b/backend/src/routes/bids.ts
@@ -249,14 +249,19 @@ router.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
   }
 });
 
-// DELETE /api/bids/:id — fixer deletes a rejected or withdrawn bid
+// DELETE /api/bids/:id — fixer deletes a rejected/withdrawn bid, or any bid
+// whose task was canceled by the requester (the job is dead either way)
 router.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const bid = await prisma.bid.findUnique({ where: { id: req.params.id } });
+    const bid = await prisma.bid.findUnique({
+      where: { id: req.params.id },
+      include: { task: { select: { status: true } } },
+    });
     if (!bid) throw new NotFoundError('Bid not found');
     if (req.user.id !== bid.fixer_id) throw new ForbiddenError('Only the fixer can delete their bid');
-    if (bid.status !== 'REJECTED' && bid.status !== 'WITHDRAWN') {
-      throw new ValidationError('Only rejected or withdrawn bids can be deleted');
+    const taskCanceled = bid.task?.status === 'CANCELED';
+    if (bid.status !== 'REJECTED' && bid.status !== 'WITHDRAWN' && !taskCanceled) {
+      throw new ValidationError('Only rejected, withdrawn, or canceled-task bids can be deleted');
     }
     await prisma.bid.delete({ where: { id: bid.id } });
     res.json({ message: 'Bid deleted' });

--- a/docs/05_User_Flows.md
+++ b/docs/05_User_Flows.md
@@ -87,7 +87,7 @@ stateDiagram-v2
     [*] --> OPEN : Requester publishes task
     OPEN --> IN_PROGRESS : Requester accepts a bid
     OPEN --> CANCELED : Requester cancels before acceptance
-    IN_PROGRESS --> COMPLETED : Requester marks as completed
+    IN_PROGRESS --> COMPLETED : Both sides confirm (after payment)
     IN_PROGRESS --> CANCELED : Requester cancels after acceptance
     CANCELED --> OPEN : Requester reopens (Planned)
     COMPLETED --> [*]
@@ -101,7 +101,7 @@ stateDiagram-v2
 | — | OPEN | Requester creates task | Task visible on discovery feed |
 | OPEN | IN_PROGRESS | Requester accepts a bid | Fixer assigned, exact address revealed to Fixer, all other PENDING bids auto-rejected, chat channel activated, Fixer notified |
 | OPEN | CANCELED | Requester cancels | All PENDING bids auto-rejected, task removed from feed |
-| IN_PROGRESS | COMPLETED | Requester taps "Mark as Completed" | Status set to COMPLETED immediately; payment prompt shown; review prompt shown to Requester (available for 14 days) |
+| IN_PROGRESS | COMPLETED | **Both** Requester and Fixer confirm completion (after the Requester confirms payment) | Status flips to COMPLETED only once both `requester_completed` and `fixer_completed` are set; `completed_at` recorded; review prompt shown to Requester (available for 14 days) |
 | IN_PROGRESS | CANCELED | Requester cancels | Fixer notified |
 | CANCELED | OPEN | Requester reopens task *(Planned)* | `assigned_fixer_id` cleared, task reappears on discovery feed; previously rejected bids stay rejected |
 
@@ -152,13 +152,17 @@ stateDiagram-v2
 
 ### 3.5 Completion & Payment
 
-1. Once the Fixer finishes the work, the Requester taps "Mark as Completed".
-2. Task status → `COMPLETED` immediately. The Requester receives a prompt to leave a review (available for 14 days).
-3. A "Pay Fixer" button appears on the completed task screen.
+Completion is **payment-first and dual-confirmed** — the task only reaches `COMPLETED` once the Requester has confirmed payment and **both** sides have confirmed the work is done.
+
+1. **Pay the Fixer first.** Once the Fixer finishes the work, the Requester sees a "Pay Fixer" button on the Task Details screen.
    * If the Fixer has set a `payment_link`: the button deep-links to their Bit/Paybox app with the agreed amount.
    * If the Fixer has **not** set a `payment_link`: the button is replaced with a message — "This Fixer hasn't set up a payment link. Contact them directly to arrange payment." Their phone number (if provided) is shown as a fallback.
-4. After paying externally, the Requester taps "Confirm Payment". This calls `PUT /api/tasks/:id/confirm-payment`, setting `Task.is_payment_confirmed = true`.
-5. The "Pay Fixer" button is replaced with "Payment Confirmed ✓".
+2. After paying externally, the Requester taps "Confirm Payment". This calls `PUT /api/tasks/:id/confirm-payment`, setting `Task.is_payment_confirmed = true`. The button becomes "Payment Confirmed ✓".
+3. **Only now** does a "Mark as Completed" button appear. The Requester taps it → `PUT /api/tasks/:id/confirm-completion`, which sets `requester_completed = true`. The task stays `IN_PROGRESS` and shows "Waiting for the Fixer to confirm".
+4. The Fixer confirms completion on their own Task Details screen → `PUT /api/tasks/:id/confirm-completion` sets `fixer_completed = true`.
+5. When **both** flags are set, the task flips to `COMPLETED`, `completed_at` is recorded, and the Requester receives a prompt to leave a review (available for 14 days).
+
+> **Why dual confirmation?** Requiring both sides to confirm — gated behind payment — reduces "marked done but never paid / never finished" disputes. The trade-off is that completion is no longer a single tap; the entry point (e.g. the "Complete & Pay" button on a task card) opens this flow rather than completing the task outright.
 
 ### 3.6 Rating the Fixer
 
@@ -272,7 +276,7 @@ flowchart TD
 ### 4.7 Post-Job: Payment
 
 1. Receives payment externally via Bit/Paybox.
-2. No further action required from the Fixer — the Requester is responsible for marking the task as completed and submitting a review.
+2. After the Requester confirms payment and marks the task complete, the Fixer must **also confirm completion** on their Task Details screen (`PUT /api/tasks/:id/confirm-completion`). The task only becomes `COMPLETED` once both sides have confirmed. (The Requester is still the one who submits the review.)
 
 ### 4.8 Withdrawing a Bid
 

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -248,7 +248,9 @@ export default function App() {
         <LanguageProvider>
           <AccessibilityProvider>
             <RootContent />
-            <AccessibilityWidget />
+            {/* Web-only: WCAG 2.0 AA / ת"י 5568 compliance applies to the website,
+                not the native app — keep the provider, hide the floating widget. */}
+            {Platform.OS === 'web' && <AccessibilityWidget />}
           </AccessibilityProvider>
         </LanguageProvider>
         <StatusBar style="light" />

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -7,28 +7,33 @@ import { brandColors, radii, spacing, typography } from '../theme';
 type TaskStatus = 'OPEN' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELED';
 type BidStatus = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'WITHDRAWN';
 
-type Status = TaskStatus | BidStatus;
+// TASK_CANCELED is a synthetic badge (not a real enum) used when a fixer's bid
+// outcome is "the requester canceled the task" — distinct from the fixer's own
+// REJECTED/CANCELED so it's clear the fixer didn't back out.
+type Status = TaskStatus | BidStatus | 'TASK_CANCELED';
 
 const STATUS_CONFIG: Record<Status, { bg: string; text: string; dotColor: string; border: string }> = {
-  OPEN:        { bg: brandColors.successSoft,  text: brandColors.success,      dotColor: brandColors.success,      border: brandColors.outlineLight },
-  IN_PROGRESS: { bg: brandColors.infoSoft,     text: brandColors.primaryMuted, dotColor: brandColors.primaryMuted, border: brandColors.outlineLight },
-  COMPLETED:   { bg: brandColors.surfaceAlt,   text: brandColors.textMuted,    dotColor: brandColors.textMuted,    border: brandColors.outlineLight },
-  CANCELED:    { bg: brandColors.dangerSoft,   text: brandColors.danger,       dotColor: brandColors.danger,       border: brandColors.outlineLight },
-  PENDING:     { bg: brandColors.warningSoft,  text: brandColors.warning,      dotColor: brandColors.warning,      border: brandColors.outlineLight },
-  ACCEPTED:    { bg: brandColors.successSoft,  text: brandColors.success,      dotColor: brandColors.success,      border: brandColors.outlineLight },
-  REJECTED:    { bg: brandColors.dangerSoft,   text: brandColors.danger,       dotColor: brandColors.danger,       border: brandColors.outlineLight },
-  WITHDRAWN:   { bg: brandColors.neutralSoft,  text: brandColors.textMuted,    dotColor: brandColors.textMuted,    border: brandColors.outlineLight },
+  OPEN:          { bg: brandColors.successSoft,  text: brandColors.success,      dotColor: brandColors.success,      border: brandColors.outlineLight },
+  IN_PROGRESS:   { bg: brandColors.infoSoft,     text: brandColors.primaryMuted, dotColor: brandColors.primaryMuted, border: brandColors.outlineLight },
+  COMPLETED:     { bg: brandColors.surfaceAlt,   text: brandColors.textMuted,    dotColor: brandColors.textMuted,    border: brandColors.outlineLight },
+  CANCELED:      { bg: brandColors.dangerSoft,   text: brandColors.danger,       dotColor: brandColors.danger,       border: brandColors.outlineLight },
+  TASK_CANCELED: { bg: brandColors.dangerSoft,   text: brandColors.danger,       dotColor: brandColors.danger,       border: brandColors.outlineLight },
+  PENDING:       { bg: brandColors.warningSoft,  text: brandColors.warning,      dotColor: brandColors.warning,      border: brandColors.outlineLight },
+  ACCEPTED:      { bg: brandColors.successSoft,  text: brandColors.success,      dotColor: brandColors.success,      border: brandColors.outlineLight },
+  REJECTED:      { bg: brandColors.dangerSoft,   text: brandColors.danger,       dotColor: brandColors.danger,       border: brandColors.outlineLight },
+  WITHDRAWN:     { bg: brandColors.neutralSoft,  text: brandColors.textMuted,    dotColor: brandColors.textMuted,    border: brandColors.outlineLight },
 };
 
 const STATUS_KEY: Record<Status, string> = {
-  OPEN:        'status.open',
-  IN_PROGRESS: 'status.inProgress',
-  COMPLETED:   'status.completed',
-  CANCELED:    'status.canceled',
-  PENDING:     'status.pending',
-  ACCEPTED:    'status.accepted',
-  REJECTED:    'status.rejected',
-  WITHDRAWN:   'status.withdrawn',
+  OPEN:          'status.open',
+  IN_PROGRESS:   'status.inProgress',
+  COMPLETED:     'status.completed',
+  CANCELED:      'status.canceled',
+  TASK_CANCELED: 'status.taskCanceled',
+  PENDING:       'status.pending',
+  ACCEPTED:      'status.accepted',
+  REJECTED:      'status.rejected',
+  WITHDRAWN:     'status.withdrawn',
 };
 
 interface StatusBadgeProps {

--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -24,6 +24,9 @@ interface TaskCardProps {
   onReactivate?: () => void;
   onCancel?: () => void;
   onMarkCompleted?: () => void;
+  markCompletedLabel?: string;
+  markCompletedIcon?: string;
+  awaitingFixer?: boolean;
   onEdit?: () => void;
   onReview?: () => void;
   onChat?: () => void;
@@ -43,6 +46,9 @@ export default function TaskCard({
   onReactivate,
   onCancel,
   onMarkCompleted,
+  markCompletedLabel,
+  markCompletedIcon,
+  awaitingFixer = false,
   onEdit,
   onReview,
   onChat,
@@ -128,6 +134,13 @@ export default function TaskCard({
           tone="success"
         />
       )}
+      {awaitingFixer && (
+        <TaskSignal
+          icon="progress-clock"
+          label={t('taskCard.awaitingFixer')}
+          tone="warning"
+        />
+      )}
       {onReview && (
         <TaskSignal
           icon="star-outline"
@@ -180,8 +193,8 @@ export default function TaskCard({
           )}
           {onMarkCompleted && (
             <ActionButton
-              icon="check-circle-outline"
-              label={t('taskCard.markComplete')}
+              icon={markCompletedIcon ?? 'check-circle-outline'}
+              label={markCompletedLabel ?? t('taskCard.markComplete')}
               tone="success"
               onPress={onMarkCompleted}
             />

--- a/frontend/src/hooks/useBids.ts
+++ b/frontend/src/hooks/useBids.ts
@@ -20,6 +20,9 @@ export interface BidTask {
   general_location_name: string;
   general_location_name_en?: string | null;
   completed_at: string | null;
+  is_payment_confirmed?: boolean;
+  requester_completed?: boolean;
+  fixer_completed?: boolean;
   requester?: {
     id: string;
     full_name: string;

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -407,7 +407,12 @@
       "reactivate": "Reactivate",
       "locationNotSet": "Location not set",
       "winningBid": "Winning bid: ₪{{price}}",
-      "winningBidRating": "Winning bid: ₪{{price}} · Rating: {{rating}}★"
+      "winningBidRating": "Winning bid: ₪{{price}} · Rating: {{rating}}★",
+      "actionNeeded": "Action needed",
+      "confirmCompletionHint": "Payment is confirmed — mark the job done on your side to close it out.",
+      "confirmCompletion": "Confirm completion",
+      "waitingRequester": "Waiting for the requester to confirm",
+      "taskCanceledNote": "The requester canceled this task — no action is needed on your part."
     },
     "stats": {
       "inView": "In view",
@@ -478,6 +483,12 @@
         "title": "Cancel accepted job?",
         "message": "Cancel \"{{title}}\"? The task will reopen for other Fixers and the requester will lose your accepted job state.",
         "confirm": "Cancel job"
+      },
+      "confirmCompletion": {
+        "title": "Confirm completion?",
+        "message": "Confirm you finished \"{{title}}\"? Once both you and the requester confirm, the job is marked completed.",
+        "confirm": "Confirm completion",
+        "error": "Failed to confirm completion."
       },
       "delete": {
         "title": "Delete bid?",
@@ -1541,6 +1552,7 @@
     "inProgress": "In progress",
     "completed": "Completed",
     "canceled": "Canceled",
+    "taskCanceled": "Task canceled",
     "pending": "Pending",
     "accepted": "Accepted",
     "rejected": "Rejected",
@@ -1559,6 +1571,8 @@
     "leaveReview": "Leave review",
     "reopen": "Reopen",
     "markComplete": "Mark complete",
+    "completePay": "Complete & Pay",
+    "awaitingFixer": "Awaiting fixer confirmation",
     "chat": "Chat"
   },
   "becomeFixer": {

--- a/frontend/src/i18n/he.json
+++ b/frontend/src/i18n/he.json
@@ -407,7 +407,12 @@
       "reactivate": "הפעל מחדש",
       "locationNotSet": "מיקום לא הוגדר",
       "winningBid": "הצעה שנבחרה: ₪{{price}}",
-      "winningBidRating": "הצעה שנבחרה: ₪{{price}} · דירוג: {{rating}}★"
+      "winningBidRating": "הצעה שנבחרה: ₪{{price}} · דירוג: {{rating}}★",
+      "actionNeeded": "נדרשת פעולה",
+      "confirmCompletionHint": "התשלום אושר — סמן שסיימת את העבודה כדי לסגור אותה.",
+      "confirmCompletion": "אשר השלמה",
+      "waitingRequester": "ממתין לאישור המבקש",
+      "taskCanceledNote": "המזמין ביטל את המשימה — לא נדרשת פעולה מצדך."
     },
     "stats": {
       "inView": "בתצוגה",
@@ -478,6 +483,12 @@
         "title": "בטל עבודה שאושרה?",
         "message": "לבטל את \"{{title}}\"? המשימה תיפתח מחדש לפיקסרים אחרים והמבקש יאבד את מצב העבודה המאושרת שלך.",
         "confirm": "בטל עבודה"
+      },
+      "confirmCompletion": {
+        "title": "לאשר השלמה?",
+        "message": "לאשר שסיימת את \"{{title}}\"? לאחר ששניכם — אתה והמבקש — תאשרו, העבודה תסומן כהושלמה.",
+        "confirm": "אשר השלמה",
+        "error": "אישור ההשלמה נכשל."
       },
       "delete": {
         "title": "מחק הצעה?",
@@ -1553,6 +1564,7 @@
     "inProgress": "בביצוע",
     "completed": "הושלם",
     "canceled": "בוטל",
+    "taskCanceled": "המשימה בוטלה",
     "pending": "ממתין",
     "accepted": "התקבל",
     "rejected": "נדחה",
@@ -1573,6 +1585,8 @@
     "leaveReview": "השאר ביקורת",
     "reopen": "פתח מחדש",
     "markComplete": "סמן כהושלם",
+    "completePay": "סיום ותשלום",
+    "awaitingFixer": "ממתין לאישור הפיקסר",
     "chat": "צ׳אט"
   },
   "becomeFixer": {

--- a/frontend/src/screens/DiscoveryFeedScreen.tsx
+++ b/frontend/src/screens/DiscoveryFeedScreen.tsx
@@ -674,11 +674,18 @@ export default function DiscoveryFeedScreen({ navigation }: Props) {
           {!loading && !error && tasks.length === 0 && (
             <View style={styles.loadingOverlay}>
               <FCard style={styles.overlayCard} shadow="md">
-                <EmptyState
-                  icon="map-search-outline"
-                  title={t('discovery.empty.noTasks.title')}
-                  message={t('discovery.empty.noTasks.message')}
-                />
+                {/* Lightweight inline empty state — the full EmptyState's
+                    rotated diamond + watermark get clipped by the card's
+                    overflow:hidden on native, so render plainly here. */}
+                <View style={styles.emptyOverlayContent}>
+                  <MaterialCommunityIcons name="map-search-outline" size={32} color={brandColors.primaryMuted} />
+                  <Text style={[typography.h3, { color: brandColors.textPrimary, textAlign: 'center', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                    {t('discovery.empty.noTasks.title')}
+                  </Text>
+                  <Text style={[typography.bodySm, { color: brandColors.textMuted, textAlign: 'center', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                    {t('discovery.empty.noTasks.message')}
+                  </Text>
+                </View>
               </FCard>
             </View>
           )}
@@ -988,6 +995,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: spacing.md,
+  },
+  emptyOverlayContent: {
+    alignItems: 'center',
+    gap: spacing.sm,
   },
   previewCardWrapper: {
     position: 'absolute',

--- a/frontend/src/screens/MyBidsScreen.tsx
+++ b/frontend/src/screens/MyBidsScreen.tsx
@@ -47,7 +47,33 @@ function formatDate(dateString: string, locale?: string): string {
   });
 }
 
+// Accepted + in progress + payment confirmed, but the fixer hasn't confirmed yet:
+// the job is waiting on the fixer's final tap to be marked COMPLETED.
+function needsFixerConfirm(bid: UserBid): boolean {
+  return (
+    bid.status === 'ACCEPTED' &&
+    bid.task.status === 'IN_PROGRESS' &&
+    !!bid.task.is_payment_confirmed &&
+    !bid.task.fixer_completed
+  );
+}
+
+// A bid whose outcome is "the requester canceled the task" — covers:
+//   • the bid was accepted and the task was then canceled,
+//   • the bid was still pending when the task was canceled, and
+//   • the bid was rejected specifically because the task was canceled.
+// Note: a bid rejected for another reason (e.g. CHOSE_ANOTHER) whose task is
+// later canceled stays a normal "Rejected" — the fixer lost it on its own merits.
+function isTaskCanceledOutcome(bid: UserBid): boolean {
+  return (
+    (bid.task.status === 'CANCELED' && (bid.status === 'ACCEPTED' || bid.status === 'PENDING')) ||
+    (bid.status === 'REJECTED' && bid.rejection_reason === 'TASK_CANCELED')
+  );
+}
+
 function getBidAccentColor(bid: UserBid): string {
+  if (needsFixerConfirm(bid)) return brandColors.secondary;
+  if (isTaskCanceledOutcome(bid)) return brandColors.danger;
   if (bid.status === 'ACCEPTED' && bid.task.status === 'COMPLETED') return brandColors.success;
   if (bid.status === 'ACCEPTED') return brandColors.secondaryDark;
   if (bid.status === 'PENDING') return brandColors.primary;
@@ -63,15 +89,24 @@ interface BidCardProps {
   onEdit: (bid: UserBid) => void;
   onCancelAccepted: (bid: UserBid) => void;
   onChat: (bid: UserBid) => void;
+  onConfirmCompletion: (bid: UserBid) => void;
 }
 
-function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccepted, onChat }: BidCardProps) {
+function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccepted, onChat, onConfirmCompletion }: BidCardProps) {
   const { t } = useTranslation();
   const { isRTL, language } = useLanguage();
   const dateLocale = language === 'he' ? 'he-IL' : 'en-US';
   const translateX = useRef(new Animated.Value(0)).current;
-  const isPending = bid.status === 'PENDING';
+  // A pending bid whose task was canceled is shown under Rejected as "Task
+  // canceled", so it must not offer pending actions (swipe/edit/withdraw).
+  const isPending = bid.status === 'PENDING' && !isTaskCanceledOutcome(bid);
   const catMeta = getCategoryMeta(bid.task.category);
+
+  // Accepted job, in progress: once the requester confirms payment, the fixer's
+  // final confirmation is the only thing left before the task is COMPLETED.
+  const acceptedActive = bid.status === 'ACCEPTED' && bid.task.status === 'IN_PROGRESS';
+  const needsCompletion = acceptedActive && !!bid.task.is_payment_confirmed && !bid.task.fixer_completed;
+  const fixerDoneWaiting = acceptedActive && !!bid.task.fixer_completed && !bid.task.requester_completed;
 
   const panResponder = useRef(
     PanResponder.create({
@@ -142,7 +177,15 @@ function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccep
                 </Text>
               </View>
             </View>
-            <StatusBadge status={bid.status === 'ACCEPTED' && bid.task.status === 'COMPLETED' ? 'COMPLETED' : bid.status} />
+            <StatusBadge
+              status={
+                isTaskCanceledOutcome(bid)
+                  ? 'TASK_CANCELED'
+                  : bid.status === 'ACCEPTED' && bid.task.status === 'COMPLETED'
+                    ? 'COMPLETED'
+                    : bid.status
+              }
+            />
           </View>
 
           <View style={styles.bidDetails}>
@@ -160,7 +203,50 @@ function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccep
             </Text>
           </View>
 
-          {bid.status === 'REJECTED' && bid.rejection_reason && (
+          {needsCompletion && (
+            <View style={styles.completionBanner}>
+              <View style={styles.completionHeader}>
+                <MaterialCommunityIcons name="alert-decagram" size={15} color={brandColors.secondaryDark} />
+                <Text style={[typography.caption, styles.completionBadgeText, { writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                  {t('myBids.card.actionNeeded')}
+                </Text>
+              </View>
+              <Text style={[typography.bodySm, { color: brandColors.textSecondary, textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                {t('myBids.card.confirmCompletionHint')}
+              </Text>
+              <Pressable
+                style={[styles.actionBtn, styles.successActionBtn, { alignSelf: isRTL ? 'flex-end' : 'flex-start' }]}
+                accessibilityRole="button"
+                accessibilityLabel={t('myBids.card.confirmCompletion')}
+                onPress={(e) => { e.stopPropagation(); onConfirmCompletion(bid); }}
+              >
+                <MaterialCommunityIcons name="check-decagram" size={13} color={brandColors.success} />
+                <Text style={[typography.caption, { color: brandColors.success, fontWeight: '700', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                  {t('myBids.card.confirmCompletion')}
+                </Text>
+              </Pressable>
+            </View>
+          )}
+
+          {fixerDoneWaiting && (
+            <View style={styles.waitingNote}>
+              <MaterialCommunityIcons name="clock-outline" size={14} color={brandColors.warning} />
+              <Text style={[typography.caption, { color: brandColors.textMuted, flex: 1, textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                {t('myBids.card.waitingRequester')}
+              </Text>
+            </View>
+          )}
+
+          {isTaskCanceledOutcome(bid) && (
+            <View style={styles.waitingNote}>
+              <MaterialCommunityIcons name="close-circle-outline" size={14} color={brandColors.danger} />
+              <Text style={[typography.caption, { color: brandColors.textMuted, flex: 1, textAlign: isRTL ? 'right' : 'left', writingDirection: isRTL ? 'rtl' : 'ltr' }]}>
+                {t('myBids.card.taskCanceledNote')}
+              </Text>
+            </View>
+          )}
+
+          {bid.status === 'REJECTED' && bid.rejection_reason && bid.rejection_reason !== 'TASK_CANCELED' && (
             <View style={styles.rejectionBanner}>
               <View style={styles.rejectionHeader}>
                 <MaterialCommunityIcons name="information-outline" size={14} color={brandColors.danger} />
@@ -215,7 +301,7 @@ function BidCard({ bid, onPress, onWithdraw, onReactivate, onEdit, onCancelAccep
                   </Pressable>
                 </>
               )}
-              {bid.status === 'ACCEPTED' && bid.task.status !== 'COMPLETED' && (
+              {bid.status === 'ACCEPTED' && bid.task.status === 'IN_PROGRESS' && (
                 <>
                   <Pressable
                     style={[styles.actionBtn, styles.chatActionBtn]}
@@ -288,7 +374,15 @@ export default function MyBidsScreen() {
   const currentMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
   const [selectedYear, setSelectedYear] = useState<number | null>(now.getFullYear());
   const [selectedMonth, setSelectedMonth] = useState<string | null>(currentMonthKey);
-  const statusFilter = activeTab === 'COMPLETED' ? 'ACCEPTED' : activeTab === 'ALL' ? null : activeTab;
+  // COMPLETED is a synthetic tab over ACCEPTED bids (narrowed by task status).
+  // REJECTED fetches everything (null) because it also surfaces accepted bids
+  // whose task was later canceled — which aren't REJECTED server-side.
+  const statusFilter =
+    activeTab === 'COMPLETED'
+      ? 'ACCEPTED'
+      : activeTab === 'ALL' || activeTab === 'REJECTED'
+        ? null
+        : activeTab;
 
   const { bids: rawBids, loading, error, refetch, updateBidLocally, removeBidLocally } = useBids({
     status: statusFilter as BidStatus | null,
@@ -322,8 +416,19 @@ export default function MyBidsScreen() {
 
   const bids = rawBids
     .filter((b) => {
-      if (activeTab === 'ALL') return b.status !== 'REJECTED' && !(b.status === 'ACCEPTED' && b.task.status === 'COMPLETED');
-      if (activeTab === 'ACCEPTED') return b.status === 'ACCEPTED' && b.task.status !== 'COMPLETED';
+      if (activeTab === 'ALL') {
+        // Active pipeline only — exclude rejected, canceled-task outcomes, and
+        // accepted bids whose task already finished (completed).
+        if (b.status === 'REJECTED') return false;
+        if (isTaskCanceledOutcome(b)) return false;
+        if (b.status === 'ACCEPTED' && b.task.status === 'COMPLETED') return false;
+        return true;
+      }
+      // Pending tab excludes bids whose task was canceled — those move to Rejected.
+      if (activeTab === 'PENDING') return b.status === 'PENDING' && !isTaskCanceledOutcome(b);
+      if (activeTab === 'ACCEPTED') return b.status === 'ACCEPTED' && b.task.status === 'IN_PROGRESS';
+      // Rejected bucket also holds every canceled-task outcome (pending/accepted/rejected).
+      if (activeTab === 'REJECTED') return b.status === 'REJECTED' || isTaskCanceledOutcome(b);
       if (activeTab === 'COMPLETED') {
         if (b.status !== 'ACCEPTED' || b.task.status !== 'COMPLETED') return false;
         if (effectiveYear == null) return false; // no year selected — show nothing
@@ -337,6 +442,10 @@ export default function MyBidsScreen() {
       return true;
     })
     .sort((a, b) => {
+      // Jobs awaiting the fixer's final confirmation float to the very top.
+      const an = needsFixerConfirm(a) ? 1 : 0;
+      const bn = needsFixerConfirm(b) ? 1 : 0;
+      if (an !== bn) return bn - an;
       if (a.status === 'ACCEPTED' && b.status !== 'ACCEPTED') return -1;
       if (b.status === 'ACCEPTED' && a.status !== 'ACCEPTED') return 1;
       return 0;
@@ -512,6 +621,27 @@ export default function MyBidsScreen() {
     [confirmBidAction, refetch],
   );
 
+  const handleConfirmCompletion = useCallback(
+    (bid: UserBid) => {
+      const doConfirm = async () => {
+        try {
+          await api.put(`/api/tasks/${bid.task_id}/confirm-completion`);
+          refetch();
+        } catch {
+          Alert.alert(t('common.error'), t('myBids.actions.confirmCompletion.error'));
+        }
+      };
+
+      confirmBidAction({
+        title: t('myBids.actions.confirmCompletion.title'),
+        message: t('myBids.actions.confirmCompletion.message', { title: bid.task.title }),
+        confirmLabel: t('myBids.actions.confirmCompletion.confirm'),
+        onConfirm: doConfirm,
+      });
+    },
+    [confirmBidAction, refetch, t],
+  );
+
   const handleEditSave = useCallback(async () => {
     if (!editingBid) return;
     setEditSaving(true);
@@ -531,7 +661,7 @@ export default function MyBidsScreen() {
 
   const handleDeleteAll = useCallback(() => {
     const targetBids = bids.filter(
-      (b) => b.status === 'REJECTED' || b.status === 'WITHDRAWN',
+      (b) => b.status === 'REJECTED' || b.status === 'WITHDRAWN' || isTaskCanceledOutcome(b),
     );
     if (targetBids.length === 0) return;
 
@@ -766,9 +896,10 @@ export default function MyBidsScreen() {
                   onEdit={handleEdit}
                   onCancelAccepted={handleCancelAccepted}
                   onChat={handleChat}
+                  onConfirmCompletion={handleConfirmCompletion}
                 />
               </View>
-              {(item.status === 'REJECTED' || item.status === 'WITHDRAWN') && (
+              {(item.status === 'REJECTED' || item.status === 'WITHDRAWN' || isTaskCanceledOutcome(item)) && (
                 <Pressable
                   style={styles.trashBtn}
                   hitSlop={8}
@@ -1091,6 +1222,34 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: 'rgba(192,57,43,0.15)',
     gap: spacing.xs,
+  },
+  completionBanner: {
+    padding: spacing.md,
+    borderRadius: radii.md,
+    backgroundColor: brandColors.warningSoft,
+    borderWidth: 1,
+    borderColor: 'rgba(155,109,42,0.18)',
+    gap: spacing.sm,
+  },
+  completionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+  },
+  completionBadgeText: {
+    color: brandColors.secondaryDark,
+    fontWeight: '800',
+    letterSpacing: 0.4,
+    textTransform: 'uppercase',
+  },
+  waitingNote: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radii.md,
+    backgroundColor: brandColors.surfaceAlt,
   },
   rejectionHeader: {
     flexDirection: 'row',

--- a/frontend/src/screens/MyTasksScreen.tsx
+++ b/frontend/src/screens/MyTasksScreen.tsx
@@ -36,6 +36,9 @@ interface Task {
   assigned_fixer_id?: string;
   assigned_fixer_avatar?: string | null;
   has_review?: boolean;
+  is_payment_confirmed?: boolean;
+  requester_completed?: boolean;
+  fixer_completed?: boolean;
   completed_at?: string;
   created_at: string;
 }
@@ -176,23 +179,11 @@ export default function MyTasksScreen({ navigation }: Props) {
     });
   };
 
-  const markCompleted = (task: Task) => {
-    const doComplete = async () => {
-      try {
-        await api.put(`/api/tasks/${task.id}/status`, { status: 'COMPLETED' });
-        navigation.navigate('TaskDetails', { taskId: task.id });
-      } catch {
-        Alert.alert(t('common.error'), t('myTasks.alerts.failedComplete'));
-      }
-    };
-
-    confirmAction({
-      title: t('myTasks.actions.complete.title'),
-      message: t('myTasks.actions.complete.message', { title: task.title }),
-      confirmLabel: t('myTasks.actions.complete.confirm'),
-      cancelLabel: t('myTasks.actions.complete.notYet'),
-      onConfirm: doComplete,
-    });
+  // Completion is a payment-gated, dual-confirmation flow (requester confirms
+  // payment, then both sides confirm) that lives on the TaskDetails screen.
+  // A one-tap list action can't represent it, so route there instead.
+  const goToCompletion = (task: Task) => {
+    navigation.navigate('TaskDetails', { taskId: task.id });
   };
 
   const reactivateTask = (task: Task) => {
@@ -419,7 +410,16 @@ export default function MyTasksScreen({ navigation }: Props) {
               helper={t('myTasks.sections.activeHelper')}
             />
             {filteredActiveTasks.length > 0 ? (
-              filteredActiveTasks.map((task) => (
+              filteredActiveTasks.map((task) => {
+                // Completion sub-state (only meaningful while IN_PROGRESS):
+                //   not paid              → "Complete & Pay"  (pay first)
+                //   paid, not yet marked  → "Mark complete"
+                //   paid + marked         → waiting on the fixer's confirmation
+                const paid = !!task.is_payment_confirmed;
+                const awaitingFixer =
+                  task.status === 'IN_PROGRESS' && paid && !!task.requester_completed && !task.fixer_completed;
+                const showComplete = task.status === 'IN_PROGRESS' && !awaitingFixer;
+                return (
                 <TaskCard
                   key={task.id}
                   title={task.title}
@@ -430,15 +430,17 @@ export default function MyTasksScreen({ navigation }: Props) {
                   bidCount={task.bid_count}
                   fixerName={task.assigned_fixer_name}
                   onPress={() => navigation.navigate('TaskDetails', { taskId: task.id })}
-                  onCancel={() => cancelTask(task)}
+                  // Backend forbids canceling once payment is confirmed.
+                  onCancel={paid ? undefined : () => cancelTask(task)}
                   onEdit={
                     task.status === 'OPEN'
                       ? () => navigation.navigate('TaskDetails', { taskId: task.id, openEdit: true })
                       : undefined
                   }
-                  onMarkCompleted={
-                    task.status === 'IN_PROGRESS' ? () => markCompleted(task) : undefined
-                  }
+                  onMarkCompleted={showComplete ? () => goToCompletion(task) : undefined}
+                  markCompletedLabel={paid ? t('taskCard.markComplete') : t('taskCard.completePay')}
+                  markCompletedIcon={paid ? 'check-circle-outline' : 'cash-check'}
+                  awaitingFixer={awaitingFixer}
                   onChat={
                     task.status === 'IN_PROGRESS' && task.assigned_fixer_id
                       ? () => navigation.navigate('Chat', {
@@ -452,7 +454,8 @@ export default function MyTasksScreen({ navigation }: Props) {
                       : undefined
                   }
                 />
-              ))
+                );
+              })
             ) : (
               <InlineEmpty
                 icon="clipboard-check-outline"


### PR DESCRIPTION
## Summary

A batch of related fixes around the **task completion flow** and **cancellation handling** on both the requester and fixer sides, plus a couple of UI polish items found along the way.

### Requester (My Tasks)
- **"Mark Complete" was broken** — it called `PUT /api/tasks/:id/status { COMPLETED }`, which the backend always rejects (that endpoint only allows `→ CANCELED`). It now routes to **Task Details**, where the real payment-gated, dual-confirmation flow lives.
- The card action is now **state-aware**: `Complete & Pay` (unpaid) → `Mark complete` (paid) → an **"Awaiting fixer confirmation"** chip once the requester has confirmed.
- **Cancel is hidden once payment is confirmed** (the backend forbids canceling a paid task, so the button would only ever error).

### Fixer (My Bids / Task Details)
- Accepted jobs **awaiting the fixer's confirmation** now get a prominent **"Confirm completion"** banner + one-tap action, sorted to the top.
- **Cancellation is unified**: any bid whose task was canceled — accepted, still-pending, or rejected-with-`TASK_CANCELED` — shows a distinct **"Task canceled"** badge under the **Rejected** tab (not "Accepted"/"Rejected"/"Canceled", so it never reads as if the fixer bailed). Pending-on-canceled bids are rerouted out of Pending.
- These canceled-task bids are now **deletable**.

### Backend
- `DELETE /api/bids/:id` also allows deleting **any bid whose task is `CANCELED`** (the job is dead either way). Rejected/withdrawn rules unchanged; the "can't delete a pending bid on an open task" behavior is preserved.

### Polish
- **Accessibility widget is now web-only** — the WCAG / ת"י 5568 requirement applies to the website, not the native app. Provider stays mounted so consumers keep working.
- **Discovery map empty state** no longer renders a clipped "triangle" (rotated diamond + watermark inside an `overflow:hidden` card) — replaced with a clean inline layout.
- **i18n**: Hebrew now uses `הפיקסר` consistently (was `המבצע` in one string).

### Docs
- `05_User_Flows.md` updated to reflect the **implemented** completion flow: payment-first, dual-confirmation (requester + fixer), rather than the old one-tap spec.

## Testing
- `tsc --noEmit` + ESLint clean on both workspaces (also enforced by the pre-commit hook).
- Backend Jest suite **not** run locally because its `cleanDatabase()` wipes the dev Postgres that holds active demo data; the delete-endpoint change was verified by reasoning against the existing test (`returns 400 when deleting a PENDING bid` on an OPEN task still holds).

## Note
The Rejected tab now fetches all bids and filters client-side (50-bid cap), so a fixer with a very large history could miss the oldest rejected entries — fine for the demo, but a candidate for a proper paginated fix later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)